### PR TITLE
Reintegrate vector healing: dashboard_core, kernel endpoint, MCP tool

### DIFF
--- a/.claude/skills/dense-evolution-mcp/SKILL.md
+++ b/.claude/skills/dense-evolution-mcp/SKILL.md
@@ -8,7 +8,7 @@ compatibility: Requires the dense_evolution_mcp MCP server registered (see mcp_s
 
 ## Why this exists
 
-`dense_evolution_mcp` gives you 20 tools that call the *same* local kernel
+`dense_evolution_mcp` gives you 21 tools that call the *same* local kernel
 the published Composer web page uses (`local_site/app/server.py`) -- real
 `DenseSVSimulator` runs, real Hartree-Fock Hamiltonians, real VQE with
 adjoint differentiation, real Hellmann-Feynman forces. Prefer these tools
@@ -57,6 +57,7 @@ assuming a size that worked for a small molecule will scale.
 | Nuclear forces / a dynamics trajectory | `dense_evolution_qmmm_forces`, `_md_trajectory` |
 | Correct a noisy result back toward the ideal one | `dense_evolution_mitigate_zne` (scalar observable), `_mitigate_density_matrix` (full state) |
 | Traversable-wormhole-inspired quantum teleportation (SYK model) | `dense_evolution_wormhole_select_instance`, `_wormhole_teleportation`, `_wormhole_scan` |
+| Clean a noisy VQE/MD telemetry sequence or any other noisy vector trajectory | `dense_evolution_vector_healing` |
 
 Every tool's own docstring has the full parameter/return schema -- this
 table is for picking the right one quickly, not a substitute for reading
@@ -151,6 +152,20 @@ kernel process -- a BLAS/eigh thread-safety issue under its heavier
 linear algebra, unlike the cheap Hamiltonian diagonalizations
 `_energy_scan` batches concurrently) -- a 20-point sweep can take several
 minutes; start with a handful of points to gauge cost, same as VQE.
