### PR TITLE
Bump version to 8.1.52: add MCP Registry ownership verification marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 ╚══════╝  ╚═══╝   ╚═════╝ ╚══════╝ ╚═════╝    ╚═╝   ╚═╝ ╚═════╝ ╚═╝  ╚═══╝
 ```
 
+<!-- mcp-name: io.github.tatopenn-cell/dense-evolution -->
 
 **Dense Statevector Quantum Simulator · JAX XLA · NISQ · VQE · QML**
 
@@ -773,6 +774,9 @@ All circuits stored as OpenQASM 2.0 strings in `dashboard_core.QASM_LIBRARY`.
 ---
 
 ## ▍ Changelog
+
+### v8.1.52
+- **MCP Registry ownership verification marker added** (`<!-- mcp-name: io.github.tatopenn-cell/dense-evolution -->`, hidden HTML comment right after the ASCII banner) -- required by the [official MCP Registry](https://github.com/modelcontextprotocol/registry) to verify this PyPI package's ownership before `dense_evolution_mcp` can be published there. No functional change; this version exists solely so the marker is present in the README rendered as this release's PyPI description (PyPI descriptions are fixed per version, so the marker had to ship in a new release rather than editing an already-published one).
 
 ### v8.1.51
 - **`trotter_evolve_ops` gains `order=2`** (Strang/symmetric product formula) alongside the existing default `order=1` -- quadratically more accurate for the same `n_steps` (verified: infidelity drops ~16x per step doubling vs. `order=1`'s ~4x, against `scipy.linalg.expm`), at 2x gates/step. Useful anywhere gate count directly limits circuit noise.

--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -30,4 +30,4 @@ from .fermions import majorana_pauli_terms
 from .entropy import partial_trace, von_neumann_entropy, mutual_information
 from .trotter import pauli_rotation_ops, trotter_evolve_ops
 
-__version__ = "8.1.51"
+__version__ = "8.1.52"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dense-evolution"
-version = "8.1.51"
+version = "8.1.52"
 description = "Micro-optimized High-Performance NISQ Statevector Quantum Circuit Simulator (Hardware-Adaptive Integration of Native NumPy, CUDA-Accelerated CuPy, and Linear Kernel Fusion via JAX JIT/XLA Compilation)"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
Adds the `<!-- mcp-name: io.github.tatopenn-cell/dense-evolution -->` hidden comment the official [MCP Registry](https://github.com/modelcontextprotocol/registry) requires to verify this PyPI package's ownership, so `dense_evolution_mcp` can be published there.

PyPI descriptions are fixed per version, so this needed a new release (8.1.52) rather than editing 8.1.51's already-published one.