### PR TITLE
Document MCP server across the docs site (home, API index, getting started, examples)

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -2,7 +2,15 @@
 
 Generated directly from the package's own docstrings via
 [`mkdocstrings`](https://mkdocstrings.github.io/) — nothing here is duplicated by hand, so
-it can't drift out of sync with the code.
+it can't drift out of sync with the code. Scoped to the `dense_evolution` package itself;
+`dashboard_core`, `ia_utils`, and `mcp_server` (the Composer kernel and its MCP adapter) are
+built on top of these modules but aren't part of this generated reference — see below.
+
+**Driving these modules without writing Python**: every module in the table has a real,
+tested execution path through the Composer kernel, reachable either from a browser
+([Composer](../composer.md)) or from an MCP-aware agent ([MCP Server](../mcp.md), 21 tools —
+Claude Code, Claude Desktop, ...). Both call the exact same kernel, not a separate
+reimplementation.
 
 | Module | What it's for |
 |---|---|

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-Three runnable, end-to-end examples, each lifted from real experiments/tests already in
+Four runnable, end-to-end examples, each lifted from real experiments/tests already in
 the repository rather than written fresh for this page:
 
 - [Density-matrix ZNE healing](#density-matrix-zne-healing) — from
@@ -10,6 +10,8 @@ the repository rather than written fresh for this page:
   `tests/test_mps.py::test_run_circuit_jit_ghz_chain`.
 - [Differentiable VQE](#differentiable-vqe) — from
   `tests/test_autodiff.py::TestCircuitToEnergyFn`.
+- [Vector healing](#vector-healing) — from `tests/test_ia_healing.py`, healing a noisy
+  vector sequence (not to be confused with density-matrix ZNE healing above).
 
 ## Density-matrix ZNE healing
 
@@ -158,3 +160,31 @@ print(f"ground state:  {float(jnp.min(jnp.diag(h_matrix))):.4f}")
 `circuit_to_energy_fn` also accepts an optional `noise=` (`dense_evolution.NoiseSpec`, a
 JAX pytree) to trace noisy VQE runs natively — composable with `jax.jit`, `jax.grad`, and
 `jax.vmap` over noise-key batches. See [`dense_evolution.autodiff`](api/autodiff.md).
+
+## Vector healing
+
+Not to be confused with [density-matrix ZNE healing](#density-matrix-zne-healing) above —
+same word, different thing. This is `dense_evolution.healing`'s Phi-Trigger applied to a
+real `(n_steps, dim)` vector sequence (a VQE parameter/energy trajectory, MD telemetry, or
+any other noisy sequence): per step, keep it if the change from a local baseline looks like
+genuine dynamics, replace it with the local median if it looks like static noise. NaN/Inf
+entries are always sanitized first, regardless of that decision.
+
+```python
+import numpy as np
+from ia_utils.vector_healing import enhanced_dense_healing_hybrid
+
+rng = np.random.default_rng(0)
+trajectory = rng.normal(loc=1.0, scale=0.05, size=(30, 4))  # e.g. a VQE parameter history
+trajectory[17] = [50.0, -30.0, 12.0, -8.0]                  # one genuine outlier step
+
+healed, meta = enhanced_dense_healing_hybrid(trajectory)
+
+print(f"outlier step replaced: {not np.array_equal(healed[17], trajectory[17])}")
+print(f"fallback_triggered:    {meta['fallback_triggered']}")     # NaN/Inf found *and* corrected
+print(f"reconstruction_error:  {meta['reconstruction_error']:.4f}")
+```
+
+Same primitives, reachable without writing Python: `dashboard_core.run_vector_healing`
+(kernel-facing wrapper), the Composer kernel's `POST /api/vector_healing`, or the MCP tool
+`dense_evolution_vector_healing` — see [MCP Server](mcp.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -104,13 +104,38 @@ See [`dense_evolution.mitigation`](api/mitigation.md) for the full API, includin
 
 `app_dashboard.py` lives at the root of the cloned repository -- it is not part of the
 pip-installed package, so this needs the `git clone` from the [Install](#install) section
-above, not just `pip install`.
+above, not just `pip install`. Circuit builder / statevector / probabilities / Q-sphere
+only -- VQE, molecular Hamiltonians, ZNE mitigation, and vector healing aren't wired into
+this Streamlit UI (yet); reach them via [Composer](composer.md) or the [MCP Server](mcp.md)
+above instead.
 
 ```bash
 pip install "dense-evolution[dashboard]"  # JAX already included by default
 cd Dense-Evolution
 streamlit run app_dashboard.py
 ```
+
+## MCP Server (drive it from an agent)
+
+Same kernel as the Composer web page above, driven by an MCP-aware agent (Claude Code,
+Claude Desktop, ...) instead of a browser -- circuits, molecular energies, VQE, QM/MM
+forces, MD trajectories, ZNE mitigation, the wormhole teleportation protocol, and healing a
+noisy vector sequence, all as callable tools instead of Python you write yourself.
+
+```bash
+pip install "dense-evolution[mcp]"
+
+dense-evolution serve   # start the kernel first, in one terminal
+dense-evolution mcp     # in another terminal, or registered with your MCP client's config
+```
+
+**Register with Claude Code:**
+
+```bash
+claude mcp add dense_evolution -- dense-evolution mcp
+```
+
+Full tool reference, setup details, and design notes: **[MCP Server](mcp.md)**.
 
 ## Running the test suite
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,11 +27,26 @@ of `2ⁿ × 16 bytes`.
   projection, Uhlmann fidelity), every entry point with a `jax.jit`-compatible variant.
 - **[`dense_evolution.healing`](api/healing.md)** — the predictive-healing primitives
   (`calculate_delta_preemp`, `calculate_vettore_dinamico`, ...) ZNE's healing-adapted branch
-  is built on.
+  is built on, and that `dashboard_core.run_vector_healing` / `dense_evolution_vector_healing`
+  (below) apply to real noisy vector sequences.
 - **[`NoiseModel`](api/registry.md)** — Kraus-channel noise (depolarizing, bitflip,
   phaseflip, amplitude damping, and a combined worst-case model), JAX- and NumPy-native.
 - **Interop** with [Qiskit and PennyLane](api/interop.md), and [autodiff](api/autodiff.md)
   through `circuit_to_energy_fn` for gradient-based VQE.
+
+## Beyond the library: Composer and MCP
+
+Two ways to drive the simulator without writing Python against it directly, both backed by
+the same local kernel (`local_site/app/server.py`, real `DenseSVSimulator`/PennyLane
+Hartree-Fock, no mocked physics):
+
+- **[Composer](composer.md)** — a browser UI: build a circuit graphically or in OpenQASM,
+  compute molecular ground-state energies, run VQE, get QM/MM forces and MD trajectories,
+  apply ZNE mitigation, and run the traversable-wormhole-inspired teleportation protocol.
+- **[MCP Server](mcp.md)** — the same kernel, driven by an MCP-aware agent (Claude Code,
+  Claude Desktop, ...) instead of a browser: 21 tools covering everything Composer does,
+  plus a batch energy scan, a batch wormhole sweep, and healing a noisy vector sequence
+  (`dense_evolution_vector_healing`, see `dense_evolution.healing` above).
 
 ## Module dependencies
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,6 @@
+# MCP Server
+
+Included directly from the repository [`mcp_server/README.md`](https://github.com/tatopenn-cell/Dense-Evolution/blob/main/mcp_server/README.md)
+so it never goes stale relative to the single source of truth.
+
+{% include-markdown "../mcp_server/README.md" %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ plugins:
 nav:
   - Home: index.md
   - Composer: composer.md
+  - MCP Server: mcp.md
   - Getting Started: getting-started.md
   - Examples: examples.md
   - Benchmarks: benchmarks.md


### PR DESCRIPTION
## Summary
- The docs homepage, API reference index, getting-started guide, and examples page had zero mentions of the MCP server -- Composer was the only entry point shown anywhere, despite the MCP adapter covering 21 tools across several releases.
- `docs/mcp.md`: a real nav page, `{% include-markdown %}`-ed from `mcp_server/README.md` (same pattern already used for `contributing.md`/`changelog.md`/`LICENSE.md` -- single source of truth, no duplication). Added to nav right after Composer.
- `docs/index.md`: new "Beyond the library: Composer and MCP" section.
- `docs/api/index.md`: note pointing to Composer/MCP as real execution paths for every module in the table.
- `docs/getting-started.md`: an actual MCP setup section (was missing entirely), plus a scope clarification on the Streamlit dashboard (VQE/mitigation/healing aren't wired into that UI, unlike Composer/MCP).
- `docs/examples.md`: a fourth worked example (vector healing), explicitly distinguished from the existing "density-matrix ZNE healing" example -- verified to run and produce the described output.
- `composer.md` itself untouched, as requested.

## Test plan
- [x] `mkdocs build --strict` -- clean, include-markdown resolves correctly
- [x] New vector-healing example in `examples.md` run directly, output matches what's documented
- [ ] CI