### PR TITLE
Update CITATION.cff and README for v8.1.60's Zenodo DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,12 +12,12 @@ authors:
 repository-code: "https://github.com/tatopenn-cell/Dense-Evolution"
 url: "https://github.com/tatopenn-cell/Dense-Evolution"
 license: "BUSL-1.1"
-version: "8.1.59"
-doi: "10.5281/zenodo.21907077"
+version: "8.1.60"
+doi: "10.5281/zenodo.21918045"
 identifiers:
   - type: doi
     value: "10.5281/zenodo.21855643"
     description: "The concept DOI for all versions of this software."
   - type: doi
-    value: "10.5281/zenodo.21907077"
-    description: "The version-specific DOI for v8.1.59."
+    value: "10.5281/zenodo.21918045"
+    description: "The version-specific DOI for v8.1.60."

--- a/README.md
+++ b/README.md
@@ -1180,7 +1180,7 @@ If Dense-Evolution is useful in academic work, please cite it via the metadata i
 Archived on [Zenodo](https://zenodo.org/):
 
 - **Concept DOI** (always resolves to the latest version): [10.5281/zenodo.21855643](https://doi.org/10.5281/zenodo.21855643)
-- **This release (v8.1.59)**: [10.5281/zenodo.21907077](https://doi.org/10.5281/zenodo.21907077)
+- **This release (v8.1.60)**: [10.5281/zenodo.21918045](https://doi.org/10.5281/zenodo.21918045)
 
 ---
 


### PR DESCRIPTION
## Summary
- `CITATION.cff`: `version` 8.1.59 → 8.1.60, version-specific `doi` updated to `10.5281/zenodo.21918045` (minted by Zenodo's GitHub webhook after the v8.1.60 release). Concept DOI (`10.5281/zenodo.21855643`) unchanged.
- `README.md`: "Cite This" section's version-DOI line updated to match.

Docs-only change, no code touched.
