### PR TITLE
Update CITATION.cff DOI for v8.1.57

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,12 +12,12 @@ authors:
 repository-code: "https://github.com/tatopenn-cell/Dense-Evolution"
 url: "https://github.com/tatopenn-cell/Dense-Evolution"
 license: "BUSL-1.1"
-version: "8.1.56"
-doi: "10.5281/zenodo.21864809"
+version: "8.1.57"
+doi: "10.5281/zenodo.21894632"
 identifiers:
   - type: doi
     value: "10.5281/zenodo.21855643"
     description: "The concept DOI for all versions of this software."
   - type: doi
-    value: "10.5281/zenodo.21864809"
-    description: "The version-specific DOI for v8.1.56."
+    value: "10.5281/zenodo.21894632"
+    description: "The version-specific DOI for v8.1.57."

--- a/README.md
+++ b/README.md
@@ -1136,7 +1136,7 @@ If Dense-Evolution is useful in academic work, please cite it via the metadata i
 Archived on [Zenodo](https://zenodo.org/):
 
 - **Concept DOI** (always resolves to the latest version): [10.5281/zenodo.21855643](https://doi.org/10.5281/zenodo.21855643)
-- **This release (v8.1.56)**: [10.5281/zenodo.21864809](https://doi.org/10.5281/zenodo.21864809)
+- **This release (v8.1.57)**: [10.5281/zenodo.21894632](https://doi.org/10.5281/zenodo.21894632)
 
 ---
 


### PR DESCRIPTION
Zenodo archived v8.1.57 automatically after the GitHub Release; new version-specific DOI 10.5281/zenodo.21894632, verified against the concept DOI redirect and cross-checked repo owner matches tatopenn-cell/Dense-Evolution.