### PR TITLE
Add 2nd-order Trotter, MD collision safety check, fix run_batch_jit dtype bug

### DIFF
--- a/dashboard_core/qmmm.py
+++ b/dashboard_core/qmmm.py
@@ -47,7 +47,42 @@ from .hamiltonians import MOLECULE_CATALOG, build_molecular_hamiltonian, _pennyl
 
 __all__ = [
     'ATOMIC_MASSES_AMU', 'compute_hellmann_feynman_forces', 'md_step', 'run_md_trajectory',
+    'MIN_NUCLEAR_DISTANCE_ANGSTROM',
 ]
+
+# Real MD safety floor, not a fabricated number: shorter than any real
+# covalent bond this project's molecule catalog could ever produce (H2's
+# own equilibrium is 0.7414 A) -- run_md_trajectory checks new positions
+# against this after every Velocity-Verlet step, since Hartree-Fock at a
+# near-collided geometry (the failure mode a too-large dt_fs drives
+# light atoms like H toward) diverges rather than raising a clear error,
+# making the actual cause hard to diagnose from the resulting crash.
+# md_step itself stays a bare, unchecked F=ma primitive -- the check
+# belongs at run_md_trajectory's real-simulation boundary, not the
+# mechanical formula (tests exercise md_step directly with synthetic,
+# not physically meaningful, starting positions).
+MIN_NUCLEAR_DISTANCE_ANGSTROM = 0.3
+
+
+def _assert_no_nuclear_collision(positions, step, dt_fs):
+    """Raises RuntimeError if any two atoms in `positions` (n_atoms, 3)
+    are closer than MIN_NUCLEAR_DISTANCE_ANGSTROM -- see that constant's
+    comment for why. A no-op for a single atom (nothing to compare)."""
+    if positions.shape[0] < 2:
+        return
+    diffs = positions[:, None, :] - positions[None, :, :]
+    dists = np.linalg.norm(diffs, axis=-1)
+    np.fill_diagonal(dists, np.inf)
+    min_dist = float(dists.min())
+    if min_dist < MIN_NUCLEAR_DISTANCE_ANGSTROM:
+        raise RuntimeError(
+            f"MD trajectory diverged: two atoms are {min_dist:.4f} A apart at step "
+            f"{step + 1} (below the {MIN_NUCLEAR_DISTANCE_ANGSTROM} A safety floor -- "
+            f"no real covalent bond in this catalog is that short). This almost always "
+            f"means dt_fs={dt_fs} is too large for the forces involved -- light atoms "
+            f"like H accelerate sharply and overshoot in a single step. Try a smaller "
+            f"dt_fs before rerunning."
+        )
 
 # Real standard atomic weights (amu) for the elements this project's real
 # molecule catalog actually uses (H2, HeH+, H3+, LiH, H2O) -- only what's
@@ -199,6 +234,7 @@ def run_md_trajectory(name: str, n_steps: int, dt_fs: float = 0.5, mapping: str 
         trajectory["force_norm"].append(result["force_norm"])
 
         positions, velocities, _accel = md_step(positions, velocities, forces, symbols, dt_fs=dt_fs)
+        _assert_no_nuclear_collision(positions, step, dt_fs)
 
         if recompute_electronic_state:
             statevector, _gs_energy, _n_qubits = _reference_ground_state(symbols, positions, charge, mapping)

--- a/dense_evolution/simulator.py
+++ b/dense_evolution/simulator.py
@@ -492,7 +492,13 @@ class DenseSVSimulator:
             )
 
         template    = jnp.array(compiled_ops, dtype=jnp.float64)
-        init_sv     = jnp.zeros(self.dim, dtype=jnp.complex128).at[0].set(1.0)
+        # self.dtype, not a hardcoded jnp.complex128: _apply_gate_fast_step
+        # (compiler.py) already derives its working dtype from the input
+        # statevector specifically so use_float32=True instances run in
+        # complex64 end to end -- hardcoding complex128 here silently
+        # discarded that for every run_batch_jit/run_parametric_batch_jit
+        # call regardless of the instance's own configured dtype.
+        init_sv     = jnp.zeros(self.dim, dtype=self.dtype).at[0].set(1.0)
 
         def simulate_single_instance(single_params: "jnp.ndarray") -> "jnp.ndarray":
             """Run one parameter vector through the circuit."""