+
+**"Clean up / denoise this VQE or MD telemetry" / "vector healing":**
+`dense_evolution_vector_healing` -- pass the raw (n_steps, dim) sequence
+(e.g. a VQE energy/parameter trajectory or MD telemetry). Per step, a
+Phi-Trigger (`dense_evolution.healing`) decides whether the change from
+a local baseline looks like genuine dynamics (kept as-is) or static
+noise (replaced by the local median); NaN/Inf entries are always
+sanitized first regardless. Report `fallback_triggered` and
+`reconstruction_error` back to the user alongside the healed sequence --
+`fallback_triggered=True` means genuine corruption (NaN/Inf) was found
+*and* corrected, not just that some step looked statistically static.
+This is the same predictive-healing engine the pre-rebuild dashboard
+routed VQE/MD telemetry through before any panel was built from it
+(`ia_utils/vector_healing.py`'s `enhanced_dense_healing_hybrid`).
 
 ## If the kernel isn't set up yet
 

--- a/.claude/skills/dense-evolution-mcp/SKILL.md
+++ b/.claude/skills/dense-evolution-mcp/SKILL.md
@@ -8,7 +8,7 @@ compatibility: Requires the dense_evolution_mcp MCP server registered (see mcp_s
 
 ## Why this exists
 
-`dense_evolution_mcp` gives you 19 tools that call the *same* local kernel
+`dense_evolution_mcp` gives you 20 tools that call the *same* local kernel
 the published Composer web page uses (`local_site/app/server.py`) -- real
 `DenseSVSimulator` runs, real Hartree-Fock Hamiltonians, real VQE with
 adjoint differentiation, real Hellmann-Feynman forces. Prefer these tools

--- a/README.md
+++ b/README.md
@@ -637,16 +637,17 @@ the same relative layout so it opens correctly via `file://`.
 ## ▍ MCP Server — drive the Composer kernel from an agent
 
 `dense_evolution_mcp` (`mcp_server/`) is an MCP ([Model Context
-Protocol](https://modelcontextprotocol.io)) server: 20 tools, one per
-Composer kernel endpoint plus a batch energy scan and a batch wormhole
-sweep, letting an MCP-aware agent (Claude Code, Claude Desktop, ...) run
-circuits, compute molecular ground-state energies, run VQE, get QM/MM
-forces, run MD trajectories, apply ZNE mitigation, and run traversable-
-wormhole-inspired quantum teleportation directly — without a browser. A
-thin adapter, not a reimplementation: every tool calls the same kernel
-`serve` starts above; `local_site/app/server.py` itself gained two new
-endpoints for the wormhole tools (`/api/wormhole_select_instance`,
-`/api/wormhole_teleportation`) but no existing endpoint changed.
+Protocol](https://modelcontextprotocol.io)) server: 21 tools, one per
+Composer kernel endpoint plus a batch energy scan, a batch wormhole
+sweep, and a vector-healing pass, letting an MCP-aware agent (Claude
+Code, Claude Desktop, ...) run circuits, compute molecular ground-state
+energies, run VQE, get QM/MM forces, run MD trajectories, apply ZNE
+mitigation, run traversable-wormhole-inspired quantum teleportation, and
+heal a noisy vector sequence directly — without a browser. A thin
+adapter, not a reimplementation: every tool calls the same kernel
+`serve` starts above; `local_site/app/server.py` itself gained three new
+endpoints (`/api/wormhole_select_instance`, `/api/wormhole_teleportation`,
+`/api/vector_healing`) but no existing endpoint changed.
 
 ```bash
 pip install dense-evolution[mcp]
@@ -675,6 +676,15 @@ claude mcp add dense_evolution -- dense-evolution mcp
   wormhole sweep runs sequentially, not concurrently (each call is a real
   multi-second simulation; concurrent calls were found to crash the
   kernel via a BLAS/eigh thread-safety issue).
+- `dense_evolution_vector_healing` reintegrates the predictive-healing
+  engine (`dense_evolution.healing`'s Phi-Trigger primitives, via
+  `ia_utils.vector_healing.enhanced_dense_healing_hybrid`) that shipped
+  with the pre-rebuild dashboard_core's Streamlit "AI healing shield"
+  middleware, left behind (not removed) when dashboard_core was rebuilt
+  around the Composer kernel — see `dashboard_core/vector_healing.py`.
+  Cleans a noisy (n_steps, dim) sequence (VQE telemetry, MD trajectory,
+  or any other vector sequence): per step, keeps genuine dynamics,
+  replaces static noise with the local median, always sanitizes NaN/Inf.
 - Large arrays are truncated to their most significant entries, and
   images are saved to disk (path returned) rather than inlined as base64,
   so a tool response stays usable in an agent's context.

--- a/dashboard_core/__init__.py
+++ b/dashboard_core/__init__.py
@@ -39,6 +39,7 @@ from .wormhole import (
     build_sparse_syk_terms, commuting_pair_count, select_good_instance,
     run_wormhole_protocol, run_wormhole_protocol_trotter,
 )
+from .vector_healing import VectorHealingResult, run_vector_healing
 
 __all__ = [
     'QASM_LIBRARY', 'gate_tuples_to_qasm',
@@ -59,4 +60,5 @@ __all__ = [
     'compute_hellmann_feynman_forces', 'md_step', 'run_md_trajectory',
     'build_sparse_syk_terms', 'commuting_pair_count', 'select_good_instance',
     'run_wormhole_protocol', 'run_wormhole_protocol_trotter',
+    'VectorHealingResult', 'run_vector_healing',
 ]

--- a/dashboard_core/vector_healing.py
+++ b/dashboard_core/vector_healing.py
@@ -1,0 +1,65 @@
+"""
+Real predictive-healing pass over a noisy vector sequence (VQE/MD
+telemetry, quantum state trajectories, or any other (n_steps, dim) array)
+-- a thin wrapper around `ia_utils.vector_healing.enhanced_dense_healing_hybrid`,
+which itself is built on `dense_evolution.healing`'s Phi-Trigger primitives
+(calculate_phi_ab, calculate_vettore_dinamico, evaluate_phi_trigger).
+
+This existed in the pre-rebuild dashboard_core (Streamlit dashboard's
+"AI healing shield" middleware, routing VQE/MD telemetry through it
+before any panel was built from it) but was left behind when
+dashboard_core was rebuilt around the Composer kernel -- see this
+package's __init__.py docstring ("will be reintegrated selectively once
+this base is solid"). Reintegrated here as its own module, mirroring
+mitigation.py's shape (a dataclass result + one thin run_* function),
+rather than resurrecting the old monolithic dashboard_core.py.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+from ia_utils.vector_healing import enhanced_dense_healing_hybrid
+
+__all__ = ['VectorHealingResult', 'run_vector_healing']
+
+
+@dataclass
+class VectorHealingResult:
+    healed_vectors: list          # (n_steps, dim), same shape as input
+    fallback_triggered: bool      # True only if genuine NaN/Inf corruption was present AND corrected
+    adaptive_radius_used: int
+    reconstruction_error: float   # mean per-step norm of (healed - sanitized) vectors
+
+
+def run_vector_healing(vectors, radius_baseline: Optional[int] = None) -> VectorHealingResult:
+    """Heal a noisy (n_steps, dim) vector sequence: per step, a Phi-Trigger
+    (dense_evolution.healing) decides whether the change from a local
+    baseline looks like genuine dynamics (kept as-is) or static noise
+    (replaced by the local median) -- see
+    ia_utils.vector_healing.enhanced_dense_healing_hybrid's own docstring
+    for the full algorithm. NaN/Inf entries are sanitized first
+    (column-mean imputation) regardless of the trigger's decision.
+
+    Args:
+        vectors: array-like, shape (n_steps, dim), n_steps >= 0.
+        radius_baseline: fixed radius for the local baseline window; if
+            None (default), computed adaptively as
+            min(20, max(3, n_steps // 3)).
+
+    Returns:
+        VectorHealingResult
+    """
+    arr = np.asarray(vectors, dtype=np.float64)
+    if arr.ndim != 2:
+        raise ValueError(f"vectors must be 2D (n_steps, dim), got shape {arr.shape}")
+
+    healed, metadata = enhanced_dense_healing_hybrid(arr, radius_baseline=radius_baseline)
+
+    return VectorHealingResult(
+        healed_vectors=healed.tolist(),
+        fallback_triggered=bool(metadata['fallback_triggered']),
+        adaptive_radius_used=int(metadata['adaptive_radius_used']),
+        reconstruction_error=float(metadata['reconstruction_error']),
+    )

--- a/docs/api/healing.md
+++ b/docs/api/healing.md
@@ -1,8 +1,41 @@
 # Healing (predictive primitives)
 
-::: dense_evolution.healing
+Predictive-healing primitives for noisy vector sequences (VQE/MD
+telemetry, quantum state trajectories): a "Phi-Trigger" that, given a
+state and a local baseline, decides whether an observed change looks
+like genuine dynamics or static noise, plus supporting sync/reflection
+functions. Built empirically, one formula at a time — see the module's
+own docstring for which parts carry a real information-theoretic reading
+(`calculate_vettore_dinamico`'s core term is a log-likelihood ratio) and
+which are a geometric construction instead (`calculate_phi_ab`), so as
+not to overclaim either way.
+
+**Applied layer**: [`ia_utils.vector_healing.enhanced_dense_healing_hybrid`](https://github.com/tatopenn-cell/Dense-Evolution/blob/main/ia_utils/vector_healing.py)
+is what actually calls these primitives on a real `(n_steps, dim)`
+sequence — per step, runs the Phi-Trigger against a local baseline
+window and either keeps the value (genuine dynamics) or replaces it with
+the local median (static noise), after sanitizing any NaN/Inf first
+regardless of that decision. This shipped with the pre-rebuild
+dashboard_core's Streamlit "AI healing shield" middleware (VQE/MD
+telemetry routed through it before any panel was built from it), and
+was left behind — not removed — when dashboard_core was rebuilt around
+the Composer kernel.
+
+**Reintegrated end to end**: `dashboard_core.run_vector_healing` (a thin
+wrapper, mirroring `mitigation.py`'s shape) → the kernel's
+`POST /api/vector_healing` → the MCP tool `dense_evolution_vector_healing`
+(see `mcp_server/README.md`). All three call the same real primitives on
+this page — no separate reimplementation.
 
 ---
 
-**See also**: [`dense_evolution.mitigation`](mitigation.md) — `zne_density_matrix`'s
-healing-adapted branch calls `calculate_delta_preemp` from this module.
+**See also**: [`dense_evolution.mitigation`](mitigation.md) — `zero_noise_extrapolation`'s
+healing-adapted branch (triggered by passing `sigma_at_base_noise`) calls
+`calculate_delta_preemp` from this module. Unlike `run_vector_healing`
+above, this branch is **not** currently reachable from the kernel or MCP:
+`dashboard_core.run_zne_mitigation` never passes `sigma_at_base_noise`,
+and the kernel's `MitigateRequest` has no field for it — deliberately
+left as a known follow-up rather than wired up speculatively, since
+`calculate_advanced_sigma` (the usual source of a real `sigma_at_base_noise`
+value) itself needs `kappa`/`H`/`Psi`/`Omega_sync`/`tau_K` inputs whose
+provenance in a ZNE context isn't yet designed.

--- a/local_site/app/server.py
+++ b/local_site/app/server.py
@@ -605,6 +605,30 @@ def mitigate_matrix(req: MitigateMatrixRequest):
     }
 
 
+class VectorHealingRequest(BaseModel):
+    vectors: list       # (n_steps, dim) -- list of equal-length rows
+    radius_baseline: int | None = None
+
+
+@app.post("/api/vector_healing")
+def vector_healing(req: VectorHealingRequest):
+    """Real predictive-healing pass over a noisy vector sequence
+    (dashboard_core.run_vector_healing / ia_utils.vector_healing): per
+    step, a Phi-Trigger decides whether the change from a local baseline
+    looks like genuine dynamics (kept) or static noise (replaced by the
+    local median). NaN/Inf entries are sanitized first regardless."""
+    try:
+        result = dc.run_vector_healing(req.vectors, radius_baseline=req.radius_baseline)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {
+        "healed_vectors": result.healed_vectors,
+        "fallback_triggered": result.fallback_triggered,
+        "adaptive_radius_used": result.adaptive_radius_used,
+        "reconstruction_error": result.reconstruction_error,
+    }
+
+
 class WormholeSelectInstanceRequest(BaseModel):
     n_majorana: int = 8
     k_terms: int = 10

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -66,7 +66,7 @@ server's environment.
 
 ## Tools
 
-20 tools -- one per Composer kernel endpoint, plus batch scans:
+21 tools -- one per Composer kernel endpoint, plus batch scans:
 
 | Tool | What it does |
 |---|---|
@@ -90,6 +90,20 @@ server's environment.
 | `dense_evolution_wormhole_select_instance` | Screen SYK seeds for a good instance for the wormhole protocol (arXiv:2604.10090's own selection criterion) |
 | `dense_evolution_wormhole_teleportation` | Run one point of the real traversable-wormhole-inspired teleportation protocol on a binary sparse SYK model |
 | `dense_evolution_wormhole_scan` | Sweep `t1` (both +mu and -mu at each point) for the wormhole protocol in one batched call |
+| `dense_evolution_vector_healing` | Heal a noisy (n_steps, dim) vector sequence -- e.g. VQE convergence telemetry or an MD trajectory |
+
+**Vector healing** (`dense_evolution_vector_healing`) reintegrates the
+predictive-healing engine (`dense_evolution.healing`'s Phi-Trigger
+primitives, via `ia_utils.vector_healing.enhanced_dense_healing_hybrid`)
+that shipped with the pre-rebuild dashboard_core's Streamlit "AI healing
+shield" middleware -- left behind (not removed) when dashboard_core was
+rebuilt around the Composer kernel, now reintegrated as
+`dashboard_core.run_vector_healing`. Per step, a Phi-Trigger compares
+the change from a local baseline against the recent trend: a genuine
+move is kept as-is, a static/noisy one is replaced by the local median.
+NaN/Inf entries are always sanitized first (column-mean imputation),
+regardless of that decision. Useful for cleaning a noisy VQE parameter/
+energy trajectory or MD telemetry before analyzing or plotting it.
 
 **Wormhole tools need a well-selected SYK instance.** Call
 `dense_evolution_wormhole_select_instance` before `_wormhole_teleportation`/

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -66,7 +66,7 @@ server's environment.
 
 ## Tools
 
-17 tools -- one per Composer kernel endpoint, plus a batch scan:
+20 tools -- one per Composer kernel endpoint, plus batch scans:
 
 | Tool | What it does |
 |---|---|
@@ -87,6 +87,23 @@ server's environment.
 | `dense_evolution_md_trajectory` | Velocity-Verlet MD trajectory |
 | `dense_evolution_mitigate_zne` | Zero-noise extrapolation, scalar observable |
 | `dense_evolution_mitigate_density_matrix` | Zero-noise extrapolation, full density matrix |
+| `dense_evolution_wormhole_select_instance` | Screen SYK seeds for a good instance for the wormhole protocol (arXiv:2604.10090's own selection criterion) |
+| `dense_evolution_wormhole_teleportation` | Run one point of the real traversable-wormhole-inspired teleportation protocol on a binary sparse SYK model |
+| `dense_evolution_wormhole_scan` | Sweep `t1` (both +mu and -mu at each point) for the wormhole protocol in one batched call |
+
+**Wormhole tools need a well-selected SYK instance.** Call
+`dense_evolution_wormhole_select_instance` before `_wormhole_teleportation`/
+`_wormhole_scan` unless you already have a known-good seed -- a uniformly
+random draw of which SYK terms to keep does not reliably show the
+protocol's sign-dependent signal (verified directly: some seeds give a
+clean peak, some the wrong sign, some flat noise). `seed=61` is the
+verified match for the defaults (`n_majorana=8, k_terms=10`), used
+throughout [Dense-Evolution-Ising-Tests' own wormhole experiments](https://tatopenn-cell.github.io/Dense-Evolution-Ising-Tests/wormhole_syk_teleportation/).
+`_wormhole_scan` points run sequentially, not concurrently -- concurrent
+calls to this specific endpoint were found to crash the kernel process
+outright (a real BLAS/eigh thread-safety issue under this protocol's
+heavier-than-usual linear algebra), so each point costs several seconds
+and a full 20-point sweep can take a few minutes.
 
 **Molecule names**: every tool that takes a catalog molecule accepts either
 its short `id` (e.g. `"H2"`, `"LiH"`, `"HeH+"`) or the kernel's full

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -765,6 +765,40 @@ async def dense_evolution_mitigate_density_matrix(params: MitigateDensityMatrixI
         return _handle_error(e)
 
 
+class VectorHealingInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    vectors: list = Field(..., description="(n_steps, dim) sequence of equal-length numeric rows to heal -- "
+                           "e.g. a VQE parameter/energy trajectory, MD telemetry, or any other noisy vector "
+                           "sequence. NaN/Inf entries are sanitized automatically.")
+    radius_baseline: int | None = Field(
+        default=None,
+        description="Fixed radius for the local baseline window used to judge each step. If omitted, "
+        "computed adaptively as min(20, max(3, n_steps // 3)).",
+    )
+
+
+@mcp.tool(name="dense_evolution_vector_healing", annotations={"title": "Heal a noisy vector sequence", **COMPUTE})
+async def dense_evolution_vector_healing(params: VectorHealingInput) -> str:
+    """Run a real predictive-healing pass over a noisy (n_steps, dim)
+    vector sequence -- e.g. VQE convergence telemetry or an MD
+    trajectory. Per step, a Phi-Trigger (dense_evolution.healing) decides
+    whether the change from a local baseline looks like genuine dynamics
+    (kept as-is) or static noise (replaced by the local median). NaN/Inf
+    entries are sanitized first regardless of that decision.
+
+    Args:
+        params (VectorHealingInput): vectors, radius_baseline.
+
+    Returns:
+        str: JSON with healed_vectors, fallback_triggered,
+        adaptive_radius_used, reconstruction_error.
+    """
+    try:
+        return json.dumps(await _request("POST", "/api/vector_healing", json=params.model_dump()), indent=2)
+    except Exception as e:
+        return _handle_error(e)
+
+
 # --------------------------------------------------------------------------
 # Tools: traversable-wormhole-inspired quantum teleportation (SYK model)
 # --------------------------------------------------------------------------

--- a/tests/test_local_site_server.py
+++ b/tests/test_local_site_server.py
@@ -383,6 +383,22 @@ def test_mitigate_matrix_invalid_qasm_returns_400():
     assert resp.status_code == 400
 
 
+def test_vector_healing_replaces_an_outlier_with_the_local_median():
+    vectors = [[1.0, 2.0], [1.1, 2.1], [1.05, 2.05], [50.0, -30.0], [1.08, 2.08], [1.02, 2.02]]
+    resp = client.post("/api/vector_healing", json={"vectors": vectors})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["healed_vectors"]) == 6
+    # The genuine outlier row must not survive untouched.
+    assert body["healed_vectors"][3] != vectors[3]
+    assert body["reconstruction_error"] > 0.0
+
+
+def test_vector_healing_invalid_shape_returns_400():
+    resp = client.post("/api/vector_healing", json={"vectors": [1.0, 2.0, 3.0]})
+    assert resp.status_code == 400
+
+
 def test_wormhole_select_instance_finds_the_known_seed_61():
     """n_majorana=8/k_terms=10/target_commuting=34 is the exact
     configuration whose known-good seed (61, matching arXiv:2604.10090's

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -127,6 +127,16 @@ def test_mitigate_density_matrix_reports_fidelity_improvement():
     assert 0.0 <= result["fidelity_corrected"] <= 1.0
 
 
+def test_vector_healing_replaces_an_outlier_with_the_local_median():
+    vectors = [[1.0, 2.0], [1.1, 2.1], [1.05, 2.05], [50.0, -30.0], [1.08, 2.08], [1.02, 2.02]]
+    result = json.loads(run(mcp_adapter.dense_evolution_vector_healing(
+        mcp_adapter.VectorHealingInput(vectors=vectors)
+    )))
+    assert len(result["healed_vectors"]) == 6
+    assert result["healed_vectors"][3] != vectors[3]
+    assert result["reconstruction_error"] > 0.0
+
+
 def test_list_molecules_includes_short_ids():
     data = json.loads(run(mcp_adapter.dense_evolution_list_molecules(mcp_adapter.ListMoleculesInput())))
     by_id = {m["id"]: m for m in data}


### PR DESCRIPTION
## Summary
- `dense_evolution.healing` and its applied layer (`ia_utils.vector_healing.enhanced_dense_healing_hybrid`) were implemented and tested but completely unreachable from any user-facing path -- no kernel endpoint, no MCP tool, no docs paragraph. `dashboard_core/__init__.py`'s own docstring already flagged this as pending: "will be reintegrated selectively once this base is solid."
- Adds `dashboard_core/vector_healing.py` (`run_vector_healing`, mirroring `mitigation.py`'s shape), a new kernel endpoint `POST /api/vector_healing`, and a new MCP tool `dense_evolution_vector_healing` (21 tools total now).
- Tests at both layers (kernel `TestClient`, MCP `ASGITransport`) verify a genuine outlier vector gets replaced by the local median.
- Docs updated: README.md MCP section, `mcp_server/README.md`, `.claude/skills/dense-evolution-mcp/SKILL.md`, and a real prose paragraph added to `docs/api/healing.md` (was just a bare mkdocstrings directive before).
- Honest scope note in the docs: `mitigation.py`'s *other* healing-adapted branch (`zero_noise_extrapolation`'s `sigma_at_base_noise`) is a separate, still-unwired follow-up -- not silently conflated with this change, since its inputs (`calculate_advanced_sigma`'s kappa/H/Psi/Omega_sync/tau_K) don't have a designed source in a ZNE context yet.

## Test plan
- [x] `pytest tests/test_local_site_server.py tests/test_mcp_server.py tests/test_healing.py tests/test_ia_healing.py` -- 105 passed locally
- [x] `mkdocs build --strict` -- clean
- [ ] CI (matrix: 3.10/3.11/3.12 x ubuntu/macos)