### PR TITLE
Document native_hf and Si2 across README, docs site, and API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ legacy/dash.py                     original Colab notebook, reference only (not 
 | **Vector Sequence Healing** | `ia_utils/` — `median_healing`, `enhanced_dense_healing_hybrid` — NaN/Inf-safe, lazy JAX import |
 | **Adversarial Robustness Testing** | `ia_utils.adversarial_vector_attack.craft_adversarial_healing_perturbation` — PGD-style minimal perturbation, flips the healing Phi-Trigger either direction |
 | **STIM Bridge** | `to_stim` — Clifford-only op-list → `stim.Circuit`, for cross-validation against STIM's stabilizer simulator/decoder tooling |
+| **Native Hartree-Fock** | `dense_evolution.native_hf` — from-scratch JAX/Obara-Saika ab-initio HF engine for elements outside PennyLane's own STO-3G table (H–Ne), auto-used by the Hamiltonian Library for e.g. Si2 |
 | **Backend Agnostic** | NumPy CPU · JAX XLA CPU/TPU · CuPy CUDA — runtime selection, zero code changes |
 | **Live Dashboard** | `app_dashboard.py` — Streamlit Quantum-Composer clone, 5 tabs (Graphical Builder/Circuit/Statevector/Probabilities/Q-sphere) per simulation run |
 
@@ -215,10 +216,10 @@ legacy/dash.py                     original Colab notebook, reference only (not 
 
 ## ▍ Scientific Validation & Applications
 
-To demonstrate the numerical accuracy and stability of **Dense Evolution**, the simulator was stress-tested across 3,500 continuous spatial sampling points to compute the **Silicon Dimer (Si2) Dissociation Curve** via Variational Quantum Eigensolver (VQE).
+To demonstrate the numerical accuracy and stability of **Dense Evolution**, the simulator was stress-tested across 3,500 continuous spatial sampling points to compute a **Silicon Dimer (Si2) Dissociation Curve** via Variational Quantum Eigensolver (VQE), using a small active space/basis (raw script linked below).
 
-* Physical Accuracy: The simulation successfully maps the exact Born-Oppenheimer Potential Energy Curve (PEC), capturing the deep quantum ground state bound minimum at ~3.55 Å with negative total energy, before converging asymptotically toward full molecular dissociation.
 * Numerical Precision: Calculations are locked at Double Precision (float64), proving the simulator's resilience against cumulative machine epsilon errors (~ 1.11 × 10⁻¹⁶) across thousands of sequential circuit executions.
+* **Honest caveat, corrected in v8.1.59**: this scan's own minimum (~3.55 Å below, negative total energy) is an artifact of its small active-space/basis choice, not the real physical Si2 equilibrium — the real experimental/literature bond length is **2.184 Å** (Balamurugan & Prasad, [arXiv:cond-mat/0108426](https://arxiv.org/abs/cond-mat/0108426)). This claim went unverified in earlier README revisions; it's stated correctly here and Si2 is now in the [Hamiltonian Library](#-hamiltonian-library) below at its real geometry, computed by the new [native Hartree-Fock engine](#-api-reference) since Si is outside PennyLane's own bundled STO-3G table.
 * Run this molecular experiment instantly on Google Colab Free Tier:
   [Open Notebook on Google Colab](https://colab.research.google.com/drive/1cX7vYsVaxO29677ltgDTbh3pqUi0NYC5#scrollTo=Qg_lqX-Iw_UM)
 
@@ -807,23 +808,28 @@ $$\frac{\partial E}{\partial \theta_i} = \left\langle\psi(\theta)\left|\frac{\pa
 
 ## ▍ Hamiltonian Library
 
-Real Hartree-Fock + fermion-to-qubit mapping (PennyLane `qchem`, Jordan-Wigner
-or Bravyi-Kitaev — both represent the identical physical Hamiltonian, just a
-different qubit basis), exact dense diagonalization for the ground-state
-energy. `dashboard_core.MOLECULE_CATALOG`:
+Real Hartree-Fock + fermion-to-qubit mapping, exact dense diagonalization
+for the ground-state energy. `_get_hamiltonian` dispatches per molecule to
+PennyLane's own `qchem` pipeline (Jordan-Wigner or Bravyi-Kitaev — both
+represent the identical physical Hamiltonian, just a different qubit basis)
+when every element is in PennyLane's bundled STO-3G table, or to
+Dense-Evolution's own [`native_hf`](#-core-features) engine otherwise.
+`dashboard_core.MOLECULE_CATALOG`:
 
-| Molecule | Qubits | Bond length | E₀ (Ha, Jordan-Wigner) |
-|---|:---:|:---:|:---:|
-| H₂ | 4 | 0.7414 Å | −1.1373 |
-| HeH⁺ | 4 | 0.7743 Å | −3.0157 |
-| H₃⁺ (D3h triangle) | 6 | 0.8738 Å | −1.2973 |
-| LiH | 12 | 1.5949 Å | −7.8824 |
-| H₂O (104.5°, frozen-core O 1s) | 12 | 0.9584 Å | −75.0127 |
+| Molecule | Qubits | Bond length | E₀ (Ha, Jordan-Wigner) | Engine |
+|---|:---:|:---:|:---:|---|
+| H₂ | 4 | 0.7414 Å | −1.1373 | PennyLane `dhf` |
+| HeH⁺ | 4 | 0.7743 Å | −3.0157 | PennyLane `dhf` |
+| H₃⁺ (D3h triangle) | 6 | 0.8738 Å | −1.2973 | PennyLane `dhf` |
+| LiH | 12 | 1.5949 Å | −7.8824 | PennyLane `dhf` |
+| H₂O (104.5°, frozen-core O 1s) | 12 | 0.9584 Å | −75.0127 | PennyLane `dhf` |
+| Si₂ | 8 | 2.184 Å (real equilibrium, active space too small to reproduce as its own minimum — see v8.1.59 changelog) | −570.6861 | `native_hf` |
 
 Custom molecules: any atomic symbols + `[[x, y, z], ...]` geometry in
-Ångström, same Hartree-Fock pipeline — capped at 12 qubits (exact dense
-diagonalization's real limit here, rejected with a clear error before
-PennyLane runs rather than attempted and failing expensively).
+Ångström, same Hartree-Fock pipeline (PennyLane or `native_hf`, dispatched
+automatically) — capped at 12 qubits (exact dense diagonalization's real
+limit here, rejected with a clear error before PennyLane runs rather than
+attempted and failing expensively).
 `dense_evolution_energy_scan` (MCP) / the Composer's "Scan energia" panel
 compute this at several geometries in one call, e.g. a dissociation curve.
 

--- a/docs/api/dashboard_core_hamiltonians.md
+++ b/docs/api/dashboard_core_hamiltonians.md
@@ -1,16 +1,34 @@
 # Dashboard Core — Hamiltonians
 
 Real molecular Hamiltonians, built on demand from actual atomic geometry
-via PennyLane's `qchem` module (Hartree-Fock + Jordan-Wigner
-fermion-to-qubit mapping) — no fabricated or hand-picked coefficients.
-Backs Composer's molecular-energy panel, [`dashboard_core.vqe`](dashboard_core_vqe.md),
+— no fabricated or hand-picked coefficients. `_get_hamiltonian` dispatches
+per molecule: PennyLane's own `qchem` pipeline (Hartree-Fock +
+Jordan-Wigner) when every requested element is in PennyLane's bundled
+STO-3G table (H2/HeH+/H3+/LiH/H2O), or Dense-Evolution's own
+[native Hartree-Fock engine](native_hf.md) otherwise — currently backing
+**Si2** (real equilibrium R = 2.184 Å, Balamurugan & Prasad,
+[arXiv:cond-mat/0108426](https://arxiv.org/abs/cond-mat/0108426)), whose
+elements PennyLane's `dhf` can't reach at all (its table stops at Ne).
+Both paths hand off to the same PennyLane `fermionic_observable` +
+`jordan_wigner` step, so the qubit mapping is identical either way. Backs
+Composer's molecular-energy panel, [`dashboard_core.vqe`](dashboard_core_vqe.md),
 and [`dashboard_core.qmmm`](dashboard_core_qmmm.md).
+
+**Honest caveat on Si2**: with only 4 active electrons/orbitals (all 20
+core electrons frozen across both atoms), this active space is too small
+to reproduce 2.184 Å as its own energy minimum — a direct 10-point
+bond-length scan found the minimum at the 1.9 Å edge of the scanned
+range, not an interior point. Stated in the catalog entry's own comment
+rather than silently picking a geometry that flatters the active-space
+choice.
 
 ::: dashboard_core.hamiltonians
 
 ---
 
 **See also**: [`dashboard_core.vqe`](dashboard_core_vqe.md) for the
-ansatz circuits optimized against these Hamiltonians, and
+ansatz circuits optimized against these Hamiltonians,
 [`dashboard_core.qmmm`](dashboard_core_qmmm.md) for the Hellmann-Feynman
-forces derived from them.
+forces derived from them, and [Native Hartree-Fock](native_hf.md) for the
+engine backing Si2 and any other element outside PennyLane's own STO-3G
+table.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -30,3 +30,4 @@ reimplementation.
 | [Fermions](fermions.md) | Majorana-fermion → qubit (Jordan-Wigner) mapping |
 | [Entropy](entropy.md) | Multi-qubit partial trace, von Neumann entropy, mutual information |
 | [Trotter](trotter.md) | Real-time Hamiltonian evolution as an actual gate circuit |
+| [Native Hartree-Fock](native_hf.md) | From-scratch JAX/Obara-Saika ab-initio HF engine for elements outside PennyLane's own STO-3G table |

--- a/docs/api/native_hf.md
+++ b/docs/api/native_hf.md
@@ -1,0 +1,54 @@
+# Native Hartree-Fock (`dense_evolution.native_hf`)
+
+A from-scratch, JAX-vectorized ab-initio Hartree-Fock engine — overlap,
+kinetic, nuclear-attraction, and electron-repulsion integrals over s/p
+Cartesian Gaussian shells via the Obara-Saika recursion (Obara & Saika,
+*J. Chem. Phys.* 84, 3963, 1986), each shell-pair/quartet batched with
+`jax.lax.scan`/`jax.vmap` and compiled with `jax.jit` instead of looping
+in the Python interpreter.
+
+It exists because PennyLane's own differentiable Hartree-Fock solver
+(`qml.qchem`, `method="dhf"`) builds these same integrals through a
+Python-level loop wrapped in its autograd-tracing numpy layer — correct,
+but profiled directly at 482 of 483 total seconds for Si2/STO-3G, almost
+entirely per-scalar-op tracer overhead rather than real FLOPs. This
+module only replaces the integral/SCF stage; the converged result still
+goes to PennyLane's own `fermionic_observable` + `jordan_wigner` for the
+qubit mapping, since that stage is already fast (under 2 seconds) and
+well-tested. Basis-set parameters come from the
+[`basis_set_exchange`](https://github.com/MolSSI-BSE/basis_set_exchange)
+package, so any element it has STO-3G data for is reachable, not just
+PennyLane's bundled H–Ne table. An element needing d-orbitals or higher
+(e.g. Fe) fails with a clear `NotImplementedError` naming the real
+limitation, not a silent wrong energy for an incomplete basis.
+
+Design and algorithm structure were informed by studying
+[lowdanie/hartree-fock-solver](https://github.com/lowdanie/hartree-fock-solver)
+("slaterform", Apache-2.0) as a reference for structuring the Obara-Saika
+recursion with `jax.lax.scan`, and by PennyLane's own white paper
+(Delgado et al., "Differentiable quantum computational chemistry with
+PennyLane", [arXiv:2111.09967](https://arxiv.org/abs/2111.09967)) — no
+source code from either project is copied here. Verified element-wise
+against an independent JAX Hartree-Fock implementation (slaterform) to
+machine precision on individual integrals and to 10 significant figures
+on Si2/STO-3G's full SCF energy.
+
+`dashboard_core.hamiltonians` calls this engine automatically —
+`bridge.build_qubit_hamiltonian` — whenever a requested molecule uses an
+element outside PennyLane's own STO-3G table; existing molecules
+(H2/HeH+/H3+/LiH/H2O) are unaffected and keep using PennyLane's `dhf`
+pipeline directly. See [Dashboard Core — Hamiltonians](dashboard_core_hamiltonians.md)
+for the dispatch logic and the Si2 catalog entry this engine backs.
+
+::: dense_evolution.native_hf.bridge
+
+::: dense_evolution.native_hf.scf
+
+::: dense_evolution.native_hf.basis
+
+---
+
+**See also**: [`Dashboard Core — Hamiltonians`](dashboard_core_hamiltonians.md)
+for the production entry point (`MOLECULE_CATALOG`'s Si2 entry), and
+[`dashboard_core.vqe`](dashboard_core_vqe.md) for the ansatz circuits
+optimized against Hamiltonians this engine can build.

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,10 @@ parsing, chunked large-scale circuits, and ZNE mitigation.
   phaseflip, amplitude damping, and a combined worst-case model), JAX- and NumPy-native.
 - **Interop** with [Qiskit and PennyLane](api/interop.md), and [autodiff](api/autodiff.md)
   through `circuit_to_energy_fn` for gradient-based VQE.
+- **[`dense_evolution.native_hf`](api/native_hf.md)** — a from-scratch, JAX/Obara-Saika
+  Hartree-Fock engine for elements outside PennyLane's own bundled STO-3G table (H–Ne),
+  automatically backing [`dashboard_core.hamiltonians`](api/dashboard_core_hamiltonians.md)
+  for molecules like Si2.
 
 ## Dashboard Core — Composer's real compute layer
 
@@ -131,6 +135,11 @@ flowchart LR
         advattack["adversarial_vector_attack<br/>(craft_adversarial_healing_perturbation)"]
     end
 
+    subgraph nativehf["native_hf (dense_evolution submodule)"]
+        nhf_bridge["bridge"]
+        nhf_scf["scf"]
+    end
+
     subgraph dashcore["dashboard_core (separate top-level package, Composer's backend)"]
         dc_wormhole["wormhole"]
         dc_vqe["vqe"]
@@ -167,6 +176,8 @@ flowchart LR
     vhealing -.->|lazy import| healing
     advattack --> healing
 
+    nhf_bridge --> nhf_scf
+    dc_hamiltonians -.->|element outside PennyLane's STO-3G table| nhf_bridge
     dc_vqe --> dc_hamiltonians
     dc_qmmm --> dc_hamiltonians
     dc_visuals --> dc_circuit_diagram
@@ -175,10 +186,10 @@ flowchart LR
     dc_vector_healing -.->|lazy import| vhealing
 ```
 
-`dashboard_core.engine`, `dashboard_core.hamiltonians`, `dashboard_core.mitigation`,
-`dashboard_core.qasm_library`, `dashboard_core.system_limits`, and `dashboard_core.wormhole`
-each depend only on `dense_evolution`'s top-level public API (`import dense_evolution as de`,
-or `from dense_evolution import mutual_information, majorana_pauli_terms, trotter_evolve_ops`
+`dashboard_core.engine`, `dashboard_core.mitigation`, `dashboard_core.qasm_library`,
+`dashboard_core.system_limits`, and `dashboard_core.wormhole` each depend only on
+`dense_evolution`'s top-level public API (`import dense_evolution as de`, or
+`from dense_evolution import mutual_information, majorana_pauli_terms, trotter_evolve_ops`
 for `wormhole`), not on a specific submodule shown above, so they have no internal edges
 drawn here beyond that. `circuit_diagram`, `state_visuals`, and `graphical_builder` have no
 internal-repo dependencies at all (NumPy / Matplotlib only).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,7 @@ nav:
       - Fermions (Majorana Jordan-Wigner): api/fermions.md
       - Entropy (partial trace, mutual information): api/entropy.md
       - Trotter (Hamiltonian evolution as gates): api/trotter.md
+      - Native Hartree-Fock (Obara-Saika, JAX): api/native_hf.md
       - "Dashboard Core — Wormhole (SYK teleportation)": api/dashboard_core_wormhole.md
       - "Dashboard Core — VQE": api/dashboard_core_vqe.md
       - "Dashboard Core — Hamiltonians": api/dashboard_core_hamiltonians.md


### PR DESCRIPTION
Docs-only follow-up to v8.1.59 (native Hartree-Fock engine + Si2 catalog entry), per the standing rule that a new function/module gets documented everywhere in the same pass, not just in the changelog.

- New `docs/api/native_hf.md` page (mkdocstrings for `bridge`/`scf`/`basis`), wired into `mkdocs.yml`'s nav and `docs/api/index.md`'s module table.
- `docs/api/dashboard_core_hamiltonians.md`: explains the PennyLane/`native_hf` dispatch and Si2's active-space caveat.
- `docs/index.md`: `native_hf` added to the feature list and the module-dependency diagram.
- `README.md`: `native_hf` row in Core Features, Si2 row in the Hamiltonian Library table, and corrects the earlier unverified "~3.55 Å" Si2 minimum claim in Scientific Validation with the real 2.184 Å literature equilibrium (Balamurugan & Prasad, arXiv:cond-mat/0108426).

No code changes — docs/README only.