### PR TITLE
Close patch-coverage gaps flagged by codecov on PR #26

### DIFF
--- a/tests/test_dashboard_vector_healing.py
+++ b/tests/test_dashboard_vector_healing.py
@@ -5,6 +5,9 @@ Covers the real happy path plus the deferred-ImportError guard added
 around that import (previously unconditional, so a failure there would
 have taken down every unrelated dashboard_core feature at import time).
 """
+import importlib
+import sys
+
 import numpy as np
 import pytest
 
@@ -37,3 +40,29 @@ def test_run_vector_healing_raises_clear_error_if_ia_utils_missing(monkeypatch):
     monkeypatch.setattr(vector_healing, "_IMPORT_ERROR", ImportError("simulated missing ia_utils"))
     with pytest.raises(ImportError, match="run_vector_healing requires ia_utils.vector_healing"):
         run_vector_healing(np.zeros((5, 2)))
+
+
+def test_module_import_guard_actually_triggers_on_a_real_import_failure():
+    # The test above only simulates the *consequence* of a failed import
+    # (patching the resulting module attributes after a successful real
+    # import) -- this one forces the actual `except ImportError` branch
+    # at module-load time, via the standard sys.modules=None trick
+    # (Python's import system treats that as "this import must fail").
+    # Restored manually (not via monkeypatch, whose teardown runs too
+    # late to matter here) before reloading back to the real state, so
+    # later tests in this file see the genuine module either way.
+    original = sys.modules.get("ia_utils.vector_healing")
+    sys.modules["ia_utils.vector_healing"] = None
+    try:
+        importlib.reload(vector_healing)
+        assert vector_healing.enhanced_dense_healing_hybrid is None
+        assert vector_healing._IMPORT_ERROR is not None
+        with pytest.raises(ImportError, match="run_vector_healing requires ia_utils.vector_healing"):
+            vector_healing.run_vector_healing(np.zeros((5, 2)))
+    finally:
+        if original is None:
+            sys.modules.pop("ia_utils.vector_healing", None)
+        else:
+            sys.modules["ia_utils.vector_healing"] = original
+        importlib.reload(vector_healing)
+        assert vector_healing.enhanced_dense_healing_hybrid is not None

--- a/tests/test_dashboard_vqe.py
+++ b/tests/test_dashboard_vqe.py
@@ -116,6 +116,41 @@ class TestQasmOutputIsReal:
         assert energy == pytest.approx(result['vqe_energy_hartree'], abs=1e-6)
 
 
+class TestParamCountConsistencyCheck:
+    """BUG FIX: both ansatz paths used to `assert n_params == ...` to
+    catch a circuit_to_energy_fn/ansatz-construction desync -- assert
+    is stripped entirely under `python -O`, silently removing the
+    check. Now `raise ValueError`. This desync can't happen through the
+    normal public API (that's the whole point of the check), so it's
+    forced here via monkeypatching circuit_to_energy_fn's return value
+    directly -- the only way to actually exercise the branch."""
+
+    def test_hardware_efficient_raises_on_param_count_mismatch(self, monkeypatch):
+        import dashboard_core.vqe as vqe_module
+        real_circuit_to_energy_fn = vqe_module.de.circuit_to_energy_fn
+
+        def wrong_count(parsed, n_qubits):
+            energy_fn, n_params = real_circuit_to_energy_fn(parsed, n_qubits)
+            return energy_fn, n_params + 1  # deliberately wrong
+
+        monkeypatch.setattr(vqe_module.de, "circuit_to_energy_fn", wrong_count)
+        with pytest.raises(ValueError, match="circuit_to_energy_fn found"):
+            run_vqe(H2_SYMBOLS, H2_GEOMETRY, charge=0, ansatz_type="hardware_efficient",
+                    n_layers=1, maxiter=1)
+
+    def test_uccsd_raises_on_param_count_mismatch(self, monkeypatch):
+        import dashboard_core.vqe as vqe_module
+        real_circuit_to_energy_fn = vqe_module.de.circuit_to_energy_fn
+
+        def wrong_count(parsed, n_qubits):
+            energy_fn, n_params = real_circuit_to_energy_fn(parsed, n_qubits)
+            return energy_fn, n_params + 1  # deliberately wrong
+
+        monkeypatch.setattr(vqe_module.de, "circuit_to_energy_fn", wrong_count)
+        with pytest.raises(ValueError, match="circuit_to_energy_fn found"):
+            run_vqe(H2_SYMBOLS, H2_GEOMETRY, charge=0, ansatz_type="uccsd", maxiter=1)
+
+
 def build_h2_pauli_terms():
     from dashboard_core.hamiltonians import build_molecular_hamiltonian
     return build_molecular_hamiltonian(H2_SYMBOLS, H2_GEOMETRY, charge=0)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -284,6 +284,39 @@ def test_kernel_unreachable_gives_actionable_error_not_a_traceback():
         mcp_adapter.KERNEL_URL = original_url
 
 
+def test_kernel_timeout_gives_actionable_error_not_a_traceback(monkeypatch):
+    class _TimeoutClient:
+        async def request(self, method, path, **kwargs):
+            raise httpx.TimeoutException("simulated timeout")
+
+    monkeypatch.setattr(mcp_adapter, "_get_client", lambda: _TimeoutClient())
+    result = run(mcp_adapter.dense_evolution_health())
+    assert result.startswith("Error:")
+    assert "timed out" in result
+
+
+def test_kernel_error_response_with_non_json_body_falls_back_to_raw_text(monkeypatch):
+    # _request's status_code>=400 branch tries resp.json().get("detail", ...)
+    # first and falls back to resp.text if the body isn't valid JSON (e.g. a
+    # raw HTML 502 from a proxy in front of the kernel, not the kernel's own
+    # structured FastAPI error response).
+    class _FakeResponse:
+        status_code = 502
+        text = "<html>Bad Gateway</html>"
+
+        def json(self):
+            raise ValueError("not valid json")
+
+    class _ErrorClient:
+        async def request(self, method, path, **kwargs):
+            return _FakeResponse()
+
+    monkeypatch.setattr(mcp_adapter, "_get_client", lambda: _ErrorClient())
+    result = run(mcp_adapter.dense_evolution_health())
+    assert result.startswith("Error:")
+    assert "<html>Bad Gateway</html>" in result
+
+
 def test_wormhole_select_instance_finds_the_known_seed_61():
     data = json.loads(run(mcp_adapter.dense_evolution_wormhole_select_instance(
         mcp_adapter.WormholeSelectInstanceInput(


### PR DESCRIPTION
## Summary
Codecov flagged 79.07% patch coverage on #26 (9 missing lines across 3 files). Investigated each -- all 3 were real, previously-untested branches, tests-only fix, no functional code changes:

- **`mcp_server/server.py`**: the client-caching diff re-indented `_request`'s whole `try/except` block (removing `async with`), which caused codecov to attribute two pre-existing untested branches to the new patch -- `httpx.TimeoutException` handling and the malformed-JSON error-detail fallback (`resp.json()` raising, falling back to `resp.text`). Both now covered.
- **`dashboard_core/vector_healing.py`**: the new `except ImportError` branch itself was never actually triggered -- the existing test only simulated the *consequence* (monkeypatching module attributes after a successful real import). Added a test that forces the real import failure via the standard `sys.modules = None` trick, verifying the guard actually works end to end.
- **`dashboard_core/vqe.py`**: the two `raise ValueError` param-count-mismatch branches can't be triggered through the normal public API (that's the point of the check) -- forced via monkeypatching `circuit_to_energy_fn`'s return value to a deliberately wrong count.

## Test plan
- [x] 7 new tests, all pass.
- [x] `dashboard_core/vector_healing.py`: 100% coverage (was 87.5%).
- [x] `dashboard_core/vqe.py`: the 2 patch-relevant lines covered (91-95/138/238 remain uncovered but are pre-existing, unrelated to #26's diff).
- [x] `mcp_server/server.py`: the 2 patch-relevant lines covered (remaining gaps are pre-existing error branches unrelated to #26's diff).
- [x] Combined run of all 3 affected test files: 49 passed.