--- a/dense_evolution/trotter.py
+++ b/dense_evolution/trotter.py
@@ -20,11 +20,25 @@ Trotterized VQE-adjacent ansatz, quench dynamics, etc.).
 pauli_rotation_ops is exact for a single Pauli-string term (fidelity
 1.0 against scipy.linalg.expm, verified in tests/test_trotter.py for
 1-4 qubit mixed X/Y/Z strings, not just Z-strings); trotter_evolve_ops
-composes many such terms via the first-order product formula, which is
-an *approximation* whose error shrinks as n_steps grows (also verified:
-infidelity drops roughly 4x per doubling of steps against a real,
-non-trivial multi-qubit Hamiltonian, consistent with the expected
+composes many such terms via the first-order product formula by default,
+which is an *approximation* whose error shrinks as n_steps grows (also
+verified: infidelity drops roughly 4x per doubling of steps against a
+real, non-trivial multi-qubit Hamiltonian, consistent with the expected
 quadratic convergence of first-order Trotter error in state overlap).
+
+order=2 selects the second-order (Strang/symmetric) product formula
+instead -- each step applies the terms forward at half the angle, then
+backward (reversed order) at half the angle again:
+[prod_k exp(-i*c_k*P_k*dt/2)] * [prod_k(reversed) exp(-i*c_k*P_k*dt/2)],
+which cancels the first-order formula's leading error term (verified in
+tests/test_trotter.py: infidelity drops roughly 16x per doubling of
+steps, consistent with the expected quartic convergence of second-order
+Trotter error in state overlap, vs. order=1's ~4x). Costs 2x the gates
+of order=1 for the same n_steps -- the standard second-order tradeoff,
+worth it when n_steps would otherwise need to be large for accuracy
+(e.g. the noise-robustness experiments in wormhole_syk_teleportation.py,
+where gate count directly limits how much depolarizing noise the
+circuit accumulates).
 """
 
 __all__ = ['pauli_rotation_ops', 'trotter_evolve_ops']
@@ -80,11 +94,19 @@ def pauli_rotation_ops(pauli_dict, angle):
     return ops
 
 
-def trotter_evolve_ops(terms, t, n_steps):
-    """First-order Trotter product formula for exp(-i*H*t),
-    H = sum_k c_k*P_k: [prod_k exp(-i*c_k*P_k*(t/n_steps))]^n_steps.
+def trotter_evolve_ops(terms, t, n_steps, order=1):
+    """Trotter product formula for exp(-i*H*t), H = sum_k c_k*P_k.
+
+    order=1 (default): [prod_k exp(-i*c_k*P_k*(t/n_steps))]^n_steps.
     Term order within one step follows `terms`' own order, identical
     every repetition (not re-randomized per step).
+
+    order=2: Strang/symmetric splitting -- each step is a forward half-
+    angle pass through `terms` followed by a backward half-angle pass
+    through `terms` reversed, [prod_k exp(-i*c_k*P_k*dt/2)] *
+    [prod_k(reversed) exp(-i*c_k*P_k*dt/2)], repeated n_steps times.
+    Quadratically more accurate than order=1 for the same n_steps (see
+    module docstring), at 2x the gate count per step.
 
     Parameters
     ----------
@@ -96,17 +118,27 @@ def trotter_evolve_ops(terms, t, n_steps):
         Total evolution time.
     n_steps : int
         Number of Trotter steps -- higher is more accurate and more
-        gates (len(terms) gates' worth of pauli_rotation_ops per term,
-        repeated n_steps times), the standard Trotter accuracy/cost
-        tradeoff.
+        gates, the standard Trotter accuracy/cost tradeoff.
+    order : int
+        1 (default) or 2 -- see above.
 
     Returns
     -------
     list[tuple]
         Gate tuples for the whole Trotterized evolution.
     """
+    if order not in (1, 2):
+        raise ValueError(f"order must be 1 or 2, got {order}")
     dt = t / n_steps
-    step_ops = []
-    for c, pdict in terms:
-        step_ops.extend(pauli_rotation_ops(pdict, c * dt))
+    if order == 1:
+        step_ops = []
+        for c, pdict in terms:
+            step_ops.extend(pauli_rotation_ops(pdict, c * dt))
+    else:
+        half_dt = dt / 2
+        step_ops = []
+        for c, pdict in terms:
+            step_ops.extend(pauli_rotation_ops(pdict, c * half_dt))
+        for c, pdict in reversed(terms):
+            step_ops.extend(pauli_rotation_ops(pdict, c * half_dt))
     return step_ops * n_steps

--- a/tests/test_dashboard_qmmm.py
+++ b/tests/test_dashboard_qmmm.py
@@ -10,8 +10,9 @@ import numpy as np
 import pytest
 
 from dashboard_core.qmmm import (
-    ATOMIC_MASSES_AMU, ACCEL_CONVERSION,
+    ATOMIC_MASSES_AMU, ACCEL_CONVERSION, MIN_NUCLEAR_DISTANCE_ANGSTROM,
     compute_hellmann_feynman_forces, md_step, run_md_trajectory,
+    _assert_no_nuclear_collision,
 )
 
 H2_EQUILIBRIUM = "H2 (Idrogeno) - R = 0.7414 A [equilibrio reale]"
@@ -111,3 +112,41 @@ class TestRunMdTrajectory:
     def test_time_axis_matches_dt(self):
         trajectory = run_md_trajectory(H2_EQUILIBRIUM, n_steps=4, dt_fs=0.25)
         assert trajectory["time_fs"] == [0.0, 0.25, 0.5, 0.75]
+
+
+class TestAssertNoNuclearCollision:
+    """Fast, direct tests for the collision safety check run_md_trajectory
+    calls after every step -- synthetic positions, no real Hartree-Fock
+    calculation needed to verify the guard itself is correct."""
+
+    def test_real_h2_equilibrium_geometry_passes(self):
+        positions = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.7414]])
+        _assert_no_nuclear_collision(positions, step=0, dt_fs=0.5)  # must not raise
+
+    def test_exactly_at_threshold_passes(self):
+        positions = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, MIN_NUCLEAR_DISTANCE_ANGSTROM]])
+        _assert_no_nuclear_collision(positions, step=0, dt_fs=0.5)  # must not raise
+
+    def test_below_threshold_raises(self):
+        positions = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.05]])
+        with pytest.raises(RuntimeError, match="diverged"):
+            _assert_no_nuclear_collision(positions, step=3, dt_fs=50.0)
+
+    def test_error_message_includes_step_and_dt(self):
+        positions = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.01]])
+        with pytest.raises(RuntimeError, match=r"step 4.*dt_fs=50\.0"):
+            _assert_no_nuclear_collision(positions, step=3, dt_fs=50.0)
+
+    def test_checks_closest_pair_among_more_than_two_atoms(self):
+        # Two atoms far apart, one pair dangerously close -- must still catch it.
+        positions = np.array([
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 5.0],
+            [0.0, 0.0, 5.05],
+        ])
+        with pytest.raises(RuntimeError):
+            _assert_no_nuclear_collision(positions, step=0, dt_fs=1.0)
+
+    def test_single_atom_never_raises(self):
+        positions = np.array([[0.0, 0.0, 0.0]])
+        _assert_no_nuclear_collision(positions, step=0, dt_fs=1000.0)  # nothing to compare

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -405,6 +405,35 @@ class TestBeastModeFloat32:
         np.testing.assert_allclose(probs(sim32), probs(sim64), atol=1e-6)
 
 
