### PR TITLE
WIP: real molecular Hamiltonians, real QM/MM geometry, Bloch sphere, …

### DIFF
--- a/dashboard_core/__init__.py
+++ b/dashboard_core/__init__.py
@@ -19,7 +19,11 @@ effects.
 """
 
 from .qasm_library import QASM_LIBRARY, infer_qubit_count_from_qasm
-from .hamiltonians import LIBRERIA_HAMILTONIANE, get_compatible_hamiltonians, save_custom_hamiltonian
+from .hamiltonians import (
+    LIBRERIA_HAMILTONIANE, get_compatible_hamiltonians, save_custom_hamiltonian,
+    MOLECULE_CATALOG, build_molecular_hamiltonian, get_compatible_molecules,
+    get_molecular_hamiltonian_matrix,
+)
 from .simulation_runner import run_simulation
 from .vqe_engine import QM_MM_HEAVY_QUBIT_THRESHOLD, run_vqe_telemetry
 from .md_telemetry import run_md_telemetry
@@ -28,6 +32,7 @@ from .panels import (
     build_panel_overview, build_panel_fisica, build_panel_mosaico,
     build_panel_vqe_results, build_panel_md_results,
     build_panel_performance, build_panel_hamiltonian,
+    build_panel_bloch_sphere, compute_bloch_vector,
 )
 from .helix_3d import build_3d_helix_patch
 from .provenance import run_benchmark_scan, build_provenance_json
@@ -38,6 +43,8 @@ from .interactive_panel import launch_interactive_panel
 __all__ = [
     'QASM_LIBRARY', 'infer_qubit_count_from_qasm',
     'LIBRERIA_HAMILTONIANE', 'get_compatible_hamiltonians', 'save_custom_hamiltonian',
+    'MOLECULE_CATALOG', 'build_molecular_hamiltonian', 'get_compatible_molecules',
+    'get_molecular_hamiltonian_matrix',
     'run_simulation',
     'QM_MM_HEAVY_QUBIT_THRESHOLD', 'run_vqe_telemetry',
     'run_md_telemetry',
@@ -45,6 +52,7 @@ __all__ = [
     'build_panel_overview', 'build_panel_fisica', 'build_panel_mosaico',
     'build_panel_vqe_results', 'build_panel_md_results',
     'build_panel_performance', 'build_panel_hamiltonian',
+    'build_panel_bloch_sphere', 'compute_bloch_vector',
     'build_3d_helix_patch',
     'run_benchmark_scan', 'build_provenance_json',
     'run_mitigation_sweep', 'build_panel_mitigation',

--- a/dashboard_core/hamiltonians.py
+++ b/dashboard_core/hamiltonians.py
@@ -1,87 +1,166 @@
 """
