### PR TITLE
Update Zenodo DOI for v8.1.59

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,12 +12,12 @@ authors:
 repository-code: "https://github.com/tatopenn-cell/Dense-Evolution"
 url: "https://github.com/tatopenn-cell/Dense-Evolution"
 license: "BUSL-1.1"
-version: "8.1.58"
-doi: "10.5281/zenodo.21900611"
+version: "8.1.59"
+doi: "10.5281/zenodo.21907077"
 identifiers:
   - type: doi
     value: "10.5281/zenodo.21855643"
     description: "The concept DOI for all versions of this software."
   - type: doi
-    value: "10.5281/zenodo.21900611"
-    description: "The version-specific DOI for v8.1.58."
+    value: "10.5281/zenodo.21907077"
+    description: "The version-specific DOI for v8.1.59."

--- a/README.md
+++ b/README.md
@@ -1176,7 +1176,7 @@ If Dense-Evolution is useful in academic work, please cite it via the metadata i
 Archived on [Zenodo](https://zenodo.org/):
 
 - **Concept DOI** (always resolves to the latest version): [10.5281/zenodo.21855643](https://doi.org/10.5281/zenodo.21855643)
-- **This release (v8.1.58)**: [10.5281/zenodo.21900611](https://doi.org/10.5281/zenodo.21900611)
+- **This release (v8.1.59)**: [10.5281/zenodo.21907077](https://doi.org/10.5281/zenodo.21907077)
 
 ---
 


### PR DESCRIPTION
Zenodo's GitHub integration minted `10.5281/zenodo.21907077` for the v8.1.59 release (concept DOI `10.5281/zenodo.21855643` unchanged). Updates `CITATION.cff` and README's "Cite This" section to match. Docs-only, no code changes.