### PR TITLE
Docs: add pre-commit setup to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,17 @@ cd Dense-Evolution
 pip install -e .[full]
 ```
 
+### Pre-commit (recommended)
+
+We use pre-commit to run black/isort/ruff/mypy locally. Install and enable hooks:
+
+```bash
+pip install pre-commit
+pre-commit install
+# run checks across the repo before opening a PR
+pre-commit run --all-files
+```
+
 ## Running tests
 
 ```bash


### PR DESCRIPTION
Document pre-commit installation and recommended usage in CONTRIBUTING.md to help contributors run formatters and linters locally before opening PRs.