-Preset Hamiltonian library and lookup/save helpers.
+Hamiltonian sources for the VQE panel: a small library of diagonal toy
+models (Ising, Heisenberg, Hubbard, ...) plus a catalog of REAL molecular
+Hamiltonians built on demand from actual atomic geometry via PennyLane's
+qchem module (Hartree-Fock + Jordan-Wigner, method='dhf' -- native to
+PennyLane, no PySCF/OpenFermion dependency needed).
 
 Split out of the former monolithic dashboard_core.py (Phase 1 of the
-dashboard refactor) -- pure move, no behavior change.
+dashboard refactor) -- the toy-model dict below is that original move,
+unchanged. The molecular catalog is new: the file used to also carry
+~10 "real molecule" entries (H2, HeH+, LiH, N2, H2O, NH3, CH4, BeH2, HF)
+labeled with specific literature bond lengths (e.g. "H2 - R = 0.74 Å
+[Equilibrio Reale]") whose actual coefficient arrays were hand-typed
+numbers, not computed from that geometry or from any real electronic
+structure calculation -- convincing-looking, but fabricated. Real
+molecules now go through build_molecular_hamiltonian() instead, which
+computes them for real; nothing here claims to be real chemistry without
+actually being it.
+
+Represented Hamiltonians come in two shapes, both understood by the VQE
+panel (dashboard_core.vqe_engine._run_vqe_telemetry_body, which branches
+on numpy .ndim): a flat list/array of length 2**n_qubits (interpreted as
+a diagonal matrix -- the toy models below, and whatever a user pastes
+into the Custom JSON textarea) or a dense (2**n_qubits, 2**n_qubits)
+Hermitian matrix (the real molecular Hamiltonians -- Jordan-Wigner maps
+electronic structure onto X/Y/Z terms, not just Z, so these are never
+diagonal in the computational basis).
 """
 
 LIBRERIA_HAMILTONIANE = {
     # ---------------------------------------------------------------------
-    # --- GRUPPO 1: BENCHMARK CHIMICI REALI (2 QUBIT / DIM=4 SPRAZIO DENSE)
+    # --- MODELLI GIOCATTOLO / DI FISICA (spettro diagonale semplificato,
+    # --- non chimica reale -- vedi MOLECULE_CATALOG per quella)
     # ---------------------------------------------------------------------
-    "H2 (Idrogeno) - R = 0.50 Å [Compressione]": [-0.51, -0.12, 0.35, 0.85],
-    "H2 (Idrogeno) - R = 0.74 Å [Equilibrio Reale]": [-1.13, -0.45, 0.12, 0.64],
-    "H2 (Idrogeno) - R = 1.20 Å [Dissociazione]": [-0.92, -0.68, -0.15, 0.22],
-    "HeH+ (Idruro di Elio) - R = 0.93 Å [Equilibrio]": [-1.41, -0.82, -0.22, 0.45],
-    "H2 (Idrogeno) - R = 1.50 Å [Asintoto Dissoc.]": [-0.78, -0.65, -0.31, 0.11],
-    "HeH+ (Idruro di Elio) - R = 0.50 Å [Stallo Interno]": [-0.22, 0.14, 0.76, 1.48],
-    "HeH+ (Idruro di Elio) - R = 1.60 Å [Limite Ionico]": [-1.05, -0.91, -0.44, 0.02],
-    "LiH (Idruro di Litio) - STO-3G (Sotto-spazio 2q)": [-1.62, -0.98, -0.11, 0.54],
-
-    # ---------------------------------------------------------------------
-    # --- GRUPPO 2: CHIMICA ED ENTANGLEMENT AVANZATO (3 QUBIT / DIM=8 SPRAZIO DENSE)
-    # ---------------------------------------------------------------------
-    "H3+ (Ione Triidrogeno Linear) - R = 0.85 Å": [-1.28, -0.94, -0.51, -0.08, 0.33, 0.76, 1.18, 1.55],
-    "H3+ (Ione Triidrogeno Triang) - R = 0.90 Å": [-1.34, -1.01, -0.62, -0.14, 0.28, 0.69, 1.09, 1.42],
-    "Modello di Lipkin (Fisica Nucleare 3q Baseline)": [-2.00, -1.41, -0.82, -0.22, 0.35, 0.91, 1.54, 2.11],
-    "Catena di Heisenberg XXX (Antiferromagnetica 3q)": [-1.82, -1.22, -0.61, -0.11, 0.42, 0.93, 1.34, 1.85],
-
-    # ---------------------------------------------------------------------
-    # --- GRUPPO 3: MASSA MOLECOLARE INTERMEDIA (4 QUBIT / DIM=16 SPRAZIO DENSE)
-    # ---------------------------------------------------------------------
-    "Modello Ising Lineare (4 Qubit Baseline)": [-1.5, -1.1, -0.7, -0.3, 0.1, 0.5, 0.9, 1.3, 1.7, 2.1, 2.5, 2.9, 3.3, 3.7, 4.1, 4.5],
-    "LiH (Idruro di Litio) - R = 1.40 Å [Minimo]": [-2.31, -2.01, -1.65, -1.22, -0.85, -0.41, 0.02, 0.44, 0.88, 1.25, 1.61, 1.98, 2.34, 2.71, 3.05, 3.42],
-    "LiH (Idruro di Litio) - R = 2.20 Å [Torsione]": [-1.89, -1.62, -1.31, -0.98, -0.62, -0.22, 0.15, 0.52, 0.91, 1.28, 1.64, 1.99, 2.33, 2.68, 3.01, 3.35],
-    "BH3 (Borano Parziale) - R = 1.15 Å": [-2.85, -2.42, -2.01, -1.55, -1.11, -0.65, -0.21, 0.22, 0.64, 1.05, 1.47, 1.88, 2.29, 2.69, 3.08, 3.49],
-    "H4 (Catena di Idrogeno Quadrata) - R = 1.00 Å": [-2.14, -1.82, -1.44, -1.02, -0.61, -0.18, 0.24, 0.65, 1.08, 1.49, 1.91, 2.32, 2.72, 3.11, 3.51, 3.92],
-    "H4 (Catena di Idrogeno Lineare) - R = 1.25 Å": [-2.45, -2.11, -1.72, -1.34, -0.92, -0.51, -0.08, 0.34, 0.76, 1.17, 1.58, 1.99, 2.38, 2.78, 3.16, 3.55],
-    "Modello Hubbard (Sito 2x2, Half-Filling 4q)": [-3.21, -2.75, -2.24, -1.72, -1.18, -0.64, -0.11, 0.42, 0.95, 1.48, 2.01, 2.54, 3.06, 3.58, 4.11, 4.64],
-    "Interazione Cooper (Superconduttività BC 4q)": [-1.95, -1.68, -1.41, -1.12, -0.84, -0.55, -0.24, 0.05, 0.36, 0.68, 0.98, 1.29, 1.58, 1.88, 2.19, 2.48],
-
-    # ---------------------------------------------------------------------
-    # --- GRUPPO 4: MACROMOLECOLE PRE-CALCOLATE (5-6 QUBIT / DIM=32-64 SPRAZIO DENSE)
-    # ---------------------------------------------------------------------
-    "H2O (Acqua Embedding Core) - R = 0.96 Å [32 Val]": [
-        -4.12, -3.79, -3.47, -3.15, -2.83, -2.51, -2.19, -1.86, -1.54, -1.22, -0.90, -0.58, -0.26, 0.06, 0.38, 0.70,
-         1.02,  1.34,  1.67,  1.99,  2.31,  2.63,  2.95,  3.27,  3.59,  3.91,  4.24,  4.56,  4.88, 5.20, 5.52, 5.85
-    ],
-    "NH3 (Ammoniaca Sotto-guscio) - R = 1.01 Å [32 Val]": [
-        -4.85, -4.49, -4.13, -3.78, -3.42, -3.06, -2.71, -2.35, -2.00, -1.64, -1.28, -0.93, -0.57, -0.21, 0.14, 0.50,
-         0.85,  1.21,  1.56,  1.92,  2.28,  2.63,  2.99,  3.35,  3.70,  4.06,  4.41,  4.77,  5.13, 5.48, 5.84, 6.22
-    ],
-    "CH4 (Metano Orbitale Ibrido) - R = 1.09 Å [32 Val]": [
-        -5.12, -4.71, -4.31, -3.91, -3.51, -3.11, -2.71, -2.31, -1.90, -1.50, -1.10, -0.70, -0.30, 0.10, 0.50, 0.90,
-         1.31,  1.71,  2.11,  2.51,  2.91,  3.31,  3.71,  4.11,  4.52,  4.92,  5.32,  5.72,  6.12, 6.52, 6.92, 7.34
-    ],
-    "BeH2 (Idruro di Berillio Active Space) [64 Val]": [
-        -6.42, -6.19, -5.96, -5.73, -5.50, -5.27, -5.04, -4.81, -4.58, -4.35, -4.12, -3.89, -3.66, -3.43, -3.20, -2.97,
-        -2.74, -2.51, -2.28, -2.05, -1.82, -1.59, -1.36, -1.13, -0.90, -0.67, -0.44, -0.21,  0.02,  0.25,  0.48,  0.71,
-         0.94,  1.17,  1.40,  1.63,  1.86,  2.09,  2.32,  2.55,  2.78,  3.01,  3.24,  3.47,  3.70,  3.93,  4.16,  4.39,
-         4.62,  4.85,  5.08,  5.31,  5.54,  5.77,  6.00,  6.23,  6.46,  6.69,  6.92,  7.15,  7.38,  7.61,  7.84,  8.11
-    ],
-    "N2 (Azoto Molecolare Singlet-State) [64 Val]": [
-        -8.95, -8.63, -8.31, -7.99, -7.67, -7.35, -7.03, -6.71, -6.39, -6.07, -5.75, -5.43, -5.11, -4.79, -4.47, -4.15,
-        -3.83, -3.51, -3.19, -2.87, -2.55, -2.23, -1.91, -1.59, -1.27, -0.95, -0.63, -0.31,  0.01,  0.33,  0.65,  0.97,
-         1.29,  1.61,  1.93,  2.25,  2.57,  2.89,  3.21,  3.53,  3.85,  4.17,  4.49,  4.81,  5.13,  5.45,  5.77,  6.09,
-         6.41,  6.73,  7.05,  7.37,  7.69,  8.01,  8.33,  8.65,  8.97,  9.29,  9.61,  9.93, 10.25, 10.57, 10.89, 11.24
-    ],
-    "HF (Acido Fluoridrico Valence Space) [64 Val]": [
-        -7.14, -6.87, -6.61, -6.34, -6.08, -5.81, -5.54, -5.28, -5.01, -4.75, -4.48, -4.21, -3.95, -3.68, -3.42, -3.15,
-        -2.88, -2.62, -2.35, -2.09, -1.82, -1.55, -1.29, -1.02, -0.76, -0.49, -0.22,  0.04,  0.31,  0.57,  0.84,  1.10,
-         1.37,  1.64,  1.90,  2.17,  2.43,  2.70,  2.96,  3.23,  3.50,  3.76,  4.03,  4.29,  4.56,  4.82,  5.09,  5.35,
-         5.62,  5.89,  6.15,  6.42,  6.68,  6.95,  7.21,  7.48,  7.75,  8.01,  8.28,  8.54,  8.81,  9.07,  9.34,  9.65
-    ],
-
-    "Spettro Uniforme Classico (Baseline linspace)": None,
+    "H3+ (Ione Triidrogeno) - modello giocattolo lineare 3q":
+        [-1.28, -0.94, -0.51, -0.08, 0.33, 0.76, 1.18, 1.55],
+    "Modello di Lipkin (Fisica Nucleare 3q Baseline)":
+        [-2.00, -1.41, -0.82, -0.22, 0.35, 0.91, 1.54, 2.11],
+    "Catena di Heisenberg XXX (Antiferromagnetica 3q)":
+        [-1.82, -1.22, -0.61, -0.11, 0.42, 0.93, 1.34, 1.85],
+    "Modello Ising Lineare (4 Qubit Baseline)":
+        [-1.5, -1.1, -0.7, -0.3, 0.1, 0.5, 0.9, 1.3, 1.7, 2.1, 2.5, 2.9, 3.3, 3.7, 4.1, 4.5],
+    "Modello Hubbard (Sito 2x2, Half-Filling 4q)":
+        [-3.21, -2.75, -2.24, -1.72, -1.18, -0.64, -0.11, 0.42, 0.95, 1.48, 2.01, 2.54, 3.06, 3.58, 4.11, 4.64],
+    "Interazione Cooper (Superconduttività BCS, modello giocattolo 4q)":
+        [-1.95, -1.68, -1.41, -1.12, -0.84, -0.55, -0.24, 0.05, 0.36, 0.68, 0.98, 1.29, 1.58, 1.88, 2.19, 2.48],
 }
 
+
+# ═══════════════════════════════════════════════════════════════════════
+# Molecole reali -- geometria vera (Å), calcolate al volo con PennyLane
+# ═══════════════════════════════════════════════════════════════════════
+
+def _triangular_h3_geometry(bond_length_angstrom: float):
+    """H3+ has a real, well-documented equilateral-triangle (D3h) ground-
+    state geometry -- not the linear-chain approximation the old static
+    library used under the same name. This is also the one genuinely
+    "ring/cyclic" molecule small enough for this simulator's exact dense
+    diagonalization (6 qubits, dim=64) -- larger rings (e.g. benzene)
+    would need far more qubits than exact diagonalization can handle
+    here, so this catalog deliberately stays small rather than promising
+    scale it doesn't have."""
+    import numpy as np
+    r = bond_length_angstrom
+    h = r * (3 ** 0.5) / 2
+    return np.array([[0.0, 0.0, 0.0], [r, 0.0, 0.0], [r / 2, h, 0.0]])
+
+
+# name -> (symbols, geometry_builder, charge). geometry_builder is either
+# a fixed np.ndarray or a zero-arg callable building one (kept lazy so
+# numpy only imports when a molecule's Hamiltonian is actually needed).
+def _linear_two_atom_geometry(bond_length_angstrom: float):
+    import numpy as np
+    return np.array([[0.0, 0.0, 0.0], [0.0, 0.0, bond_length_angstrom]])
+
+
+MOLECULE_CATALOG = {
+    # Bond lengths are real, published equilibrium geometries, not
+    # invented to look plausible:
+    "H2 (Idrogeno) - R = 0.7414 Å [equilibrio reale]": {
+        "symbols": ["H", "H"],
+        "geometry": lambda: _linear_two_atom_geometry(0.7414),
+        "charge": 0,
+    },
+    "HeH+ (Idruro di Elio, catione) - R = 0.7743 Å [equilibrio reale]": {
+        "symbols": ["He", "H"],
+        "geometry": lambda: _linear_two_atom_geometry(0.7743),
+        "charge": 1,
+    },
+    "H3+ (Ione Triidrogeno) - triangolo equilatero D3h, R = 0.8738 Å [equilibrio reale]": {
+        "symbols": ["H", "H", "H"],
+        "geometry": lambda: _triangular_h3_geometry(0.8738),
+        "charge": 1,
+    },
+}
+
+_molecular_hamiltonian_cache = {}
+
+
+def build_molecular_hamiltonian(symbols, geometry, charge: int = 0):
+    """Computes a REAL molecular electronic-structure Hamiltonian from
+    real atomic symbols + 3D geometry (Å), via PennyLane's native
+    Hartree-Fock solver (method='dhf' -- no PySCF/OpenFermion needed,
+    pennylane is already a project dependency). Returns
+    (H_dense: np.ndarray complex128, n_qubits: int) -- Jordan-Wigner maps
+    the fermionic Hamiltonian onto real X/Y/Z Pauli terms, so H_dense is
+    generally NOT diagonal even though its eigenvalues (and the physics)
+    are real.
+
+    Cached in-memory by (symbols, geometry, charge) -- Hartree-Fock is
+    not free, and the same catalog molecule gets selected repeatedly
+    across VQE runs."""
+    import numpy as np
+    import pennylane as qml
+
+    key = (tuple(symbols), tuple(map(tuple, np.asarray(geometry).round(10))), charge)
+    if key in _molecular_hamiltonian_cache:
+        return _molecular_hamiltonian_cache[key]
+
+    molecule = qml.qchem.Molecule(symbols, np.asarray(geometry), charge=charge, unit="angstrom")
+    H, n_qubits = qml.qchem.molecular_hamiltonian(molecule, method="dhf")
+    H_dense = np.asarray(qml.matrix(H), dtype=np.complex128)
+
+    result = (H_dense, n_qubits)
+    _molecular_hamiltonian_cache[key] = result
+    return result
+
+
+def get_compatible_molecules(n_qubits, catalog=None):
+    """Like get_compatible_hamiltonians, but for MOLECULE_CATALOG: builds
+    (and caches) each molecule's real Hamiltonian to learn its actual
+    qubit count, then filters to the ones matching n_qubits. Building is
+    cheap for this catalog's small molecules (4-6 qubits) and cached
+    after the first call, so this is safe to call on every UI refresh."""
+    catalog = catalog if catalog is not None else MOLECULE_CATALOG
+    if n_qubits is None or n_qubits <= 0:
+        return {}
+    compatible = {}
+    for name, spec in catalog.items():
+        geometry = spec["geometry"]() if callable(spec["geometry"]) else spec["geometry"]
+        _, mol_n_qubits = build_molecular_hamiltonian(spec["symbols"], geometry, spec["charge"])
+        if mol_n_qubits == n_qubits:
+            compatible[name] = spec
+    return compatible
+
+
+def get_molecular_hamiltonian_matrix(name, catalog=None):
+    """Resolves a MOLECULE_CATALOG entry by name to its (cached) dense
+    Hamiltonian matrix -- what the VQE panel actually needs once the user
+    has picked a molecule from the dropdown."""
+    catalog = catalog if catalog is not None else MOLECULE_CATALOG
+    spec = catalog[name]
+    geometry = spec["geometry"]() if callable(spec["geometry"]) else spec["geometry"]
+    H_dense, _ = build_molecular_hamiltonian(spec["symbols"], geometry, spec["charge"])
+    return H_dense
+
+
+# ═══════════════════════════════════════════════════════════════════════
 
 def get_compatible_hamiltonians(n_qubits, library=None):
     """Filters a Hamiltonian library down to entries whose diagonal length
     matches 2**n_qubits. Adapted from update_hamiltonian_options_and_state's
-    filter (dash.py:2825) — `values is not None and len(values) == expected_dim`,
-    which is also why "Spettro Uniforme Classico" (value None) never actually
-    appears as selectable in the original either; ported faithfully."""
+    filter (dash.py:2825) — `values is not None and len(values) == expected_dim`."""
     library = library if library is not None else LIBRERIA_HAMILTONIANE
     if n_qubits is None or n_qubits <= 0:
         return {}

--- a/dashboard_core/panels.py
+++ b/dashboard_core/panels.py
@@ -293,7 +293,11 @@ def build_panel_fisica(res, seed: int = 42) -> plt.Figure:
 
     ax2 = fig.add_axes([0.52, 0.10, 0.45, 0.70], projection='3d')
     ax2.set_facecolor('#0d1117')
-    rng = np.random.default_rng(seed)
+    # `seed` (the parameter above) was only ever used to build an `rng` that
+    # this deterministic scatter (linspace/cos/sin below) never actually
+    # consumed -- dead code removed rather than wired up, since nothing here
+    # needs randomization. `seed` itself is left in the signature: callers
+    # already pass it, and dropping the parameter is a separate API change.
     angoli = np.linspace(0, 2 * np.pi, dim_vis)
     raggio = np.sqrt(range(dim_vis))
     x_c = raggio * np.cos(angoli)
@@ -548,4 +552,71 @@ def build_panel_performance(res: Dict, run_history: list) -> plt.Figure:
     fig.suptitle(f'Performance — {len(run_history)} run(s) in this session',
                  color=C['title'], fontsize=14, fontweight='bold', **MONO)
     plt.tight_layout(rect=[0, 0.03, 1, 0.93])
+    return fig
+
+
+_PAULI_X = np.array([[0, 1], [1, 0]], dtype=complex)
+_PAULI_Y = np.array([[0, -1j], [1j, 0]], dtype=complex)
+_PAULI_Z = np.array([[1, 0], [0, -1]], dtype=complex)
+
+
+def compute_bloch_vector(sv, n_qubits: int, qubit_index: int):
+    """The real Bloch vector (Tr(ρX), Tr(ρY), Tr(ρZ)) for one qubit's
+    reduced density matrix ρ, traced out of the full `sv` statevector --
+    standard single-qubit visualization in Qiskit (plot_bloch_vector) and
+    PennyLane/qsim demos, previously absent from this dashboard.
+
+    Qubit-index convention verified empirically against this simulator's
+    own measurement labeling (format(idx, '0{n}b'), qubit 0 = leftmost/
+    most-significant bit): reshaping the flat statevector into `n_qubits`
+    axes of size 2 puts axis `i` in exactly that same qubit-0-first order,
+    so no bit-reversal is needed here.
+
+    Returns (bx, by, bz), each a float in [-1, 1] (exactly on the unit
+    sphere surface for a pure, unentangled qubit; strictly inside it —
+    a real physical effect, not a bug — when qubit_index is entangled
+    with the rest of the register, e.g. (0,0,0) for either half of a
+    Bell pair)."""
+    sv = np.asarray(sv).reshape([2] * n_qubits)
+    sv = np.moveaxis(sv, qubit_index, 0).reshape(2, -1)
+    rho = sv @ sv.conj().T
+    return (
+        float(np.real(np.trace(rho @ _PAULI_X))),
+        float(np.real(np.trace(rho @ _PAULI_Y))),
+        float(np.real(np.trace(rho @ _PAULI_Z))),
+    )
+
+
+def build_panel_bloch_sphere(sv, n_qubits: int, qubit_index: int = 0) -> plt.Figure:
+    """Plots compute_bloch_vector's result on a 3D Bloch sphere -- a
+    wireframe sphere, the three real (X/Y/Z) axes, and an arrow from the
+    origin to the qubit's actual state. A short arrow (inside the sphere,
+    not reaching the surface) is the correct, honest rendering of a
+    genuinely mixed/entangled reduced state, not a rendering error."""
+    bx, by, bz = compute_bloch_vector(sv, n_qubits, qubit_index)
+
+    fig = plt.figure(figsize=(6, 6), facecolor=FIG_BG_DARK)
+    ax = fig.add_axes([0.05, 0.05, 0.9, 0.9], projection='3d')
+    ax.set_facecolor(C['panel'])
+
+    u, v = np.meshgrid(np.linspace(0, 2 * np.pi, 40), np.linspace(0, np.pi, 20))
+    xs, ys, zs = np.cos(u) * np.sin(v), np.sin(u) * np.sin(v), np.cos(v)
+    ax.plot_wireframe(xs, ys, zs, color=C['border'], linewidth=0.4, alpha=0.5)
+
+    axis_len = 1.3
+    for vec, label in (([axis_len, 0, 0], 'X'), ([0, axis_len, 0], 'Y'), ([0, 0, axis_len], 'Z')):
+        ax.plot([0, vec[0]], [0, vec[1]], [0, vec[2]], color=C['label'], lw=0.8)
+        ax.text(*vec, label, color=C['label'], fontsize=10, **MONO)
+
+    ax.quiver(0, 0, 0, bx, by, bz, color=C['accent'], linewidth=2.5, arrow_length_ratio=0.12)
+    ax.scatter([bx], [by], [bz], color=C['accent'], s=40)
+
+    ax.set_xlim(-1.3, 1.3); ax.set_ylim(-1.3, 1.3); ax.set_zlim(-1.3, 1.3)
+    ax.set_box_aspect((1, 1, 1))
+    ax.set_axis_off()
+    fig.suptitle(
+        f'Bloch Sphere — qubit {qubit_index}  '
+        f'(x={bx:.3f}, y={by:.3f}, z={bz:.3f}, |v|={(bx**2+by**2+bz**2)**0.5:.3f})',
+        color=C['title'], fontsize=12, fontweight='bold', **MONO,
+    )
     return fig

--- a/dashboard_core/simulation_runner.py
+++ b/dashboard_core/simulation_runner.py
@@ -293,8 +293,6 @@ def _run_simulation_body(source_mode, circuit_name, qasm_text, noise_model, nois
     stato_dominante = format(idx_max, '0' + str(n_qubits) + 'b')
 
     fidelity_value = float(np.sum(np.sqrt(prob * prob_id)))
-    noise_factor_curve = np.array([fidelity_value * (1.0 - (i * float(noise_p) / 20.0)) for i in range(100)])
-    noise_factor_curve = np.clip(noise_factor_curve, 0.0, 1.0)
 
     # np.random.choice(len(prob), p=prob, ...) builds an internal cumulative
     # array over the full 2**n_qubits distribution -- another O(2**n) cost
@@ -313,7 +311,6 @@ def _run_simulation_body(source_mode, circuit_name, qasm_text, noise_model, nois
     return {
         'prob': prob,
         'prob_ideal': prob_ideal,
-        'noise_factor': noise_factor_curve,
         'fidelity': fidelity_value,
         'n_qubits': n_qubits,
         'entropy': shannon_entropy,
@@ -323,6 +320,7 @@ def _run_simulation_body(source_mode, circuit_name, qasm_text, noise_model, nois
         'ram': sim.memory_mb(),
         'nome': nome_circuito,
         'porte_count': len(comandi_beast_mode),
+        'circuit_ops': comandi_beast_mode,  # feeds dense_evolution.drawing.draw_circuit
         'shots_data': shots_data,
         'sim': sim,
         'parser': parser,

--- a/dashboard_core/vqe_engine.py
+++ b/dashboard_core/vqe_engine.py
@@ -20,7 +20,17 @@ QM_MM_HEAVY_QUBIT_THRESHOLD = 12
 
 
 class QMMMForceEngine:
-    """Hellmann-Feynman QM/MM force engine via JAX autodiff. Adapted from dash.py:1455."""
+    """Hellmann-Feynman QM/MM force engine via JAX autodiff. Adapted from
+    dash.py:1455 -- that version's generate_pauli_expectation_mpo docstring
+    admitted it was "Placeholder tracciabile... In produzione si
+    interfaccia con le stringhe generate da Jordan-Wigner". The mean-field
+    external-potential approximation here (single_orbital_v below) is
+    still a real simplification, not full electronic structure -- but as
+    of dashboard_core.hamiltonians.build_molecular_hamiltonian, h_pq_core
+    is now a genuine Jordan-Wigner-mapped molecular Hamiltonian when a
+    catalog molecule is selected, not a fake one, and the classical
+    positions/charges it's perturbed by (see _run_vqe_telemetry_body) are
+    that same molecule's real equilibrium geometry, not a fixed stand-in."""
 
     def __init__(self, simulator_instance):
         self.sim = simulator_instance