+class TestRunBatchJitFloat32:
+    """run_batch_jit built its own init_sv hardcoded to jnp.complex128,
+    ignoring self.dtype/self.use_float32 entirely -- a separate instance
+    of the same category of bug TestBeastModeFloat32 documents for
+    run_circuit_jit above (that one already got its own fix; this one
+    hadn't). Fixed by deriving init_sv's dtype from self.dtype, matching
+    _apply_gate_fast_step's own sv_dtype-derived (not hardcoded)
+    approach in compiler.py."""
+
+    def test_output_is_complex64_under_use_float32(self):
+        sim = DenseSVSimulator(n_qubits=3, use_float32=True)
+        out = sim.run_batch_jit([['h', 0, -1], ['rx', 1, None]], np.array([[0.5]]))
+        assert np.asarray(out).dtype == np.complex64
+
+    def test_output_is_complex128_by_default(self):
+        sim = DenseSVSimulator(n_qubits=3, use_float32=False)
+        out = sim.run_batch_jit([['h', 0, -1], ['rx', 1, None]], np.array([[0.5]]))
+        assert np.asarray(out).dtype == np.complex128
+
+    def test_float32_batch_matches_float64_within_precision(self):
+        circuit = [['h', 0, -1], ['cx', 0, 1], ['ry', 2, None]]
+        batch = np.array([[0.3], [0.9], [1.5]])
+        sim32 = DenseSVSimulator(n_qubits=3, use_float32=True)
+        sim64 = DenseSVSimulator(n_qubits=3, use_float32=False)
+        out32 = np.asarray(sim32.run_batch_jit(circuit, batch))
+        out64 = np.asarray(sim64.run_batch_jit(circuit, batch))
+        np.testing.assert_allclose(np.abs(out32) ** 2, np.abs(out64) ** 2, atol=1e-6)
+
+
 class TestBeastModeDonateArgnums:
     """run_circuit_jit's self.sv = ... call used to allocate a
     fresh statevector buffer on every call instead of letting XLA reuse the

--- a/tests/test_trotter.py
+++ b/tests/test_trotter.py
@@ -115,3 +115,89 @@ class TestTrotterEvolveOps:
         ops_per_step = len(pauli_rotation_ops({0: 'X'}, 1.0)) + len(pauli_rotation_ops({0: 'Y', 1: 'Z'}, 1.0))
         ops = trotter_evolve_ops(terms, t=1.0, n_steps=5)
         assert len(ops) == ops_per_step * 5
+
+    def test_invalid_order_raises(self):
+        terms = [(1.0, {0: 'X'})]
+        with pytest.raises(ValueError):
+            trotter_evolve_ops(terms, t=1.0, n_steps=1, order=3)
+
+
+class TestTrotterEvolveOpsSecondOrder:
+
+    def test_order_2_converges_faster_than_order_1(self):
+        """Second-order (Strang) infidelity should shrink ~16x per step
+        doubling (quartic in state overlap), clearly faster than
+        order=1's ~4x (quadratic), for the same real, non-trivial,
+        non-commuting Hamiltonian used in the order=1 convergence test."""
+        n_qubits = 3
+        terms = [
+            (0.6, {0: 'X', 1: 'Y'}),
+            (-0.4, {1: 'Z', 2: 'X'}),
+            (0.3, {0: 'Y', 2: 'Z'}),
+        ]
+        t = 0.5
+        psi0 = _random_state(n_qubits, seed=11)
+
+        H = sum(c * pauli_hamiltonian_to_matrix([(1.0, p)], n_qubits) for c, p in terms)
+        psi_exact = scipy.linalg.expm(-1j * H * t) @ psi0
+
+        infidelities = []
+        for n_steps in (1, 2, 4, 8):
+            ops = trotter_evolve_ops(terms, t, n_steps, order=2)
+            psi_trotter = _run_ops_on_state(psi0, n_qubits, ops)
+            fidelity = statevector_fidelity(psi_trotter, psi_exact)
+            infidelities.append(1.0 - fidelity)
+
+        for earlier, later in zip(infidelities, infidelities[1:]):
+            assert later <= earlier + 1e-12
+        # quartic convergence: infidelity ratio between consecutive
+        # doublings should be well below order=1's ~4x -- 8x is a safe
+        # margin that still clearly distinguishes it from first order.
+        for earlier, later in zip(infidelities[:-1], infidelities[1:]):
+            if earlier > 1e-14:
+                assert later < earlier / 8
+
+    def test_order_2_more_accurate_than_order_1_at_matched_step_count(self):
+        n_qubits = 3
+        terms = [
+            (0.6, {0: 'X', 1: 'Y'}),
+            (-0.4, {1: 'Z', 2: 'X'}),
+            (0.3, {0: 'Y', 2: 'Z'}),
+        ]
+        t = 0.5
+        n_steps = 4
+        psi0 = _random_state(n_qubits, seed=11)
+
+        H = sum(c * pauli_hamiltonian_to_matrix([(1.0, p)], n_qubits) for c, p in terms)
+        psi_exact = scipy.linalg.expm(-1j * H * t) @ psi0
+
+        psi_order1 = _run_ops_on_state(psi0, n_qubits, trotter_evolve_ops(terms, t, n_steps, order=1))
+        psi_order2 = _run_ops_on_state(psi0, n_qubits, trotter_evolve_ops(terms, t, n_steps, order=2))
+
+        infidelity_1 = 1.0 - statevector_fidelity(psi_order1, psi_exact)
+        infidelity_2 = 1.0 - statevector_fidelity(psi_order2, psi_exact)
+        assert infidelity_2 < infidelity_1
+
+    def test_order_2_single_term_reduces_to_order_1(self):
+        """With one term, forward and backward half-passes both act on
+        the same single Pauli string, so order=2 should reduce to a
+        single order=1-equivalent full-angle rotation per step (the
+        two half-angle rotations on the same axis compose additively)."""
+        pauli_dict = {0: 'X', 1: 'Z'}
+        terms = [(1.0, pauli_dict)]
+        t, n_steps = 0.8, 1
+
+        ops_order1 = trotter_evolve_ops(terms, t, n_steps, order=1)
+        ops_order2 = trotter_evolve_ops(terms, t, n_steps, order=2)
+
+        n_qubits = 2
+        psi0 = _random_state(n_qubits, seed=13)
+        psi1 = _run_ops_on_state(psi0, n_qubits, ops_order1)
+        psi2 = _run_ops_on_state(psi0, n_qubits, ops_order2)
+        assert statevector_fidelity(psi1, psi2) == pytest.approx(1.0, abs=1e-9)
+
+    def test_order_2_gate_count_is_double_order_1(self):
+        terms = [(1.0, {0: 'X'}), (1.0, {0: 'Y', 1: 'Z'})]
+        ops1 = trotter_evolve_ops(terms, t=1.0, n_steps=5, order=1)
+        ops2 = trotter_evolve_ops(terms, t=1.0, n_steps=5, order=2)
+        assert len(ops2) == 2 * len(ops1)


### PR DESCRIPTION
## Summary
Three fixes from a code-review pass (verified against source, not taken at face value):

- **`dense_evolution/trotter.py`**: `trotter_evolve_ops` gains an `order=2` option (Strang/symmetric splitting) alongside the existing default `order=1` -- quadratically more accurate for the same `n_steps`, at 2x gates/step. Useful anywhere gate count directly limits circuit noise (e.g. the wormhole SYK teleportation Trotter noise experiments in the Discovery repo).
- **`dashboard_core/qmmm.py`**: `run_md_trajectory` now raises a clear `RuntimeError` if two atoms end up closer than a physically-motivated 0.3 Å floor after a step, instead of silently feeding a near-collided geometry into Hartree-Fock (which diverges rather than failing informatively). Catches the real failure mode of a too-large `dt_fs` with light atoms. The check lives in `run_md_trajectory`, not the bare `md_step` primitive, since the risk is specifically at the real-simulation boundary.
- **`dense_evolution/simulator.py`**: `run_batch_jit`'s `init_sv` was hardcoded to `complex128` regardless of `self.dtype`/`use_float32`, silently ignoring the instance's own configured precision -- a separate instance of the same bug class `run_circuit_jit` already had a documented fix for (see `TestBeastModeFloat32`). Now derives from `self.dtype`, matching `_apply_gate_fast_step`'s existing sv-dtype-derived approach.

## Test plan
- [x] New tests for `order=2` (quartic convergence verified against `scipy.linalg.expm`, not just claimed)
- [x] New tests for the MD collision guard (fast, synthetic positions -- no real Hartree-Fock needed to test the guard itself)
- [x] New tests confirming `run_batch_jit` output dtype actually matches `use_float32`
- [x] Full suite: `pytest tests/test_trotter.py tests/test_dashboard_qmmm.py tests/test_simulator.py` -- 124 passed, no regressions