### PR TITLE
Update CITATION.cff DOI for v8.1.56

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,12 +12,12 @@ authors:
 repository-code: "https://github.com/tatopenn-cell/Dense-Evolution"
 url: "https://github.com/tatopenn-cell/Dense-Evolution"
 license: "BUSL-1.1"
-version: "8.1.54"
-doi: "10.5281/zenodo.21855644"
+version: "8.1.56"
+doi: "10.5281/zenodo.21864809"
 identifiers:
   - type: doi
     value: "10.5281/zenodo.21855643"
     description: "The concept DOI for all versions of this software."
   - type: doi
-    value: "10.5281/zenodo.21855644"
-    description: "The version-specific DOI for v8.1.54."
+    value: "10.5281/zenodo.21864809"
+    description: "The version-specific DOI for v8.1.56."


### PR DESCRIPTION
## What & why

`CITATION.cff` was stale at `version: "8.1.54"` / DOI `10.5281/zenodo.21855644` even though v8.1.55 and v8.1.56 have since shipped. The v8.1.56 GitHub Release (already published) triggered Zenodo's GitHub integration to mint a new version-specific record. This bumps `CITATION.cff` to match.

- Concept DOI (unchanged, always resolves to latest): `10.5281/zenodo.21855643`
- New version DOI for v8.1.56: `10.5281/zenodo.21864809`
- Verified against Zenodo's own API record before writing anything: `id: 21864809`, `metadata.version: v8.1.56`, `custom["code:codeRepository"]: https://github.com/tatopenn-cell/Dense-Evolution`, `related_identifiers: [.../tree/v8.1.56]` — resolved via the concept DOI redirect (`https://doi.org/10.5281/zenodo.21855643` → `zenodo.org/records/21864809`), not the dashboard UI.

Scope note: only `CITATION.cff` is touched here. `README.md`'s "Cite This" section and `docs/index.md` still reference the v8.1.54 version DOI in prose — left alone to avoid colliding with other in-flight README work on a separate branch; can be a fast follow-up.

## Testing

- [x] No code changes, metadata only.
- [ ] N/A — not user-visible in changelog.

## Notes for the reviewer

pyproject.toml version was already correctly at 8.1.56 and is untouched.