@@ -126,14 +136,30 @@ def _run_vqe_mock_simulation(epochs: int, lr: float, beta1: float, beta2: float,
 
 def run_vqe_telemetry(sim, parser, qasm_text, circuit_name, n_qubits, use_float32,
                        epochs, lr, beta1, beta2, seed, hamiltonian_values=None,
-                       on_epoch=None) -> pd.DataFrame:
+                       on_epoch=None, classical_geometry=None) -> pd.DataFrame:
     """Adapted from ottimizza_vqe (dash.py:3194, canonical/later definition).
 
     Runs real JAX-autodiff VQE (via QMMMForceEngine Hellmann-Feynman forces) if the
     circuit has parametric gates, else falls back to _run_vqe_mock_simulation — this
-    branch is unchanged from the original. `hamiltonian_values`, if given, must be an
-    array of length 2**n_qubits (custom Hamiltonian); otherwise a random one is used,
-    replacing the original's globals()-based custom-Hamiltonian widget lookup.
+    branch is unchanged from the original.
+
+    `hamiltonian_values`, if given, is either a flat array of length 2**n_qubits
+    (a diagonal Hamiltonian -- a toy model from LIBRERIA_HAMILTONIANE, or whatever a
+    user pastes into the Custom JSON textarea) or a dense (2**n_qubits, 2**n_qubits)
+    Hermitian matrix (a real molecular Hamiltonian from
+    dashboard_core.hamiltonians.get_molecular_hamiltonian_matrix -- Jordan-Wigner maps
+    electronic structure onto real X/Y/Z terms, so this is generally NOT diagonal).
+    If not given, a random diagonal spectrum is used, replacing the original's
+    globals()-based custom-Hamiltonian widget lookup.
+
+    `classical_geometry`, if given, is a dict with 'positions' ((n_atoms, 3) Å),
+    'charges' ((n_atoms,)) and optionally 'orbital_centers' -- the REAL geometry of
+    whatever molecule hamiltonian_values came from, fed to QMMMForceEngine instead of
+    a fixed placeholder. When None (a toy model or a Custom JSON Hamiltonian with no
+    known geometry is selected), QM/MM force computation is skipped entirely rather
+    than perturbed by a geometry that doesn't actually correspond to anything real —
+    engine stays None, norma_forze_mm stays 0.0, same as any other QMMMForceEngine
+    failure already handled below.
 
     `on_epoch`, if given, is called as `on_epoch(epoch: int, total_epochs: int, row: dict)`
     once per completed epoch — purely additive, default None, no behavior change for
@@ -147,6 +173,7 @@ def run_vqe_telemetry(sim, parser, qasm_text, circuit_name, n_qubits, use_float3
         return _run_vqe_telemetry_body(
             sim, parser, qasm_text, circuit_name, n_qubits, use_float32,
             epochs, lr, beta1, beta2, seed, hamiltonian_values, on_epoch,
+            classical_geometry,
         )
     finally:
         # `sim` was built under a precision fixed at its own creation (run_simulation);
@@ -157,7 +184,7 @@ def run_vqe_telemetry(sim, parser, qasm_text, circuit_name, n_qubits, use_float3
 
 def _run_vqe_telemetry_body(sim, parser, qasm_text, circuit_name, n_qubits, use_float32,
                              epochs, lr, beta1, beta2, seed, hamiltonian_values=None,
-                             on_epoch=None) -> pd.DataFrame:
+                             on_epoch=None, classical_geometry=None) -> pd.DataFrame:
     circ_obj = parser.parse(qasm_text)
     energy_fn, n_params = de.circuit_to_energy_fn(circ_obj, n_qubits)
 
@@ -175,21 +202,42 @@ def _run_vqe_telemetry_body(sim, parser, qasm_text, circuit_name, n_qubits, use_
 
     np.random.seed(seed)
     classical_dtype = jnp.float32 if use_float32 else jnp.float64
+    h_complex_dtype = jnp.complex64 if use_float32 else jnp.complex128
 
-    if hamiltonian_values is not None and len(hamiltonian_values) == 2 ** n_qubits:
-        valori_energetici = np.array(hamiltonian_values, dtype=classical_dtype)
+    ham_array = np.asarray(hamiltonian_values) if hamiltonian_values is not None else None
+    if ham_array is not None and ham_array.ndim == 2 and ham_array.shape == (2 ** n_qubits, 2 ** n_qubits):
+        # A real molecular Hamiltonian (dashboard_core.hamiltonians.
+        # get_molecular_hamiltonian_matrix) -- Jordan-Wigner maps onto X/Y/Z
+        # terms, so this is generally dense, not diagonal.
+        sim.H_matrix = jnp.array(ham_array, dtype=h_complex_dtype)
+    elif ham_array is not None and ham_array.ndim == 1 and len(ham_array) == 2 ** n_qubits:
+        valori_energetici = ham_array.astype(classical_dtype)
+        sim.H_matrix = jnp.diag(jnp.array(valori_energetici, dtype=classical_dtype)).astype(h_complex_dtype)
     else:
         valori_energetici = np.sort(np.random.uniform(-2.5, 2.5, 2 ** n_qubits)).astype(classical_dtype)
-
-    sim.H_matrix = jnp.diag(jnp.array(valori_energetici, dtype=classical_dtype))
+        sim.H_matrix = jnp.diag(jnp.array(valori_energetici, dtype=classical_dtype)).astype(h_complex_dtype)
 
     history = []
     stato_zero_dtype = jnp.complex64 if use_float32 else jnp.complex128
     stato_zero = jnp.zeros(2 ** n_qubits, dtype=stato_zero_dtype).at[0].set(1.0)
 
-    classical_positions = jnp.array([[0.0, 0.0, 0.0], [1.4, 0.0, 0.0]], dtype=classical_dtype)
-    classical_charges = jnp.array([1.0, -1.0], dtype=classical_dtype)
-    orbital_centers = jnp.array([[0.0, 0.0, 0.1]], dtype=classical_dtype)
+    if classical_geometry is not None:
+        # Real geometry (dashboard_core.hamiltonians.MOLECULE_CATALOG),
+        # matching whatever molecule hamiltonian_values above came from --
+        # not a fixed stand-in used for every circuit regardless of what
+        # it represents.
+        classical_positions = jnp.array(classical_geometry['positions'], dtype=classical_dtype)
+        classical_charges = jnp.array(classical_geometry['charges'], dtype=classical_dtype)
+        orbital_centers = jnp.array(
+            classical_geometry.get('orbital_centers', classical_geometry['positions']),
+            dtype=classical_dtype,
+        )
+    else:
+        # No known real geometry for the selected Hamiltonian (a toy model,
+        # or a Custom JSON array with no associated molecule) -- skip QM/MM
+        # force computation entirely below rather than perturb the energy
+        # with a geometry that doesn't correspond to anything real.
+        classical_positions = classical_charges = orbital_centers = None
 
     # Built once, reused every epoch — only theta changes, so this traces/
     # JIT-compiles a single time instead of rebuilding the circuit (and
@@ -211,7 +259,7 @@ def _run_vqe_telemetry_body(sim, parser, qasm_text, circuit_name, n_qubits, use_
         purita = float(np.sum(prob ** 2))
 
         norma_forze_mm = 0.0
-        if engine is not None:
+        if engine is not None and classical_positions is not None:
             try:
                 _, forze_mm = engine.compute_forces(
                     classical_positions, classical_charges, orbital_centers, sim.H_matrix, sv

--- a/tests/test_dashboard_core.py
+++ b/tests/test_dashboard_core.py
@@ -59,7 +59,10 @@ def md_telemetry():
 
 def test_run_simulation_ideal_keys(bell_res):
     expected_keys = {
-        "prob", "prob_ideal", "noise_factor", "fidelity", "n_qubits", "entropy",
+        # noise_factor deliberately not here anymore: it was a fabricated
+        # decay curve (fidelity_value * linear formula), never consumed by
+        # any panel -- confirmed dead and removed, not a fake left in place.
+        "prob", "prob_ideal", "fidelity", "n_qubits", "entropy",
         "idx_max", "stato_dominante", "tempo", "ram", "nome", "porte_count",
         "shots_data", "sim", "parser",
     }

--- a/ui_pages/quantum_simulator.py
+++ b/ui_pages/quantum_simulator.py
@@ -102,7 +102,7 @@ def _render_sidebar() -> dict:
         else:
             vqe_epochs, vqe_lr, vqe_beta1, vqe_beta2, confirm_heavy_vqe = 20, 0.05, 0.9, 0.999, False
 
-        hamiltonian_values, hamiltonian_name = None, None
+        hamiltonian_values, hamiltonian_name, classical_geometry = None, None, None
         if vqe_enabled:
             st.header("🧬 Hamiltoniana personalizzata")
             hamiltonian_enabled = st.checkbox("Abilita Hamiltoniana personalizzata", value=False, key="qs_ham_enabled")
@@ -112,17 +112,47 @@ def _render_sidebar() -> dict:
                 inferred_n_qubits = dc.infer_qubit_count_from_qasm(current_qasm)
                 compatible = dc.get_compatible_hamiltonians(inferred_n_qubits, ham_library)
 
-                ham_mode = st.radio("Modalità", ["Libreria Built-in", "Custom JSON Textarea"], key="qs_ham_mode")
-                if ham_mode == "Libreria Built-in":
+                ham_mode = st.radio(
+                    "Modalità", ["Molecole Reali", "Modelli Giocattolo", "Custom JSON Textarea"], key="qs_ham_mode",
+                )
+                if ham_mode == "Molecole Reali":
+                    compatible_molecules = dc.get_compatible_molecules(inferred_n_qubits)
+                    if compatible_molecules:
+                        hamiltonian_name = st.selectbox(
+                            f"Molecola ({inferred_n_qubits} qubit, dim={2**inferred_n_qubits if inferred_n_qubits else '?'}) "
+                            "— Hamiltoniana calcolata al volo via PennyLane qchem (Hartree-Fock, Jordan-Wigner), "
+                            "non un array di numeri fissi",
+                            options=list(compatible_molecules.keys()), key="qs_mol_sel",
+                        )
+                        spec = compatible_molecules[hamiltonian_name]
+                        geometry = spec["geometry"]() if callable(spec["geometry"]) else spec["geometry"]
+                        hamiltonian_values = dc.get_molecular_hamiltonian_matrix(hamiltonian_name)
+                        classical_geometry = {
+                            "positions": geometry,
+                            "charges": [1.0] * len(spec["symbols"]),
+                        }
+                        st.caption(
+                            f"Simboli: {', '.join(spec['symbols'])} — carica: {spec['charge']:+d} — "
+                            f"geometria reale (Å): {geometry.tolist()}"
+                        )
+                    else:
+                        st.caption(
+                            f"Nessuna molecola nel catalogo ha esattamente {inferred_n_qubits or '?'} qubit "
+                            "sotto Jordan-Wigner. Il catalogo resta piccolo apposta (H2, HeH+, H3+ ad anello) — "
+                            "molecole più grandi richiederebbero più qubit di quanti questo simulatore possa "
+                            "diagonalizzare esattamente."
+                        )
+                elif ham_mode == "Modelli Giocattolo":
                     if compatible:
                         hamiltonian_name = st.selectbox(
-                            f"Hamiltoniana ({inferred_n_qubits} qubit, dim={2**inferred_n_qubits if inferred_n_qubits else '?'})",
+                            f"Modello ({inferred_n_qubits} qubit, dim={2**inferred_n_qubits if inferred_n_qubits else '?'}) "
+                            "— spettro diagonale semplificato, non chimica reale",
                             options=list(compatible.keys()), key="qs_ham_sel",
                         )
                         hamiltonian_values = compatible[hamiltonian_name]
                     else:
                         st.caption(
-                            f"Nessuna Hamiltoniana in libreria è compatibile con {inferred_n_qubits or '?'} qubit "
+                            f"Nessun modello in libreria è compatibile con {inferred_n_qubits or '?'} qubit "
                             f"(serve un array di lunghezza 2^n = {2**inferred_n_qubits if inferred_n_qubits else '?'}). "
                             "Usa la modalità Custom JSON qui sotto."
                         )


### PR DESCRIPTION
…dead-code cleanup

Snapshot before splitting dashboard work (Streamlit + ipywidgets) into dedicated branches out of main. Real PennyLane qchem molecular Hamiltonian catalog (H2/HeH+/H3+ ring) replaces the static coefficient library, real geometry now threads into the QM/MM force engine, added a real Bloch-vector panel, removed the fabricated noise_factor_curve and a dead rng.

## What & why

What does this change, and why is it needed — not just what it does mechanically.

## Testing

- [ ] Added/updated tests for the change (especially for anything numerical — statevector/probability outputs)
- [ ] `pytest tests/` passes locally
- [ ] Updated `README.md`'s changelog section if this is user-visible

## Notes for the reviewer

Anything that needs extra attention, or context that isn't obvious from the diff.
