### PR TITLE
Fix CI: install stim so to_stim's tests run instead of skipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           pip install setuptools pytest pytest-cov numpy scipy pandas matplotlib psutil ipython jax jaxlib seaborn plotly
           pip install qiskit pennylane pylatexenc
           pip install qiskit-ibm-runtime # tests/test_interop_calibration_noise.py -- FakeSherbrooke, real historical IBM Eagle-127 calibration data, offline/no account needed
+          pip install stim # tests/test_interop_stim_bridge.py -- to_stim() correctness tests were being silently skipped in CI without this (pytest.importorskip), leaving the real logic uncovered
           pip install streamlit>=1.30.0 ipywidgets>=8.0.0
           pip install fastapi uvicorn pydantic httpx2 # composer extra -- local_site/app/server.py + tests/test_local_site_server.py (httpx2: starlette.testclient's current required client)
           pip install mcp httpx # mcp extra -- mcp_server/server.py + tests/test_mcp_server.py (real httpx, not the httpx2 alias above -- the MCP adapter imports httpx directly)


### PR DESCRIPTION
codecov/patch flagged the real root cause: interop.py's patch coverage was 33.33% (14 lines missing) because tests/test_interop_stim_bridge.py's pytest.importorskip('stim') was silently skipping 5/6 tests in CI -- stim was never installed there (qiskit-ibm-runtime was added for the sibling calibration-noise tests, stim itself was missed). Adds pip install stim to the CI workflow.