### PR TITLE
Update README Cite This section to v8.1.56 DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1115,7 +1115,7 @@ If Dense-Evolution is useful in academic work, please cite it via the metadata i
 Archived on [Zenodo](https://zenodo.org/):
 
 - **Concept DOI** (always resolves to the latest version): [10.5281/zenodo.21855643](https://doi.org/10.5281/zenodo.21855643)
-- **This release (v8.1.54)**: [10.5281/zenodo.21855644](https://doi.org/10.5281/zenodo.21855644)
+- **This release (v8.1.56)**: [10.5281/zenodo.21864809](https://doi.org/10.5281/zenodo.21864809)
 
 ---
 


### PR DESCRIPTION
## What & why

The README's "Cite This" section (~line 1118) still said "**This release (v8.1.54)**: [10.5281/zenodo.21855644]" — stale, since the project has since shipped 8.1.55 and 8.1.56. Updated to "**This release (v8.1.56)**: [10.5281/zenodo.21864809]", the version-specific Zenodo DOI minted for the v8.1.56 GitHub Release.

Left untouched:
- The `### v8.1.54` changelog entry further up the README — that's a correct historical record, not a current-state claim.
- `docs/index.md` — checked, it only references the version-agnostic concept DOI (`10.5281/zenodo.21855643`), nothing stale there.
- The concept DOI itself, which always resolves to latest and didn't need changing.

## Testing

- [x] Docs-only change, no code/tests affected
- [ ] `pytest tests/` — not applicable
- [x] README changelog untouched intentionally (see above)

## Notes for the reviewer

Small follow-up related to #44, which bumps `CITATION.cff` itself to 8.1.56 and the same DOI (separate file, no overlap). Also open in parallel: #45, which fixes an unrelated stale "dashboard architecture" section of this same `README.md` (different section, no overlap expected).

No particular merge order is assumed between this PR, #44, and #45 — leaving that call to the reviewer.
