### PR TITLE
Sync mcp_server/README.md and SKILL.md tool docs with the wormhole tools

### DIFF
--- a/.claude/skills/dense-evolution-mcp/SKILL.md
+++ b/.claude/skills/dense-evolution-mcp/SKILL.md
@@ -8,7 +8,7 @@ compatibility: Requires the dense_evolution_mcp MCP server registered (see mcp_s
 
 ## Why this exists
 
-`dense_evolution_mcp` gives you 19 tools that call the *same* local kernel
+`dense_evolution_mcp` gives you 20 tools that call the *same* local kernel
 the published Composer web page uses (`local_site/app/server.py`) -- real
 `DenseSVSimulator` runs, real Hartree-Fock Hamiltonians, real VQE with
 adjoint differentiation, real Hellmann-Feynman forces. Prefer these tools

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -66,7 +66,7 @@ server's environment.
 
 ## Tools
 
-17 tools -- one per Composer kernel endpoint, plus a batch scan:
+20 tools -- one per Composer kernel endpoint, plus batch scans:
 
 | Tool | What it does |
 |---|---|
@@ -87,6 +87,23 @@ server's environment.
 | `dense_evolution_md_trajectory` | Velocity-Verlet MD trajectory |
 | `dense_evolution_mitigate_zne` | Zero-noise extrapolation, scalar observable |
 | `dense_evolution_mitigate_density_matrix` | Zero-noise extrapolation, full density matrix |
+| `dense_evolution_wormhole_select_instance` | Screen SYK seeds for a good instance for the wormhole protocol (arXiv:2604.10090's own selection criterion) |
+| `dense_evolution_wormhole_teleportation` | Run one point of the real traversable-wormhole-inspired teleportation protocol on a binary sparse SYK model |
+| `dense_evolution_wormhole_scan` | Sweep `t1` (both +mu and -mu at each point) for the wormhole protocol in one batched call |
+
+**Wormhole tools need a well-selected SYK instance.** Call
+`dense_evolution_wormhole_select_instance` before `_wormhole_teleportation`/
+`_wormhole_scan` unless you already have a known-good seed -- a uniformly
+random draw of which SYK terms to keep does not reliably show the
+protocol's sign-dependent signal (verified directly: some seeds give a
+clean peak, some the wrong sign, some flat noise). `seed=61` is the
+verified match for the defaults (`n_majorana=8, k_terms=10`), used
+throughout [Dense-Evolution-Ising-Tests' own wormhole experiments](https://tatopenn-cell.github.io/Dense-Evolution-Ising-Tests/wormhole_syk_teleportation/).
+`_wormhole_scan` points run sequentially, not concurrently -- concurrent
+calls to this specific endpoint were found to crash the kernel process
+outright (a real BLAS/eigh thread-safety issue under this protocol's
+heavier-than-usual linear algebra), so each point costs several seconds
+and a full 20-point sweep can take a few minutes.
 
 **Molecule names**: every tool that takes a catalog molecule accepts either
 its short `id` (e.g. `"H2"`, `"LiH"`, `"HeH+"`) or the kernel's full


### PR DESCRIPTION
## Summary
- The main README's "MCP Server" section already correctly said 20 tools and described the wormhole tools -- but `mcp_server/README.md`'s own tool table was left behind at 17 tools, missing `dense_evolution_wormhole_select_instance`/`_wormhole_teleportation`/`_wormhole_scan` entirely.
- `.claude/skills/dense-evolution-mcp/SKILL.md` said 19 tools instead of 20 (its tool-map table already had the wormhole row, just the intro count was stale).
- Historical changelog entries in README.md that correctly say "17 tools" (accurate for that point in the project's history) are left untouched.

## Test plan
- [ ] Review the new mcp_server/README.md tool table rows and wormhole usage note