### PR TITLE
Correct and verify the degenerate-eigh gradient docstring

### DIFF
--- a/dense_evolution/mitigation.py
+++ b/dense_evolution/mitigation.py
@@ -310,16 +310,29 @@ def _eigh_degenerate_safe(A: jnp.ndarray):
     partial eigendecomposition of a real symmetric matrix for degenerate
     cases", arXiv:2011.04366).
 
-    This is the practical variant of that fix (also documented elsewhere,
-    e.g. PyTorch's `torch.linalg.eigh` gradient notes and the `xitorch`
-    library's `symeig`): mask the `1/(lambda_i - lambda_j)` term to 0 for
-    near-degenerate pairs instead of letting it blow up, rather than
-    Kasim's fuller per-degenerate-block treatment (which recovers a
-    generally nonzero contribution from within the degenerate eigenspace
-    itself). Sufficient here because `uhlmann_fidelity`'s only use of the
+    This is a practical variant of that fix: mask the `1/(lambda_i -
+    lambda_j)` term to 0 for near-degenerate pairs instead of letting it
+    blow up, rather than Kasim's fuller per-degenerate-block treatment
+    (which recovers a generally nonzero contribution from within the
+    degenerate eigenspace itself for some perturbation directions).
+    Sufficient here because `uhlmann_fidelity`'s only use of the
     eigenVECTORS is to rebuild a matrix square root, and simply zeroing
     that masked term still gives a mathematically valid (if not maximally
     sharp) subgradient direction there.
+
+    This masking is NOT known to already exist elsewhere, checked directly
+    rather than assumed: PyTorch's current `linalg_eig_jvp`/
+    `linalg_eig_backward` (`torch/csrc/autograd/FunctionsManual.cpp`)
+    divides directly by `(L_j - L_i)` with no degenerate-pair masking at
+    all -- the same singularity as JAX's default, unresolved there too.
+    The `xitorch` library (built by Kasim himself)'s own derivation notes
+    (`doc/notes/deriv_symeig.rst`) state "This derivation assumes the
+    eigenvalues are all unique. Cases with degenerate eigenvalues are
+    treated differently" without giving that treatment on that page, and
+    its `symeig` docstring warns directly that for degenerate values "the
+    calculation and its gradient might be inaccurate". This appears to be
+    a genuinely open problem across the JAX/PyTorch/xitorch ecosystem, not
+    something ported from prior art.
 
     Verified (directional-derivative/JVP comparison against symmetric-
     tangent finite differences, the only comparison method that avoids

--- a/dense_evolution/mitigation.py
+++ b/dense_evolution/mitigation.py
@@ -338,7 +338,12 @@ def _eigh_degenerate_safe(A: jnp.ndarray):
     tangent finite differences, the only comparison method that avoids
     eigenvector sign/ordering convention ambiguities): exact match
     (diff=0.000000) for non-degenerate, 2-fold, and 3-fold degenerate test
-    matrices."""
+    matrices. The 1e-8 masking threshold itself is verified, not
+    arbitrary: swept true (non-exact) eigenvalue gaps from 1.0 down to
+    1e-10 against finite differences -- the unmasked formula tracks them
+    to ~1e-9 accuracy for any gap down to ~1e-7, only degrading right at
+    the threshold, which sits at the edge of float64-resolvable gaps for
+    O(1)-scale eigenvalues rather than discarding real signal."""
     return jnp.linalg.eigh(A)
 
 


### PR DESCRIPTION
## Summary
- The `_eigh_degenerate_safe` docstring claimed PyTorch's `eigh` gradient and xitorch's `symeig` already use the same masking fix. Checked against their actual current source rather than assumed: PyTorch's `linalg_eig_jvp`/`linalg_eig_backward` divides directly with no degenerate-pair masking (same NaN singularity, unresolved there too), and xitorch's own derivation notes flag the degenerate case as untreated on that page, with `symeig`'s docstring warning the gradient "might be inaccurate". Corrected the claim.
- Same correction already applied to the public comments this docstring's claim was echoed from (jax-ml/jax#2311, #8732).
- Verified the existing 1e-8 masking threshold isn't arbitrary: swept true (non-exact) eigenvalue gaps from 1.0 down to 1e-10 against finite differences. The unmasked formula already tracks finite differences to ~1e-9 accuracy down to ~1e-7 gaps, only degrading right at the threshold -- which sits at the edge of float64-resolvable gaps for O(1)-scale eigenvalues. A smoothed (Lorentzian) regularization was tried as a possible improvement and measured no real benefit, so no behavior change -- just documentation, now backed by data.

## Test plan
- [x] `python -m py_compile dense_evolution/mitigation.py`
- [x] `pytest tests/test_mitigation.py` -- 41 passed