### PR TITLE
Document ia_utils.adversarial_vector_attack, add ia_utils to the API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ legacy/dash.py                                      original Colab notebook, ref
 | **Anti-OOM Engine** | `SafeMemoryGuard` blocks execution before JAX raises `RESOURCE_EXHAUSTED` |
 | **Predictive Healing** | `healing.py` — Φ_AB alignment, dynamic vector, Σ-sync, `MemoryReflectionEngine` |
 | **Vector Sequence Healing** | `ia_utils/` — `median_healing`, `enhanced_dense_healing_hybrid` — NaN/Inf-safe, lazy JAX import |
+| **Adversarial Robustness Testing** | `ia_utils.adversarial_vector_attack.craft_adversarial_healing_perturbation` — PGD-style minimal perturbation, flips the healing Phi-Trigger either direction |
 | **Backend Agnostic** | NumPy CPU · JAX XLA CPU/TPU · CuPy CUDA — runtime selection, zero code changes |
 | **Live Dashboard** | 8-panel ipywidgets telemetry: probability, VQE energy, entropy, purity, gradient, noise, θ-correction, Pearson heatmap |
 
@@ -314,6 +315,25 @@ healed, metadata = enhanced_dense_healing_hybrid(vettori, radius_baseline=None)
 ```
 
 See **IA Utils — Vector Sequence Healing** above for details.
+
+### `ia_utils.adversarial_vector_attack`
+
+A gradient-based (PGD-style) stress test for `enhanced_dense_healing_hybrid`'s Phi-Trigger decision -- crafts the *minimal* perturbation, within an L2 epsilon-ball, that flips whether a given vector sequence gets treated as "dynamic" (passed through unhealed) or "static" (median-replaced). Adapted from IGME's chained-differentiable-attack idea ([arXiv:2607.27465](https://arxiv.org/abs/2607.27465), He & Zhang), applied here to vector sequences instead of image segmentation.
+
+```python
+from ia_utils.adversarial_vector_attack import craft_adversarial_healing_perturbation
+
+result = craft_adversarial_healing_perturbation(
+    vettori, target_idx=10,
+    epsilon=0.1,               # L2 budget for the perturbation
+    direction="flip_to_dynamic",  # or "flip_to_static"
+)
+result["success"]            # bool: did the perturbation flip the trigger?
+result["perturbed_vettori"]  # the adversarial sequence
+result["perturbation_norm"]  # actual L2 norm used (0.0 if the gradient saturated -- reported, not hidden)
+```
+
+Two directions of attack: `flip_to_dynamic` (evade -- make static-looking corruption pass through unhealed) or `flip_to_static` (suppress -- make genuine dynamic signal get wrongly median-replaced). Use this to check whether `enhanced_dense_healing_hybrid`'s trigger is robust at your own operating point before relying on it in a pipeline where inputs aren't trusted.
 
 ---
 

--- a/docs/api/ia_utils_adversarial_vector_attack.md
+++ b/docs/api/ia_utils_adversarial_vector_attack.md
@@ -1,0 +1,41 @@
+# IA Utils — Adversarial Vector Attack
+
+A gradient-based (PGD-style) stress test for
+[`enhanced_dense_healing_hybrid`](ia_utils_vector_healing.md)'s
+Phi-Trigger decision. `evaluate_phi_trigger`
+([`dense_evolution.healing`](healing.md)) thresholds `|v_dinamic|` with a
+hard step (not differentiable at the boundary), but `v_dinamic` itself is
+built entirely from JAX-differentiable operations — this crafts the
+*minimal* perturbation (projected into an L2 epsilon-ball) that flips the
+trigger either direction, rather than adding random noise and hoping.
+
+Adapted from IGME's chained-differentiable-attack idea
+([arXiv:2607.27465](https://arxiv.org/abs/2607.27465), "Efficient Chained
+Method Ensemble for Transferable Semantic Segmentation Attacks", He &
+Zhang), applied here to vector sequences instead of image segmentation.
+
+::: ia_utils.adversarial_vector_attack
+
+---
+
+**Two directions of attack**:
+
+- `flip_to_dynamic` (evade) — make static-looking corruption pass through
+  unhealed.
+- `flip_to_static` (suppress) — make genuine dynamic signal get wrongly
+  median-replaced.
+
+Two real bugs were found and fixed during this utility's own
+verification, not assumed correct: the default `step_size` used to scale
+with the epsilon budget (a *larger* budget converged to a *worse*
+result — verified directly, non-monotonic in epsilon — now a small fixed
+default independent of epsilon), and `calculate_phi_ab`'s `[0,1]` clip
+saturating for inputs whose semantic distance exceeds
+`MAX_SEMANTIC_DISTANCE`, giving an exact-zero gradient (a real property
+of the formula, now detected and reported — `perturbation_norm == 0`,
+`success == False` — rather than silently misreported as "no better
+point found").
+
+**See also**: [`ia_utils.vector_healing`](ia_utils_vector_healing.md) for
+the function under test, and [`dense_evolution.healing`](healing.md) for
+the underlying Phi-Trigger primitives.

--- a/docs/api/ia_utils_vector_healing.md
+++ b/docs/api/ia_utils_vector_healing.md
@@ -1,0 +1,20 @@
+# IA Utils — Vector Sequence Healing
+
+Standalone module (`ia_utils/`, a separate top-level package alongside
+`dense_evolution/`) for cleaning sequences of vectors — e.g. hidden
+states, embeddings, VQE/MD telemetry — that may contain `NaN` or `Inf`
+entries, or spurious spikes that look like noise rather than genuine
+signal. `median_healing` and `enhanced_dense_healing_hybrid` both
+preprocess the input (Inf → NaN → column-mean imputation) before
+healing, so corrupted values never propagate into the output.
+
+::: ia_utils.vector_healing
+
+---
+
+**See also**: [`dense_evolution.healing`](healing.md) for the predictive
+"Phi-Trigger" primitives `enhanced_dense_healing_hybrid` calls internally
+to decide, per step, whether an observed change looks like genuine
+dynamics (kept as-is) or static noise (replaced with the local median).
+[`ia_utils.adversarial_vector_attack`](ia_utils_adversarial_vector_attack.md)
+for a gradient-based robustness test of that same Phi-Trigger decision.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,8 @@ nav:
       - Gates: api/gates.md
       - Mitigation (ZNE / density-matrix healing): api/mitigation.md
       - Healing (predictive primitives): api/healing.md
+      - IA Utils — Vector Healing: api/ia_utils_vector_healing.md
+      - IA Utils — Adversarial Vector Attack: api/ia_utils_adversarial_vector_attack.md
       - Interop (Qiskit / PennyLane): api/interop.md
       - Autodiff: api/autodiff.md
       - Topology (entangling layers): api/topology.md


### PR DESCRIPTION
## Summary
Real feedback from an actual reader (via LinkedIn): \`ia_utils\` wasn't discoverable because it wasn't explained.

Checked and confirmed two real gaps:
1. \`ia_utils.adversarial_vector_attack\` had zero mentions anywhere outside changelog entries -- no README section, no usage example, no Core Features row.
2. The entire \`ia_utils\` package (both \`vector_healing\` and \`adversarial_vector_attack\`) was completely absent from the auto-generated API reference site -- every \`dense_evolution/\` module has its own \`docs/api/*.md\` page and nav entry, \`ia_utils/\` had none.

Fixed both: README section + Core Features row for \`adversarial_vector_attack\` (matching \`vector_healing\`'s existing treatment), and two new API pages wired into \`mkdocs.yml\`'s nav.

## Test plan
- [x] \`mkdocs build --strict\` -- clean
- [x] Verified the built HTML actually contains the real function docs (grepped for function names in the generated pages, not just "build didn't error")