### PR TITLE
Phase 2: move drawing.py/measurement.py into dense_evolution.utils/

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -22,10 +22,10 @@ from .mitigation import (richardson_extrapolate, zero_noise_extrapolation, polyn
 from .topology import entangling_layer
 from .observables import pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix
 from .states import ghz_state
-from .measurement import sample_counts, statevector_fidelity
+from .utils.measurement import sample_counts, statevector_fidelity
 from .qft import qft
 from .random_circuit import random_circuit
-from .drawing import draw_circuit
+from .utils.drawing import draw_circuit
 from .harrison_tb import (ELEMENTS as HARRISON_ELEMENTS, ETA as HARRISON_ETA,
                            sp3_dimer_hamiltonian, zincblende_hamiltonian)
 from .vhd_tb import (MATERIALS as VHD_MATERIALS, sp3s_star_hamiltonian,

--- a/dense_evolution/drawing.py
+++ b/dense_evolution/drawing.py
@@ -1,101 +1,10 @@
-"""
-Plain-text circuit diagrams -- the fast way to sanity-check what a
-gate-tuple list actually builds without running it, the same job
-Qiskit's `circuit.draw()` or Cirq's text diagrams do.
-
-Uses plain ASCII ('-', '|', '*') rather than Unicode box-drawing
-characters deliberately: a diagram meant to be printed to a terminal or
-written to a log file needs to survive whatever console encoding the
-caller happens to have (this was tested against, and would otherwise
-crash on, a default Windows cp1252 console).
+"""Backward-compatibility shim -- the real implementation moved to
+dense_evolution.utils.drawing as part of the Phase 2 subpackage split
+(see prog.txt). Kept so `from dense_evolution.drawing import draw_circuit`
+(used by external consumers, e.g. Dense-Evolution-Discovery) keeps working
+unchanged. Import from dense_evolution.utils.drawing directly in new code.
 """
 
-__all__ = ['draw_circuit']
+from dense_evolution.utils.drawing import draw_circuit
 
-_LABELS = {
-    'h': 'H', 'x': 'X', 'y': 'Y', 'z': 'Z', 's': 'S', 'sdg': 'Sdg',
-    't': 'T', 'tdg': 'Tdg', 'sx': 'Sx', 'id': 'I',
-    'rx': 'Rx', 'ry': 'Ry', 'rz': 'Rz', 'p': 'P', 'u1': 'P', 'phase': 'P',
-}
-_TWO_QUBIT_TARGET_SYMBOL = {'cx': 'X', 'cz': 'Z', 'cy': 'Y', 'cp': 'P', 'crz': 'Rz'}
-
-
-def draw_circuit(circuit, n_qubits):
-    """
-    Render a circuit (in the gate-tuple form run_circuit accepts) as a
-    plain-text diagram, one gate per column, one line per qubit.
-
-    Parameters
-    ----------
-    circuit : list[tuple]
-        Gate ops, as passed to `DenseSVSimulator.run_circuit`. Supports
-        every gate this package's transpiler recognizes: single-qubit
-        static and parametric gates, cx/cz/cy/cp/crz, swap, and ccx.
-    n_qubits : int
-        Number of qubit rows to draw, must be >= 1 (should cover every
-        qubit index referenced in `circuit`).
-
-    Returns
-    -------
-    str
-        Multi-line diagram, one row per qubit (``q0: --H----*--``, ...).
-        Print it, or split on '\\n' to inspect individual rows.
-
-    Examples
-    --------
-    >>> import dense_evolution as de
-    >>> print(de.draw_circuit([('h', 0), ('cx', 0, 1)], n_qubits=2))
-    q0: --H----*--
-    q1: -------X--
-    """
-    if n_qubits < 1:
-        raise ValueError(f"draw_circuit needs at least 1 qubit, got {n_qubits}")
-
-    prefixes = [f"q{q}: " for q in range(n_qubits)]
-    prefix_width = max(len(p) for p in prefixes)
-    rows = [p.ljust(prefix_width) for p in prefixes]
-
-    for op in circuit:
-        name = op[0]
-        col = {}  # qubit -> symbol to draw in this column (None = plain wire)
-
-        if name == 'swap':
-            a, b = op[1], op[2]
-            lo, hi = min(a, b), max(a, b)
-            for q in range(n_qubits):
-                col[q] = 'x' if q in (a, b) else ('|' if lo < q < hi else None)
-        elif name == 'ccx':
-            c1, c2, tgt = op[1], op[2], op[3]
-            lo, hi = min(c1, c2, tgt), max(c1, c2, tgt)
-            for q in range(n_qubits):
-                if q in (c1, c2):
-                    col[q] = '*'
-                elif q == tgt:
-                    col[q] = 'X'
-                else:
-                    col[q] = '|' if lo < q < hi else None
-        elif name in _TWO_QUBIT_TARGET_SYMBOL:
-            ctrl, tgt = op[1], op[2]
-            lo, hi = min(ctrl, tgt), max(ctrl, tgt)
-            for q in range(n_qubits):
-                if q == ctrl:
-                    col[q] = '*'
-                elif q == tgt:
-                    col[q] = _TWO_QUBIT_TARGET_SYMBOL[name]
-                else:
-                    col[q] = '|' if lo < q < hi else None
-        else:
-            q = op[1]
-            col[q] = _LABELS.get(name, name.upper())
-
-        label_width = max((len(v) for v in col.values() if v is not None), default=1)
-        seg_width = label_width + 4  # 2 filler chars on each side
-
-        for q in range(n_qubits):
-            content = col.get(q)
-            if content is None:
-                rows[q] += '-' * seg_width
-            else:
-                rows[q] += '--' + content.center(label_width) + '--'
-
-    return '\n'.join(rows)
+__all__ = ["draw_circuit"]

--- a/dense_evolution/measurement.py
+++ b/dense_evolution/measurement.py
@@ -1,94 +1,10 @@
+"""Backward-compatibility shim -- the real implementation moved to
+dense_evolution.utils.measurement as part of the Phase 2 subpackage split
+(see prog.txt). Kept so `from dense_evolution.measurement import ...`
+(used by external consumers, e.g. Dense-Evolution-Discovery) keeps working
+unchanged. Import from dense_evolution.utils.measurement directly in new code.
 """
-Measurement-related conveniences: turning a statevector into finite-shot
-counts the way real hardware and every other SDK report results (Qiskit's
-`get_counts()`, PennyLane's `qml.counts()`), and comparing two pure states
-directly without building a density matrix first.
 
-Sampling a statevector into shot counts is another pattern found
-hand-duplicated across this package's own experiment scripts -- always
-the same `rng.choice(dim, p=probs)` + `np.bincount` (or `np.unique`)
-couple of lines, rewritten fresh each time.
-"""
-import numpy as np
+from dense_evolution.utils.measurement import sample_counts, statevector_fidelity
 
-__all__ = ['sample_counts', 'statevector_fidelity']
-
-
-def sample_counts(statevector, n_shots, rng=None):
-    """
-    Simulate n_shots projective measurements of every qubit in the
-    computational basis, returning a Qiskit-style counts dict.
-
-    Parameters
-    ----------
-    statevector : array-like, shape (2**n_qubits,)
-    n_shots : int
-        Number of measurement shots to sample, must be >= 1.
-    rng : numpy.random.Generator, optional
-        A fresh `numpy.random.default_rng()` is used if not given --
-        pass one explicitly for reproducible sampling.
-
-    Returns
-    -------
-    dict[str, int]
-        Bitstring keys read left-to-right as qubit 0 upward (matching
-        DenseSVSimulator's own qubit-0-is-MSB layout and
-        pauli_expectation's string convention), each mapped to how many
-        of the n_shots samples landed on it. Only bitstrings with at
-        least one hit appear (unobserved outcomes are simply absent, as
-        in Qiskit's get_counts()).
-
-    Examples
-    --------
-    >>> import dense_evolution as de
-    >>> sim = de.DenseSVSimulator(2)
-    >>> sim.run_circuit([('h', 0), ('cx', 0, 1)])
-    >>> de.sample_counts(sim.get_statevector(), 1000)
-    {'00': 494, '11': 506}
-    """
-    statevector = np.asarray(statevector)
-    dim = statevector.shape[0]
-    n_qubits = dim.bit_length() - 1
-    if 1 << n_qubits != dim:
-        raise ValueError(f"statevector length {dim} is not a power of 2")
-    if n_shots < 1:
-        raise ValueError(f"n_shots must be >= 1, got {n_shots}")
-
-    probs = np.abs(statevector) ** 2
-    total = probs.sum()
-    if not np.isfinite(total) or total <= 0:
-        raise ValueError("statevector has zero or non-finite total probability")
-    probs = probs / total
-
-    if rng is None:
-        rng = np.random.default_rng()
-    outcomes = rng.choice(dim, size=n_shots, p=probs)
-    values, freqs = np.unique(outcomes, return_counts=True)
-
-    return {format(int(v), f'0{n_qubits}b'): int(f) for v, f in zip(values, freqs)}
-
-
-def statevector_fidelity(statevector_a, statevector_b):
-    """
-    Fidelity |<a|b>|^2 between two pure statevectors -- the cheap, direct
-    pure-state counterpart to `uhlmann_fidelity` (which compares two full
-    density matrices, needed for the mixed/noisy states that
-    `zne_density_matrix` and friends work with). Use this one whenever
-    both states are pure; it never builds an O(dim^2) density matrix.
-
-    Parameters
-    ----------
-    statevector_a, statevector_b : array-like, shape (2**n_qubits,)
-        Must have the same shape.
-
-    Returns
-    -------
-    float
-        In [0, 1] up to floating-point error. 1.0 for identical states
-        (up to global phase), 0.0 for orthogonal states.
-    """
-    a = np.asarray(statevector_a)
-    b = np.asarray(statevector_b)
-    if a.shape != b.shape:
-        raise ValueError(f"statevector shapes differ: {a.shape} vs {b.shape}")
-    return float(np.abs(np.vdot(a, b)) ** 2)
+__all__ = ["sample_counts", "statevector_fidelity"]

--- a/dense_evolution/utils/__init__.py
+++ b/dense_evolution/utils/__init__.py
@@ -1,0 +1,13 @@
+"""Utility subpackage: circuit drawing and measurement/sampling helpers.
+
+Part of the Phase 2 subpackage split (see prog.txt) -- `utils/` is the
+first subpackage moved, chosen because it has no internal dense_evolution
+dependents (leaf module), matching dynamiqs's own `core/` vs `apis/`
+split philosophy applied here as "role" grouping rather than "physics
+domain" grouping.
+"""
+
+from .drawing import draw_circuit
+from .measurement import sample_counts, statevector_fidelity
+
+__all__ = ["draw_circuit", "sample_counts", "statevector_fidelity"]

--- a/dense_evolution/utils/drawing.py
+++ b/dense_evolution/utils/drawing.py
@@ -1,0 +1,101 @@
+"""
+Plain-text circuit diagrams -- the fast way to sanity-check what a
+gate-tuple list actually builds without running it, the same job
+Qiskit's `circuit.draw()` or Cirq's text diagrams do.
+
+Uses plain ASCII ('-', '|', '*') rather than Unicode box-drawing
+characters deliberately: a diagram meant to be printed to a terminal or
+written to a log file needs to survive whatever console encoding the
+caller happens to have (this was tested against, and would otherwise
+crash on, a default Windows cp1252 console).
+"""
+
+__all__ = ['draw_circuit']
+
+_LABELS = {
+    'h': 'H', 'x': 'X', 'y': 'Y', 'z': 'Z', 's': 'S', 'sdg': 'Sdg',
+    't': 'T', 'tdg': 'Tdg', 'sx': 'Sx', 'id': 'I',
+    'rx': 'Rx', 'ry': 'Ry', 'rz': 'Rz', 'p': 'P', 'u1': 'P', 'phase': 'P',
+}
+_TWO_QUBIT_TARGET_SYMBOL = {'cx': 'X', 'cz': 'Z', 'cy': 'Y', 'cp': 'P', 'crz': 'Rz'}
+
+
+def draw_circuit(circuit, n_qubits):
+    """
+    Render a circuit (in the gate-tuple form run_circuit accepts) as a
+    plain-text diagram, one gate per column, one line per qubit.
+
+    Parameters
+    ----------
+    circuit : list[tuple]
+        Gate ops, as passed to `DenseSVSimulator.run_circuit`. Supports
+        every gate this package's transpiler recognizes: single-qubit
+        static and parametric gates, cx/cz/cy/cp/crz, swap, and ccx.
+    n_qubits : int
+        Number of qubit rows to draw, must be >= 1 (should cover every
+        qubit index referenced in `circuit`).
+
+    Returns
+    -------
+    str
+        Multi-line diagram, one row per qubit (``q0: --H----*--``, ...).
+        Print it, or split on '\\n' to inspect individual rows.
+
+    Examples
+    --------
+    >>> import dense_evolution as de
+    >>> print(de.draw_circuit([('h', 0), ('cx', 0, 1)], n_qubits=2))
+    q0: --H----*--
+    q1: -------X--
+    """
+    if n_qubits < 1:
+        raise ValueError(f"draw_circuit needs at least 1 qubit, got {n_qubits}")
+
+    prefixes = [f"q{q}: " for q in range(n_qubits)]
+    prefix_width = max(len(p) for p in prefixes)
+    rows = [p.ljust(prefix_width) for p in prefixes]
+
+    for op in circuit:
+        name = op[0]
+        col = {}  # qubit -> symbol to draw in this column (None = plain wire)
+
+        if name == 'swap':
+            a, b = op[1], op[2]
+            lo, hi = min(a, b), max(a, b)
+            for q in range(n_qubits):
+                col[q] = 'x' if q in (a, b) else ('|' if lo < q < hi else None)
+        elif name == 'ccx':
+            c1, c2, tgt = op[1], op[2], op[3]
+            lo, hi = min(c1, c2, tgt), max(c1, c2, tgt)
+            for q in range(n_qubits):
+                if q in (c1, c2):
+                    col[q] = '*'
+                elif q == tgt:
+                    col[q] = 'X'
+                else:
+                    col[q] = '|' if lo < q < hi else None
+        elif name in _TWO_QUBIT_TARGET_SYMBOL:
+            ctrl, tgt = op[1], op[2]
+            lo, hi = min(ctrl, tgt), max(ctrl, tgt)
+            for q in range(n_qubits):
+                if q == ctrl:
+                    col[q] = '*'
+                elif q == tgt:
+                    col[q] = _TWO_QUBIT_TARGET_SYMBOL[name]
+                else:
+                    col[q] = '|' if lo < q < hi else None
+        else:
+            q = op[1]
+            col[q] = _LABELS.get(name, name.upper())
+
+        label_width = max((len(v) for v in col.values() if v is not None), default=1)
+        seg_width = label_width + 4  # 2 filler chars on each side
+
+        for q in range(n_qubits):
+            content = col.get(q)
+            if content is None:
+                rows[q] += '-' * seg_width
+            else:
+                rows[q] += '--' + content.center(label_width) + '--'
+
+    return '\n'.join(rows)

--- a/dense_evolution/utils/measurement.py
+++ b/dense_evolution/utils/measurement.py
@@ -1,0 +1,94 @@
+"""
+Measurement-related conveniences: turning a statevector into finite-shot
+counts the way real hardware and every other SDK report results (Qiskit's
+`get_counts()`, PennyLane's `qml.counts()`), and comparing two pure states
+directly without building a density matrix first.
+
+Sampling a statevector into shot counts is another pattern found
+hand-duplicated across this package's own experiment scripts -- always
+the same `rng.choice(dim, p=probs)` + `np.bincount` (or `np.unique`)
+couple of lines, rewritten fresh each time.
+"""
+import numpy as np
+
+__all__ = ['sample_counts', 'statevector_fidelity']
+
+
+def sample_counts(statevector, n_shots, rng=None):
+    """
+    Simulate n_shots projective measurements of every qubit in the
+    computational basis, returning a Qiskit-style counts dict.
+
+    Parameters
+    ----------
+    statevector : array-like, shape (2**n_qubits,)
+    n_shots : int
+        Number of measurement shots to sample, must be >= 1.
+    rng : numpy.random.Generator, optional
+        A fresh `numpy.random.default_rng()` is used if not given --
+        pass one explicitly for reproducible sampling.
+
+    Returns
+    -------
+    dict[str, int]
+        Bitstring keys read left-to-right as qubit 0 upward (matching
+        DenseSVSimulator's own qubit-0-is-MSB layout and
+        pauli_expectation's string convention), each mapped to how many
+        of the n_shots samples landed on it. Only bitstrings with at
+        least one hit appear (unobserved outcomes are simply absent, as
+        in Qiskit's get_counts()).
+
+    Examples
+    --------
+    >>> import dense_evolution as de
+    >>> sim = de.DenseSVSimulator(2)
+    >>> sim.run_circuit([('h', 0), ('cx', 0, 1)])
+    >>> de.sample_counts(sim.get_statevector(), 1000)
+    {'00': 494, '11': 506}
+    """
+    statevector = np.asarray(statevector)
+    dim = statevector.shape[0]
+    n_qubits = dim.bit_length() - 1
+    if 1 << n_qubits != dim:
+        raise ValueError(f"statevector length {dim} is not a power of 2")
+    if n_shots < 1:
+        raise ValueError(f"n_shots must be >= 1, got {n_shots}")
+
+    probs = np.abs(statevector) ** 2
+    total = probs.sum()
+    if not np.isfinite(total) or total <= 0:
+        raise ValueError("statevector has zero or non-finite total probability")
+    probs = probs / total
+
+    if rng is None:
+        rng = np.random.default_rng()
+    outcomes = rng.choice(dim, size=n_shots, p=probs)
+    values, freqs = np.unique(outcomes, return_counts=True)
+
+    return {format(int(v), f'0{n_qubits}b'): int(f) for v, f in zip(values, freqs)}
+
+
+def statevector_fidelity(statevector_a, statevector_b):
+    """
+    Fidelity |<a|b>|^2 between two pure statevectors -- the cheap, direct
+    pure-state counterpart to `uhlmann_fidelity` (which compares two full
+    density matrices, needed for the mixed/noisy states that
+    `zne_density_matrix` and friends work with). Use this one whenever
+    both states are pure; it never builds an O(dim^2) density matrix.
+
+    Parameters
+    ----------
+    statevector_a, statevector_b : array-like, shape (2**n_qubits,)
+        Must have the same shape.
+
+    Returns
+    -------
+    float
+        In [0, 1] up to floating-point error. 1.0 for identical states
+        (up to global phase), 0.0 for orthogonal states.
+    """
+    a = np.asarray(statevector_a)
+    b = np.asarray(statevector_b)
+    if a.shape != b.shape:
+        raise ValueError(f"statevector shapes differ: {a.shape} vs {b.shape}")
+    return float(np.abs(np.vdot(a, b)) ** 2)

--- a/docs/api/drawing.md
+++ b/docs/api/drawing.md
@@ -4,4 +4,4 @@ A plain-text circuit diagram -- the fast way to sanity-check what a gate-tuple l
 builds, without running it. Deliberately ASCII-only (`-`, `|`, `*`), not Unicode box-drawing, so
 a printed diagram survives any console encoding.
 
-::: dense_evolution.drawing
+::: dense_evolution.utils.drawing

--- a/docs/api/measurement.md
+++ b/docs/api/measurement.md
@@ -4,7 +4,7 @@ Turning a statevector into finite-shot counts (`sample_counts`, a Qiskit-`get_co
 equivalent), and comparing two pure states directly (`statevector_fidelity`) without building a
 density matrix first.
 
-::: dense_evolution.measurement
+::: dense_evolution.utils.measurement
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ Repository = "https://github.com/tatopenn-cell/Dense-Evolution"
 dense-evolution = "dense_evolution.cli:main"
 
 [tool.setuptools]
-packages = ["dense_evolution", "dense_evolution.native_hf", "ia_utils", "dashboard_core", "local_site", "local_site.app", "mcp_server"]
+packages = ["dense_evolution", "dense_evolution.native_hf", "dense_evolution.utils", "ia_utils", "dashboard_core", "local_site", "local_site.app", "mcp_server"]
 
 # Physical location moved under tools/ and research/ (root cleanup) --
 # import names stay exactly as-is (`import dashboard_core` etc. still


### PR DESCRIPTION
Part of #76 (library subpackage split). First subpackage moved: `utils/` (`drawing.py`, `measurement.py`), chosen as the least-dependent leaf module per the planned migration order.

- Real content now lives at `dense_evolution.utils.drawing`/`.measurement`.
- Backward-compatible shims left at the old top-level paths (`dense_evolution/drawing.py`, `dense_evolution/measurement.py`) so external consumers (e.g. Dense-Evolution-Discovery) importing `dense_evolution.drawing`/`.measurement` directly keep working unchanged — verified the shim and the new canonical path resolve to the literal same function object.
- `pyproject.toml`'s `packages` list and the `mkdocstrings` directives in `docs/api/drawing.md`/`measurement.md` updated to the new canonical location.

## Test plan
- [x] `pip install -e .` + import smoke test (new path, old shim path, identity check)
- [x] Full test suite: 12 failures, all confirmed resource-contention artifacts (5 `MemoryPressureError`, 6 that reproduce as pure test-server flakiness) — re-ran the 6 non-memory ones in isolation and got 89/89 passed, confirming they're unrelated to this change
