### PR TITLE
Document all 14 dashboard_core modules, update homepage diagram

### DIFF
--- a/dashboard_core/vector_healing.py
+++ b/dashboard_core/vector_healing.py
@@ -47,7 +47,7 @@ class VectorHealingResult:
     reconstruction_error: float   # mean per-step norm of (healed - sanitized) vectors
 
 
-def run_vector_healing(vectors, radius_baseline: Optional[int] = None) -> VectorHealingResult:
+def run_vector_healing(vectors: np.ndarray, radius_baseline: Optional[int] = None) -> VectorHealingResult:
     """Heal a noisy (n_steps, dim) vector sequence: per step, a Phi-Trigger
     (dense_evolution.healing) decides whether the change from a local
     baseline looks like genuine dynamics (kept as-is) or static noise

--- a/docs/api/dashboard_core_circuit_builder_component.md
+++ b/docs/api/dashboard_core_circuit_builder_component.md
@@ -1,0 +1,12 @@
+# Dashboard Core — Circuit Builder Component
+
+Graphical (drag-and-drop) circuit builder — the fourth pillar of IBM
+Quantum Composer's layout (graphical editor + code editor + statevector
+view + results) reproduced natively for this project's own dashboard.
+
+::: dashboard_core.circuit_builder_component
+
+---
+
+**See also**: [`dashboard_core.graphical_builder`](dashboard_core_graphical_builder.md),
+which converts this component's output into runnable gate tuples.

--- a/docs/api/dashboard_core_circuit_diagram.md
+++ b/docs/api/dashboard_core_circuit_diagram.md
@@ -1,0 +1,13 @@
+# Dashboard Core — Circuit Diagram
+
+Native circuit-diagram renderer — pure matplotlib, never a Qiskit
+`QuantumCircuit`. Replaces `qiskit.circuit.draw(output='mpl')` for
+exactly the gate set `dense_evolution` actually supports, so Composer
+never depends on Qiskit just to draw a picture.
+
+::: dashboard_core.circuit_diagram
+
+---
+
+**See also**: [`dashboard_core.visuals`](dashboard_core_visuals.md), which
+aggregates this with [`state_visuals`](dashboard_core_state_visuals.md).

--- a/docs/api/dashboard_core_engine.md
+++ b/docs/api/dashboard_core_engine.md
@@ -1,0 +1,8 @@
+# Dashboard Core — Engine
+
+The real simulation engine for the dashboard: runs an actual
+[`DenseSVSimulator`](simulator.md) circuit, not a mocked/placeholder
+result, and is what Composer's UI and the MCP server's simulation tools
+both call underneath.
+
+::: dashboard_core.engine

--- a/docs/api/dashboard_core_graphical_builder.md
+++ b/docs/api/dashboard_core_graphical_builder.md
@@ -1,0 +1,13 @@
+# Dashboard Core — Graphical Builder
+
+Turns the ops list produced by the graphical (drag-and-drop) circuit
+builder component into `dense_evolution`'s own `(name, *qubits[, param])`
+gate-tuple format, so a circuit built visually runs through the exact
+same execution path as one written in OpenQASM.
+
+::: dashboard_core.graphical_builder
+
+---
+
+**See also**: [`dashboard_core.circuit_builder_component`](dashboard_core_circuit_builder_component.md),
+the UI component this module's output feeds.

--- a/docs/api/dashboard_core_hamiltonians.md
+++ b/docs/api/dashboard_core_hamiltonians.md
@@ -1,0 +1,16 @@
+# Dashboard Core — Hamiltonians
+
+Real molecular Hamiltonians, built on demand from actual atomic geometry
+via PennyLane's `qchem` module (Hartree-Fock + Jordan-Wigner
+fermion-to-qubit mapping) — no fabricated or hand-picked coefficients.
+Backs Composer's molecular-energy panel, [`dashboard_core.vqe`](dashboard_core_vqe.md),
+and [`dashboard_core.qmmm`](dashboard_core_qmmm.md).
+
+::: dashboard_core.hamiltonians
+
+---
+
+**See also**: [`dashboard_core.vqe`](dashboard_core_vqe.md) for the
+ansatz circuits optimized against these Hamiltonians, and
+[`dashboard_core.qmmm`](dashboard_core_qmmm.md) for the Hellmann-Feynman
+forces derived from them.

--- a/docs/api/dashboard_core_mitigation.md
+++ b/docs/api/dashboard_core_mitigation.md
@@ -1,0 +1,17 @@
+# Dashboard Core — Mitigation (Composer's ZNE panel)
+
+Real Zero-Noise Extrapolation (ZNE) error mitigation, wired to the same
+engine and real noise channels ([`dense_evolution.registry.NoiseModel`](registry.md))
+the rest of Composer uses — a thin dashboard-facing layer over
+[`dense_evolution.mitigation`](mitigation.md), not a separate
+reimplementation.
+
+::: dashboard_core.mitigation
+
+---
+
+**Not to be confused with** [`dense_evolution.mitigation`](mitigation.md)
+(same name, different module) — that one is the actual ZNE
+implementation (`richardson_extrapolate`, `zne_density_matrix`,
+`jsd_predictive_zne_density_matrix`, ...); this one is the dashboard's
+request/response wrapper around it.

--- a/docs/api/dashboard_core_qasm_library.md
+++ b/docs/api/dashboard_core_qasm_library.md
@@ -1,0 +1,12 @@
+# Dashboard Core — QASM Library
+
+Real, standard OpenQASM 2.0 circuits offered as Composer presets —
+textbook examples (Bell pair, GHZ, W-state) and `dense_evolution`'s own
+gate library exercised end to end, not synthetic placeholder text.
+
+::: dashboard_core.qasm_library
+
+---
+
+**See also**: [`dense_evolution.parser.QASMParser`](parser.md), which
+these presets are meant to be fed into.

--- a/docs/api/dashboard_core_qmmm.md
+++ b/docs/api/dashboard_core_qmmm.md
@@ -1,0 +1,14 @@
+# Dashboard Core — QM/MM
+
+Real Hellmann-Feynman nuclear forces and a real Velocity-Verlet MD step
+for this project's molecule catalog — no fabricated geometry, no
+placeholder forces. Backs Composer's QM/MM force and MD-trajectory
+panels.
+
+::: dashboard_core.qmmm
+
+---
+
+**See also**: [`dashboard_core.hamiltonians`](dashboard_core_hamiltonians.md)
+for `MOLECULE_CATALOG` and `build_molecular_hamiltonian`, which this
+module's forces are derived from.

--- a/docs/api/dashboard_core_state_visuals.md
+++ b/docs/api/dashboard_core_state_visuals.md
@@ -1,0 +1,11 @@
+# Dashboard Core — State Visuals
+
+Native statevector visualizations — histogram, Q-sphere, per-qubit Bloch
+spheres — pure matplotlib/numpy, no Qiskit anywhere.
+
+::: dashboard_core.state_visuals
+
+---
+
+**See also**: [`dashboard_core.visuals`](dashboard_core_visuals.md), which
+aggregates this with [`circuit_diagram`](dashboard_core_circuit_diagram.md).

--- a/docs/api/dashboard_core_system_limits.md
+++ b/docs/api/dashboard_core_system_limits.md
@@ -1,0 +1,8 @@
+# Dashboard Core — System Limits
+
+Real, per-machine qubit limits — detects actual available RAM instead of
+a number picked to fit whatever machine this was developed on, so
+Composer refuses an allocation that would actually exhaust memory rather
+than crashing partway through.
+
+::: dashboard_core.system_limits

--- a/docs/api/dashboard_core_vector_healing.md
+++ b/docs/api/dashboard_core_vector_healing.md
@@ -1,0 +1,18 @@
+# Dashboard Core — Vector Healing (Composer's healing panel)
+
+Real predictive-healing pass over a noisy vector sequence (VQE/MD
+telemetry, quantum state trajectories, or any other `(n_steps, dim)`
+array) — a thin dashboard-facing wrapper around
+[`ia_utils.vector_healing.enhanced_dense_healing_hybrid`](ia_utils_vector_healing.md),
+lazily imported so a missing/stripped `ia_utils` install fails with a
+clear error at call time rather than breaking `dashboard_core` import
+for everyone.
+
+::: dashboard_core.vector_healing
+
+---
+
+**Not to be confused with** [`ia_utils.vector_healing`](ia_utils_vector_healing.md)
+(same name, different module) — that one has the real
+`median_healing`/`enhanced_dense_healing_hybrid` implementation; this
+one is the dashboard's request/response wrapper around it.

--- a/docs/api/dashboard_core_visuals.md
+++ b/docs/api/dashboard_core_visuals.md
@@ -1,0 +1,9 @@
+# Dashboard Core — Visuals
+
+Every visualization here is native (plain matplotlib/numpy) — no Qiskit
+anywhere in this module. Aggregates
+[`circuit_diagram`](dashboard_core_circuit_diagram.md) and
+[`state_visuals`](dashboard_core_state_visuals.md) into the set Composer
+actually renders.
+
+::: dashboard_core.visuals

--- a/docs/api/dashboard_core_vqe.md
+++ b/docs/api/dashboard_core_vqe.md
@@ -1,0 +1,15 @@
+# Dashboard Core — VQE
+
+Real, dynamically-generated VQE ansatz circuits for molecular
+Hamiltonians — no fixed/hardcoded rotation angles. Every circuit this
+module returns is built from the actual molecule's own qubit count and
+Hamiltonian, run through [`dense_evolution.autodiff`](autodiff.md)'s
+gradient engine.
+
+::: dashboard_core.vqe
+
+---
+
+**See also**: [`dashboard_core.hamiltonians`](dashboard_core_hamiltonians.md)
+for where the molecular Hamiltonian this ansatz optimizes against comes
+from.

--- a/docs/api/dashboard_core_wormhole.md
+++ b/docs/api/dashboard_core_wormhole.md
@@ -1,0 +1,20 @@
+# Dashboard Core — Wormhole (Traversable-Wormhole Teleportation)
+
+Traversable-wormhole-inspired quantum teleportation (Gao-Jafferis-Wall
+theory), via a binary sparse Sachdev-Ye-Kitaev (SYK) model — the real
+protocol backing Composer's "traversable-wormhole-inspired teleportation"
+panel and the MCP server's wormhole tools. Built on
+[`dense_evolution.fermions`](fermions.md) (`majorana_pauli_terms`) and
+[`dense_evolution.entropy`](entropy.md) (`mutual_information`), the
+protocol's actual readout quantity.
+
+::: dashboard_core.wormhole
+
+---
+
+**Research log**: [Dense-Evolution-Discovery](https://github.com/tatopenn-cell/Dense-Evolution-Discovery)
+runs this implementation through 20+ real, verified experiments (parameter
+scans, generality checks, noise robustness, honest negative results) —
+see its own [docs site](https://tatopenn-cell.github.io/Dense-Evolution-Discovery/wormhole_syk_teleportation/)
+for the full write-up. This page documents the shipped implementation;
+that repo documents what's been discovered by running it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,29 @@ Using this in academic work? See [CITATION.cff](https://github.com/tatopenn-cell
 - **Interop** with [Qiskit and PennyLane](api/interop.md), and [autodiff](api/autodiff.md)
   through `circuit_to_energy_fn` for gradient-based VQE.
 
+## Dashboard Core — Composer's real compute layer
+
+`dashboard_core` (a separate top-level package, `pip install`ed alongside `dense_evolution`
+and `ia_utils`) is what Composer and the MCP server both actually call underneath — real
+physics and real rendering, not mocked results glued to a UI:
+
+**Science**: [Wormhole (SYK teleportation)](api/dashboard_core_wormhole.md) ·
+[VQE](api/dashboard_core_vqe.md) · [Hamiltonians](api/dashboard_core_hamiltonians.md) ·
+[QM/MM](api/dashboard_core_qmmm.md)
+
+**Mitigation & healing**: [Mitigation (ZNE panel)](api/dashboard_core_mitigation.md) ·
+[Vector Healing (healing panel)](api/dashboard_core_vector_healing.md)
+
+**Infrastructure**: [Engine](api/dashboard_core_engine.md) ·
+[System Limits](api/dashboard_core_system_limits.md) ·
+[QASM Library](api/dashboard_core_qasm_library.md)
+
+**Visualization & UI**: [Circuit Diagram](api/dashboard_core_circuit_diagram.md) ·
+[State Visuals](api/dashboard_core_state_visuals.md) ·
+[Visuals](api/dashboard_core_visuals.md) ·
+[Graphical Builder](api/dashboard_core_graphical_builder.md) ·
+[Circuit Builder Component](api/dashboard_core_circuit_builder_component.md)
+
 ## Beyond the library: Composer and MCP
 
 Two ways to drive the simulator without writing Python against it directly, both backed by
@@ -50,7 +73,8 @@ Hartree-Fock, no mocked physics):
 
 - **[Composer](composer.md)** — a browser UI: build a circuit graphically or in OpenQASM,
   compute molecular ground-state energies, run VQE, get QM/MM forces and MD trajectories,
-  apply ZNE mitigation, and run the traversable-wormhole-inspired teleportation protocol.
+  apply ZNE mitigation, and run the [traversable-wormhole-inspired teleportation
+  protocol](api/dashboard_core_wormhole.md).
 - **[MCP Server](mcp.md)** — the same kernel, driven by an MCP-aware agent (Claude Code,
   Claude Desktop, ...) instead of a browser: 21 tools covering everything Composer does,
   plus a batch energy scan, a batch wormhole sweep, and healing a noisy vector sequence
@@ -89,6 +113,23 @@ flowchart LR
         advattack["adversarial_vector_attack<br/>(craft_adversarial_healing_perturbation)"]
     end
 
+    subgraph dashcore["dashboard_core (separate top-level package, Composer's backend)"]
+        dc_wormhole["wormhole"]
+        dc_vqe["vqe"]
+        dc_hamiltonians["hamiltonians"]
+        dc_qmmm["qmmm"]
+        dc_mitigation["mitigation<br/>(ZNE panel)"]
+        dc_vector_healing["vector_healing<br/>(healing panel)"]
+        dc_engine["engine"]
+        dc_qasm_library["qasm_library"]
+        dc_system_limits["system_limits"]
+        dc_circuit_diagram["circuit_diagram"]
+        dc_state_visuals["state_visuals"]
+        dc_visuals["visuals"]
+        dc_graphical_builder["graphical_builder"]
+        dc_circuit_builder_component["circuit_builder_component"]
+    end
+
     gates --> registry
     simulator --> registry
     simulator --> gates
@@ -107,7 +148,22 @@ flowchart LR
     mitigation --> healing
     vhealing -.->|lazy import| healing
     advattack --> healing
+
+    dc_vqe --> dc_hamiltonians
+    dc_qmmm --> dc_hamiltonians
+    dc_visuals --> dc_circuit_diagram
+    dc_visuals --> dc_state_visuals
+    dc_circuit_builder_component --> dc_graphical_builder
+    dc_vector_healing -.->|lazy import| vhealing
 ```
+
+`dashboard_core.engine`, `dashboard_core.hamiltonians`, `dashboard_core.mitigation`,
+`dashboard_core.qasm_library`, `dashboard_core.system_limits`, and `dashboard_core.wormhole`
+each depend only on `dense_evolution`'s top-level public API (`import dense_evolution as de`,
+or `from dense_evolution import mutual_information, majorana_pauli_terms, trotter_evolve_ops`
+for `wormhole`), not on a specific submodule shown above, so they have no internal edges
+drawn here beyond that. `circuit_diagram`, `state_visuals`, and `graphical_builder` have no
+internal-repo dependencies at all (NumPy / Matplotlib only).
 
 ## Where to start
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,20 @@ nav:
       - Fermions (Majorana Jordan-Wigner): api/fermions.md
       - Entropy (partial trace, mutual information): api/entropy.md
       - Trotter (Hamiltonian evolution as gates): api/trotter.md
+      - "Dashboard Core — Wormhole (SYK teleportation)": api/dashboard_core_wormhole.md
+      - "Dashboard Core — VQE": api/dashboard_core_vqe.md
+      - "Dashboard Core — Hamiltonians": api/dashboard_core_hamiltonians.md
+      - "Dashboard Core — QM/MM": api/dashboard_core_qmmm.md
+      - "Dashboard Core — Mitigation (ZNE panel)": api/dashboard_core_mitigation.md
+      - "Dashboard Core — Vector Healing (healing panel)": api/dashboard_core_vector_healing.md
+      - "Dashboard Core — Engine": api/dashboard_core_engine.md
+      - "Dashboard Core — QASM Library": api/dashboard_core_qasm_library.md
+      - "Dashboard Core — System Limits": api/dashboard_core_system_limits.md
+      - "Dashboard Core — Circuit Diagram": api/dashboard_core_circuit_diagram.md
+      - "Dashboard Core — State Visuals": api/dashboard_core_state_visuals.md
+      - "Dashboard Core — Visuals": api/dashboard_core_visuals.md
+      - "Dashboard Core — Graphical Builder": api/dashboard_core_graphical_builder.md
+      - "Dashboard Core — Circuit Builder Component": api/dashboard_core_circuit_builder_component.md
   - Changelog: changelog.md
   - Contributing: contributing.md
   - License: LICENSE.md


### PR DESCRIPTION
## Summary
- `dashboard_core` is part of the pip-installable package (`pyproject.toml`'s `packages` list) but had zero API documentation, despite backing every Composer panel including the wormhole teleportation protocol.
- Adds an mkdocstrings page per module (14 total): wormhole, vqe, hamiltonians, qmmm, mitigation, vector_healing, engine, qasm_library, system_limits, circuit_diagram, state_visuals, visuals, graphical_builder, circuit_builder_component.
- Wires all 14 into `mkdocs.yml` nav.
- Adds a "Dashboard Core" section and a `dashboard_core` subgraph (real traced import edges) to the homepage's module-dependency diagram.
- Fixes a missing type annotation on `run_vector_healing`'s `vectors` parameter, surfaced by `mkdocs build --strict`.

## Test plan
- [x] `mkdocs build --strict` clean
- [x] `python -m py_compile dashboard_core/vector_healing.py`
- [x] `pytest tests/test_dashboard_vector_healing.py` — 4 passed