### PR TITLE
Fix: dense_evolution.native_hf missing from the built package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ Repository = "https://github.com/tatopenn-cell/Dense-Evolution"
 dense-evolution = "dense_evolution.cli:main"
 
 [tool.setuptools]
-packages = ["dense_evolution", "ia_utils", "dashboard_core", "local_site", "local_site.app", "mcp_server"]
+packages = ["dense_evolution", "dense_evolution.native_hf", "ia_utils", "dashboard_core", "local_site", "local_site.app", "mcp_server"]
 
 [tool.setuptools.package-data]
 "dense_evolution" = ["*.py"]


### PR DESCRIPTION
## Summary
\`[tool.setuptools] packages\` is an explicit list, not auto-discovery -- the new \`native_hf\` subpackage (added in #56) was never added to it, so \`python -m build\` silently produced a wheel/sdist without it.

## Verification
Caught by actually building the package and installing the wheel into a clean venv (not just trusting a green test suite, which runs against the source tree, not a built package): \`from dense_evolution.native_hf.bridge import build_qubit_hamiltonian\` failed with \`ModuleNotFoundError\` before this fix, imports cleanly after.

## Test plan
- [ ] CI green