### PR TITLE
Warn (not block) on macOS before touching the Qiskit interop bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ git clone https://github.com/tatopenn-cell/Dense-Evolution.git
 cd Dense-Evolution && pip install -e .[full]
 ```
 
+> **macOS note on `dense-evolution[qiskit]`**: Qiskit's own `QuantumCircuit.__init__` is known to segfault the whole process on macOS/arm64 (see v8.1.43 below for the full reproduction — an upstream Qiskit bug, not something Dense-Evolution can fix from its side). `dense_evolution/interop.py` now warns (`RuntimeWarning`, once per process) the first time you touch the Qiskit bridge on `sys.platform == 'darwin'`, but it does not block — some Qiskit/macOS combinations may work fine. If you hit a crash, `pip install dense-evolution[pennylane]` gives the same circuit-interop functionality without constructing any Qiskit object.
+
 **Google Colab (3 lines):**
 
 ```python

--- a/dense_evolution/interop.py
+++ b/dense_evolution/interop.py
@@ -1,3 +1,5 @@
+import sys
+import warnings
 from typing import Optional, Tuple
 import numpy as np
 
@@ -16,12 +18,26 @@ try:
 except ImportError:
     HAS_PENNYLANE = False
 
+_macos_qiskit_warning_shown = False
+
 
 def _require_qiskit():
     if not HAS_QISKIT:
         raise ImportError(
             "Qiskit interop requires the 'qiskit' package. "
             "Install it with: pip install dense-evolution[qiskit]")
+    global _macos_qiskit_warning_shown
+    if sys.platform == 'darwin' and not _macos_qiskit_warning_shown:
+        _macos_qiskit_warning_shown = True
+        warnings.warn(
+            "Qiskit's own QuantumCircuit.__init__ is known to segfault the "
+            "whole process on macOS/arm64 (reproduced on GitHub Actions "
+            "arm64 runners, Python 3.10-3.12) -- this is an upstream Qiskit "
+            "bug, not something dense-evolution can fix from its side. If "
+            "you hit a crash, consider the PennyLane bridge instead "
+            "(pip install dense-evolution[pennylane]), which does not "
+            "construct Qiskit objects and has no known issue of this kind.",
+            RuntimeWarning, stacklevel=2)
 
 
 def _require_pennylane():

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -6,6 +6,7 @@ class so this file stays green in environments without qiskit/pennylane
 installed, on top of CI installing both explicitly.
 """
 import sys
+import warnings
 
 import numpy as np
 import pytest
@@ -44,6 +45,42 @@ class TestImportSafety:
         monkeypatch.setattr(interop, 'HAS_PENNYLANE', False)
         with pytest.raises(ImportError, match='pennylane'):
             from_pennylane(None)
+
+
+# ─────────────────────────────────────────────────────────────
+# macOS Qiskit segfault warning
+#
+# The warning logic is gated purely on HAS_QISKIT + sys.platform, both of
+# which are monkeypatched here — doesn't require qiskit to actually be
+# importable, so this runs the same on every platform/CI environment,
+# unlike TestQiskitInterop below.
+# ─────────────────────────────────────────────────────────────
+
+class TestMacOSQiskitWarning:
+
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self, monkeypatch):
+        monkeypatch.setattr(interop, 'HAS_QISKIT', True)
+        monkeypatch.setattr(interop, '_macos_qiskit_warning_shown', False)
+
+    def test_warns_on_darwin(self, monkeypatch):
+        monkeypatch.setattr(sys, 'platform', 'darwin')
+        with pytest.warns(RuntimeWarning, match='segfault'):
+            interop._require_qiskit()
+
+    def test_no_warning_on_non_darwin(self, monkeypatch):
+        monkeypatch.setattr(sys, 'platform', 'linux')
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            interop._require_qiskit()  # would raise if it warned
+
+    def test_warns_only_once_per_process(self, monkeypatch):
+        monkeypatch.setattr(sys, 'platform', 'darwin')
+        with pytest.warns(RuntimeWarning, match='segfault'):
+            interop._require_qiskit()
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            interop._require_qiskit()  # second call: flag already set, no warning
 
 
 # ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

`qiskit.circuit.QuantumCircuit.__init__` has a known upstream Qiskit bug that segfaults the whole process on macOS/arm64 (already documented in this README around v8.1.43). A segfault can't be caught with try/except, so the only real mitigation available to us is to warn *before* the risky call rather than try to block it — not every Mac/Qiskit-version combination necessarily crashes, so a hard block was deliberately rejected.

`_require_qiskit()` in `dense_evolution/interop.py` now emits a `RuntimeWarning` (once per process, via a module-level flag) when `sys.platform == 'darwin'` and Qiskit is actually available, right before the caller touches a real Qiskit `QuantumCircuit` object.

## Testing

- [x] Added `TestMacOSQiskitWarning` (3 tests) to `tests/test_interop.py` — monkeypatches platform/`HAS_QISKIT` so they run without needing real macOS or even real Qiskit installed
- [x] `pytest tests/` passes locally
- [x] Updated `README.md` with a short note near the `pip install dense-evolution[qiskit]` instructions pointing at this risk and suggesting the PennyLane bridge as an alternative

No version bump — per project convention, `pyproject.toml`'s version isn't bumped until an actual PyPI release is being cut, and this isn't one.

## Notes for the reviewer

Base is `origin/main` at `813051a`. Warning is process-global (fires once), not per-call, to avoid spamming stderr in loops that repeatedly build circuits.
