### PR TITLE
Add to_stim: generic STIM bridge, generalized from Steane block 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ legacy/dash.py                     original Colab notebook, reference only (not 
 | **Predictive Healing** | `healing.py` — Φ_AB alignment, dynamic vector, Σ-sync, `MemoryReflectionEngine` |
 | **Vector Sequence Healing** | `ia_utils/` — `median_healing`, `enhanced_dense_healing_hybrid` — NaN/Inf-safe, lazy JAX import |
 | **Adversarial Robustness Testing** | `ia_utils.adversarial_vector_attack.craft_adversarial_healing_perturbation` — PGD-style minimal perturbation, flips the healing Phi-Trigger either direction |
+| **STIM Bridge** | `to_stim` — Clifford-only op-list → `stim.Circuit`, for cross-validation against STIM's stabilizer simulator/decoder tooling |
 | **Backend Agnostic** | NumPy CPU · JAX XLA CPU/TPU · CuPy CUDA — runtime selection, zero code changes |
 | **Live Dashboard** | `app_dashboard.py` — Streamlit Quantum-Composer clone, 5 tabs (Graphical Builder/Circuit/Statevector/Probabilities/Q-sphere) per simulation run |
 
@@ -436,6 +437,16 @@ for entry in specs:
 ```
 
 Pass `circuit=` to restrict the result to just the `(gate, qargs)` targets a specific circuit uses — still exactly one entry per unique target no matter how many times the circuit repeats it. Promoted from [Dense-Evolution-Discovery](https://github.com/tatopenn-cell/Dense-Evolution-Discovery)'s Steane-code hardware bridge script, which found a real bug worth preserving here: calling Qiskit Aer's `add_quantum_error` once per gate *occurrence* (rather than once per unique target) composes the same Kraus channel with itself repeatedly, blowing up to multi-GB memory on circuits with many repeats on the same qubits. This function can't reproduce that bug by construction — it dedupes by `(gate, qargs)` before ever emitting a spec entry.
+
+**STIM bridge — `to_stim`.** Converts a Dense-Evolution op-list circuit into a `stim.Circuit`, for cross-validation against STIM's own stabilizer simulator/decoder tooling:
+
+```python
+from dense_evolution import to_stim
+
+circuit = to_stim([['h', 0], ['cx', 0, 1]], n_qubits=2)
+```
+
+STIM is a *stabilizer* simulator — it can only represent Clifford operations (`h`/`x`/`y`/`z`/`s`/`sdg`/`sx`/`id`/`cx`/`cy`/`cz` map 1:1 onto native STIM instructions here). A continuous-angle rotation (`rx`/`ry`/`rz`/`p`/...) or a non-Clifford gate (`t`/`tdg`) raises `ValueError` naming the offending gate, rather than being silently dropped or approximated — a stabilizer circuit that's silently wrong defeats the point of using STIM as an independent check. Generalized from [Dense-Evolution-Discovery](https://github.com/tatopenn-cell/Dense-Evolution-Discovery)'s Steane-code STIM cross-check, which was specific to that one circuit; this version works on any Clifford op-list.
 
 **Known limits** (inherited from the QASM2 bridge, not something this layer works around):
 - No classical control flow — `if`/`while` and mid-circuit-measurement-conditioned gates are parsed out, not executed (same limitation as native QASM3 circuits, see Changelog v8.1.13).

--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -10,7 +10,7 @@ from .gates import GATES, PARAMETRIC_GATES, GATE_IDS
 from .chunk import Chunk
 from .interop import (
     from_qiskit, from_pennylane, run_qiskit_circuit, run_pennylane_circuit,
-    noise_model_from_qiskit_backend,
+    noise_model_from_qiskit_backend, to_stim,
 )
 from .autodiff import circuit_to_energy_fn
 from .mps import MPSSimulator

--- a/dense_evolution/interop.py
+++ b/dense_evolution/interop.py
@@ -18,6 +18,12 @@ try:
 except ImportError:
     HAS_PENNYLANE = False
 
+try:
+    import stim
+    HAS_STIM = True
+except ImportError:
+    HAS_STIM = False
+
 _macos_qiskit_warning_shown = False
 
 
@@ -45,6 +51,13 @@ def _require_pennylane():
         raise ImportError(
             "PennyLane interop requires the 'pennylane' package. "
             "Install it with: pip install dense-evolution[pennylane]")
+
+
+def _require_stim():
+    if not HAS_STIM:
+        raise ImportError(
+            "STIM interop requires the 'stim' package. "
+            "Install it with: pip install dense-evolution[stim]")
 
 
 def _to_qiskit_bit_order(probs: np.ndarray, n_qubits: int) -> np.ndarray:
@@ -280,3 +293,55 @@ def run_pennylane_circuit(
     sim.run_circuit(circ.to_tuples())
     probs = np.asarray(sim.get_probabilities())
     return sim, probs
+
+
+_STIM_GATE_MAP = {
+    'h': 'H', 'x': 'X', 'y': 'Y', 'z': 'Z',
+    's': 'S', 'sdg': 'S_DAG', 'sx': 'SQRT_X', 'id': 'I',
+    'cx': 'CX', 'cy': 'CY', 'cz': 'CZ',
+}
+
+
+def to_stim(ops, n_qubits: int) -> 'stim.Circuit':
+    """Convert a Dense-Evolution op-list circuit (e.g. [['h', 0], ['cx', 0, 1]])
+    into a stim.Circuit, for cross-validation against STIM's own stabilizer
+    simulator/decoder tooling. Promoted from Dense-Evolution-Discovery's
+    Steane-code STIM bridge script (scripts/steane_code_block4_stim_translation.py),
+    generalized from that script's Steane-specific gate set to every
+    STIM-representable gate this library has.
+
+    STIM is a STABILIZER simulator: it can only represent Clifford
+    operations. Every gate below maps 1:1 onto a native STIM instruction
+    (h/x/y/z/s/sdg/sx/id/cx/cy/cz); anything else in the op list --
+    continuous-angle rotations (rx/ry/rz/p/phase/u1/cp/cphase/crz) or the
+    non-Clifford t/tdg gates -- raises ValueError rather than being dropped
+    or approximated, since a silently-wrong stabilizer circuit defeats the
+    purpose of using STIM as an independent cross-check in the first place.
+
+    A leading no-op 'I' on qubit n_qubits - 1 is emitted first so the
+    returned circuit always has exactly n_qubits qubits, even if the
+    highest-indexed qubit is never otherwise touched by `ops`.
+
+    Qubit indexing matches `ops` directly (STIM has no reordering of its
+    own, unlike Qiskit's little-endian convention handled by
+    run_qiskit_circuit) -- but STIM's state_vector()/TableauSimulator
+    output is still little-endian (qubit 0 = least significant bit),
+    the same convention _to_qiskit_bit_order reorders into, so comparing
+    against DenseSVSimulator's own MSB-first probabilities/statevector
+    still needs that same reordering."""
+    _require_stim()
+    circuit = stim.Circuit()
+    if n_qubits > 0:
+        circuit.append('I', [n_qubits - 1])
+    for op in ops:
+        gate_name = op[0]
+        stim_gate = _STIM_GATE_MAP.get(gate_name)
+        if stim_gate is None:
+            raise ValueError(
+                f"Gate '{gate_name}' is not representable in STIM -- STIM is "
+                "a stabilizer simulator and only supports Clifford "
+                "operations (h, x, y, z, s, sdg, sx, id, cx, cy, cz here), "
+                "not continuous-angle rotations (rx/ry/rz/p/phase/u1/cp/"
+                "cphase/crz) or non-Clifford gates (t/tdg).")
+        circuit.append(stim_gate, list(op[1:]))
+    return circuit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ qiskit = [
 pennylane = [
     "pennylane>=0.35.0"
 ]
+stim = [
+    "stim>=1.13.0"
+]
 composer = [
     "fastapi>=0.110.0",
     "uvicorn>=0.29.0",

--- a/tests/test_interop_stim_bridge.py
+++ b/tests/test_interop_stim_bridge.py
@@ -1,0 +1,88 @@
+"""
+Tests for dense_evolution.interop.to_stim (STIM bridge).
+
+STIM is an optional dependency — pytest.importorskip guards the
+correctness tests so this file stays green without it installed, on top
+of CI installing it explicitly.
+"""
+import numpy as np
+import pytest
+
+import dense_evolution as de
+from dense_evolution import interop
+from dense_evolution.interop import to_stim
+from dense_evolution.simulator import DenseSVSimulator
+
+stim = pytest.importorskip("stim")
+
+
+def _to_le_order(probs: np.ndarray, n_qubits: int) -> np.ndarray:
+    """Reorder an MSB-first probability array (Dense-Evolution's own
+    convention) into little-endian order (STIM's/Qiskit's convention) via
+    a bit-reversal permutation. Takes probabilities directly -- callers
+    must not pass raw amplitudes here (squaring already-squared
+    probabilities silently halves the apparent magnitude and was a real
+    bug caught in this exact test)."""
+    perm = [int(format(i, f'0{n_qubits}b')[::-1], 2) for i in range(2 ** n_qubits)]
+    return probs[perm]
+
+
+class TestToStimCliffordCircuits:
+
+    def test_bell_state_matches_dense_sv_simulator(self):
+        ops = [['h', 0], ['cx', 0, 1]]
+        n_qubits = 2
+
+        sim = DenseSVSimulator(n_qubits=n_qubits, use_float32=False)
+        sim.run_circuit(ops)
+        de_probs = np.asarray(sim.get_probabilities())
+
+        circuit = to_stim(ops, n_qubits)
+        tsim = stim.TableauSimulator()
+        tsim.do(circuit)
+        stim_probs = np.abs(np.asarray(tsim.state_vector())) ** 2
+        # STIM's state_vector() is little-endian (qubit 0 = LSB), same as
+        # Qiskit's convention -- reorder DE's MSB-first probs to compare.
+        de_probs_le = _to_le_order(de_probs, n_qubits)
+        assert np.allclose(de_probs_le, stim_probs, atol=1e-9)
+
+    def test_larger_clifford_circuit_matches_dense_sv_simulator(self):
+        ops = [['h', 0], ['s', 0], ['cx', 0, 1], ['cy', 1, 2],
+               ['sx', 2], ['sdg', 1], ['x', 0], ['y', 1], ['z', 2],
+               ['h', 2], ['cz', 0, 2]]
+        n_qubits = 3
+
+        sim = DenseSVSimulator(n_qubits=n_qubits, use_float32=False)
+        sim.run_circuit(ops)
+        de_probs = np.asarray(sim.get_probabilities())
+
+        circuit = to_stim(ops, n_qubits)
+        tsim = stim.TableauSimulator()
+        tsim.do(circuit)
+        stim_probs = np.abs(np.asarray(tsim.state_vector())) ** 2
+
+        de_probs_le = _to_le_order(de_probs, n_qubits)
+        assert np.allclose(de_probs_le, stim_probs, atol=1e-9)
+
+    def test_untouched_high_qubit_still_sets_circuit_width(self):
+        circuit = to_stim([['h', 0]], n_qubits=4)
+        assert circuit.num_qubits == 4
+
+
+class TestToStimNonCliffordRejection:
+
+    def test_parametric_rotation_raises_value_error(self):
+        with pytest.raises(ValueError, match='rx'):
+            to_stim([['h', 0], ['rx', 0, 0.3]], n_qubits=1)
+
+    def test_t_gate_raises_value_error(self):
+        with pytest.raises(ValueError, match='t'):
+            to_stim([['t', 0]], n_qubits=1)
+
+
+class TestToStimImportGuard:
+
+    def test_missing_stim_raises_clear_importerror(self, monkeypatch):
+        monkeypatch.setattr(interop, 'HAS_STIM', False)
+        with pytest.raises(ImportError, match='stim'):
+            to_stim([['h', 0]], n_qubits=1)


### PR DESCRIPTION
Generalizes Dense-Evolution-Discovery's Steane-specific STIM translation into a reusable `to_stim(ops, n_qubits)` bridge, following the same pattern as the existing Qiskit/PennyLane interop. Clifford-only by construction; non-Clifford gates raise ValueError naming the gate. 6/6 new tests pass, verified against STIM's own TableauSimulator (not just crash-free). Caught and fixed a real test bug along the way (double-squaring already-computed probabilities). Adds the `stim` optional extra and README docs.