### PR TITLE
Docs site fixes: Hello World example, SEO title, Mermaid mobile scroll, breadcrumbs

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -1,0 +1,8 @@
+.mermaid {
+  overflow-x: auto;
+  display: block;
+}
+
+.mermaid svg {
+  max-width: none;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,24 @@ of `2ⁿ × 16 bytes`.
 
 Using this in academic work? See [CITATION.cff](https://github.com/tatopenn-cell/Dense-Evolution/blob/main/CITATION.cff) in the repository root for citation metadata. Archived on Zenodo — concept DOI [10.5281/zenodo.21855643](https://doi.org/10.5281/zenodo.21855643).
 
+## Hello world: a Bell state
+
+```python
+import dense_evolution as de
+
+sim = de.DenseSVSimulator(n_qubits=2)
+sim.run_circuit([('h', 0), ('cx', 0, 1)])
+
+print(sim.get_statevector())
+# [0.70710678+0.j 0.        +0.j 0.        +0.j 0.70710678+0.j]
+print(sim.get_probabilities())
+# [0.5 0.  0.  0.5]
+```
+
+That's the full API surface for a basic run: build a gate list, run it, read the
+statevector or probabilities back. See [Getting Started](getting-started.md) for OpenQASM
+parsing, chunked large-scale circuits, and ZNE mitigation.
+
 ## What's in here
 
 - **[`DenseSVSimulator`](api/simulator.md)** — the core dense statevector engine, JIT-fused

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: Dense-Evolution
-site_description: High-performance NISQ statevector quantum circuit simulator, JAX XLA-accelerated.
+site_name: Dense-Evolution — JAX NISQ Quantum Circuit Simulator
+site_description: Dense-Evolution is a high-performance, JAX XLA-accelerated NISQ statevector quantum circuit simulator for VQE, QML, and Zero-Noise Extrapolation workloads.
 site_url: https://tatopenn-cell.github.io/Dense-Evolution/
 repo_url: https://github.com/tatopenn-cell/Dense-Evolution
 repo_name: tatopenn-cell/Dense-Evolution
@@ -29,6 +29,7 @@ theme:
     - navigation.tabs
     - navigation.top
     - navigation.indexes
+    - navigation.path
     - search.suggest
     - search.highlight
     - content.code.copy
@@ -55,6 +56,9 @@ markdown_extensions:
       alternate_style: true
   - toc:
       permalink: true
+
+extra_css:
+  - assets/extra.css
 
 extra_javascript:
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
## Summary

Docs-site punch list fixes (mkdocs-material). One item was already resolved earlier this session (real Zenodo DOI in CITATION.cff/README, v8.1.56) and isn't part of this PR.

1. **"Edit this page" link** -- verified already correct (`edit_uri`/`repo_url` resolve properly, `main` is the real default branch). No change.
2. **Hello World example** -- added a Bell-state snippet to `docs/index.md`'s intro, run against the real library, output copy-pasted from actual execution.
3. **Generic SEO title** -- `site_name`/`site_description` in `mkdocs.yml` expanded to mention JAX/NISQ/VQE/QML/ZNE, verified via `mkdocs build --strict`.
4. **No side TOC on API pages** -- verified already correct, no bug found (mkdocstrings emits full heading hierarchy, material's TOC sidebar picks it up).
5. **Mermaid diagrams not scrollable on mobile** -- fixed with a small `docs/assets/extra.css` (`overflow-x: auto` on `.mermaid`).
6. **No breadcrumbs** -- enabled `navigation.path` under `theme.features` (supported in the installed mkdocs-material version, not Insiders-gated).

Build passes `mkdocs build --strict` cleanly.

## Test plan

- [x] `mkdocs build --strict` passes
- [x] Bell-state example verified against the real installed library, not guessed
- [x] Breadcrumb and Mermaid-scroll fixes verified in the built HTML output
