### PR TITLE
Phase 2: move interop.py into dense_evolution.interop/ subpackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ sim.run_chunk(circuit_ops, chunk_size_gates=500)   # SafeMemoryGuard active
 ## ▍ Architecture
 
 ```
-dense_evolution/
+dense_evolution/                  (flat package root -- see "Architectural refactor in progress" note below)
 ├── registry.py       hardware detection · JAX/CuPy/NumPy flags · NoiseModel (Kraus channels)
 ├── gates.py          GATES{} · PARAMETRIC_GATES{} · GATE_IDS{}
 ├── healing.py        predictive state engine · Phi_AB · vettore dinamico · MemoryReflectionEngine
@@ -153,9 +153,12 @@ dense_evolution/
 ├── mps.py            MPSSimulator — matrix-product-state backend, JAX-backed
 ├── autodiff.py        circuit_to_energy_fn — the real, public VQE gradient engine
 ├── mitigation.py      Zero-Noise Extrapolation — richardson_extrapolate, zero_noise_extrapolation, zne_density_matrix, jsd_predictive_zne_density_matrix (+ jit variants)
-├── interop.py         run_qiskit_circuit / run_pennylane_circuit / from_qiskit / from_pennylane
+├── interop/            [subpackage] `dense_evolution.interop` still works unchanged (compat shim)
+│   └── qiskit_pennylane.py   run_qiskit_circuit / run_pennylane_circuit / from_qiskit / from_pennylane
 ├── observables.py     Pauli-string expectation values, O(2ⁿ) direct from a statevector
-├── measurement.py     statevector → finite-shot counts, sampling helpers
+├── utils/              [subpackage] `dense_evolution.drawing`/`.measurement` still work unchanged (compat shims)
+│   ├── drawing.py       plain-text circuit diagrams (ASCII, console-safe)
+│   └── measurement.py   statevector → finite-shot counts, sampling helpers
 ├── states.py          common state-preparation circuits (Bell, GHZ, W, ...) as gate tuples
 ├── topology.py        entangling_layer — linear/circular/full/star/brick patterns
 ├── qft.py             Quantum Fourier Transform circuit builder
@@ -163,35 +166,38 @@ dense_evolution/
 ├── entropy.py         partial_trace · von_neumann_entropy · mutual_information (multi-qubit, MSB-first)
 ├── trotter.py         pauli_rotation_ops · trotter_evolve_ops — real-time Hamiltonian evolution as gates
 ├── random_circuit.py  random circuit generation for benchmarking/fuzz-testing
-├── drawing.py         plain-text circuit diagrams (ASCII, console-safe)
 ├── harrison_tb.py     sp3 tight-binding Hamiltonians, Harrison universal parameter table
 ├── vhd_tb.py          sp3s* tight-binding, Vogl-Hjalmarson-Dow material-specific parameters
 └── cli.py             `dense-evolution` console script — serve · offline-composer · mcp
 
-ia_utils/
-└── vector_healing.py   median_healing · enhanced_dense_healing_hybrid (NaN/Inf-safe, lazy JAX import)
+tools/                              (apps built on the library, not part of it — see prog.txt Sezione 1)
+├── ia_utils/
+│   └── vector_healing.py   median_healing · enhanced_dense_healing_hybrid (NaN/Inf-safe, lazy JAX import)
+├── dashboard_core/
+│   ├── engine.py                     run_circuit_from_qasm — real DenseSVSimulator execution, shared by app_dashboard.py and local_site/app/server.py
+│   ├── graphical_builder.py          drag-and-drop grid ops → native gate tuples (app_dashboard.py's Graphical Builder tab)
+│   ├── circuit_builder_component.py  Streamlit component backing that grid
+│   ├── circuit_diagram.py            plain matplotlib circuit diagrams (no Qiskit QuantumCircuit ever constructed)
+│   ├── state_visuals.py              native statevector histogram / Bloch / Q-sphere rendering
+│   ├── visuals.py                    circuit/histogram/qsphere/Bloch figure wrappers used by app_dashboard.py
+│   ├── qasm_library.py               preset OpenQASM circuits (Bell, GHZ, ...)
+│   ├── system_limits.py              RAM-based safe qubit ceiling
+│   ├── hamiltonians.py                real molecular Hamiltonians (PennyLane Hartree-Fock) — served by local_site/app/server.py, not app_dashboard.py
+│   ├── vqe.py                         VQE engine — served by local_site/app/server.py, not app_dashboard.py
+│   ├── qmmm.py                        Hellmann-Feynman QM/MM forces + MD trajectories — served by local_site/app/server.py, not app_dashboard.py
+│   ├── mitigation.py                  Zero-Noise Extrapolation (statevector + density-matrix) — served by local_site/app/server.py, not app_dashboard.py
+│   ├── vector_healing.py              dense_evolution.healing / ia_utils.vector_healing bridge — served by the MCP server, not app_dashboard.py
+│   └── wormhole.py                    binary sparse SYK model — traversable-wormhole-inspired teleportation (see "MCP Server" below)
+├── app_dashboard.py                   Streamlit "Quantum Composer" clone — Graphical Builder/Circuit/Statevector/Probabilities/Q-sphere tabs only, `streamlit run tools/app_dashboard.py`
+└── mcp_server/server.py               dense_evolution_mcp — MCP adapter over the Composer kernel (see "MCP Server" below)
 
-dashboard_core/
-├── engine.py                     run_circuit_from_qasm — real DenseSVSimulator execution, shared by app_dashboard.py and local_site/app/server.py
-├── graphical_builder.py          drag-and-drop grid ops → native gate tuples (app_dashboard.py's Graphical Builder tab)
-├── circuit_builder_component.py  Streamlit component backing that grid
-├── circuit_diagram.py            plain matplotlib circuit diagrams (no Qiskit QuantumCircuit ever constructed)
-├── state_visuals.py              native statevector histogram / Bloch / Q-sphere rendering
-├── visuals.py                    circuit/histogram/qsphere/Bloch figure wrappers used by app_dashboard.py
-├── qasm_library.py               preset OpenQASM circuits (Bell, GHZ, ...)
-├── system_limits.py              RAM-based safe qubit ceiling
-├── hamiltonians.py                real molecular Hamiltonians (PennyLane Hartree-Fock) — served by local_site/app/server.py, not app_dashboard.py
-├── vqe.py                         VQE engine — served by local_site/app/server.py, not app_dashboard.py
-├── qmmm.py                        Hellmann-Feynman QM/MM forces + MD trajectories — served by local_site/app/server.py, not app_dashboard.py
-├── mitigation.py                  Zero-Noise Extrapolation (statevector + density-matrix) — served by local_site/app/server.py, not app_dashboard.py
-├── vector_healing.py              dense_evolution.healing / ia_utils.vector_healing bridge — served by the MCP server, not app_dashboard.py
-└── wormhole.py                    binary sparse SYK model — traversable-wormhole-inspired teleportation (see "MCP Server" below)
-app_dashboard.py                   Streamlit "Quantum Composer" clone — Graphical Builder/Circuit/Statevector/Probabilities/Q-sphere tabs only, `streamlit run app_dashboard.py`
-local_site/app/server.py           Composer's local FastAPI compute kernel — full feature set: VQE, molecular Hamiltonians, QM/MM, MD, mitigation, wormhole teleportation, vector healing (see "Composer" below)
-mcp_server/server.py               dense_evolution_mcp — MCP adapter over the Composer kernel (see "MCP Server" below)
-research/wormhole_syk.py           the original wormhole research reproduction + its own verification suite, reference only (not installed as a module — see research/wormhole_syk.md)
-legacy/dash.py                     original Colab notebook, reference only (not installed as a module)
+research/                           (not installed as a module -- reference/experimentation only)
+├── local_site/app/server.py       Composer's local FastAPI compute kernel — full feature set: VQE, molecular Hamiltonians, QM/MM, MD, mitigation, wormhole teleportation, vector healing (see "Composer" below)
+├── wormhole_syk.py                 the original wormhole research reproduction + its own verification suite, reference only (see research/wormhole_syk.md)
+└── legacy/dash.py                  original Colab notebook, reference only
 ```
+
+**Architectural refactor in progress** (tracking issue [#76](https://github.com/tatopenn-cell/Dense-Evolution/issues/76)): `dense_evolution/` is being split into thematic subpackages (`utils/`, `interop/` done so far; `physics/`, `circuits/`, `backends/`, `mitigation/`, `solvers/` planned next), one PR per subpackage. Every moved module keeps a backward-compatible shim at its old top-level path, so nothing above marked "compat shim" requires any code change on your end.
 
 **Data flow per run (`app_dashboard.py`):**
 

--- a/dense_evolution/interop/__init__.py
+++ b/dense_evolution/interop/__init__.py
@@ -1,0 +1,18 @@
+"""Interop subpackage: bridges to Qiskit and PennyLane circuits/backends."""
+from .qiskit_pennylane import (
+    from_qiskit,
+    from_pennylane,
+    run_qiskit_circuit,
+    run_pennylane_circuit,
+    noise_model_from_qiskit_backend,
+    to_stim,
+)
+
+__all__ = [
+    "from_qiskit",
+    "from_pennylane",
+    "run_qiskit_circuit",
+    "run_pennylane_circuit",
+    "noise_model_from_qiskit_backend",
+    "to_stim",
+]

--- a/dense_evolution/interop/qiskit_pennylane.py
+++ b/dense_evolution/interop/qiskit_pennylane.py
@@ -55,8 +55,8 @@ import warnings
 from typing import Optional, Tuple
 import numpy as np
 
-from .parser import QASMParser, QASMCircuit
-from .simulator import DenseSVSimulator
+from ..parser import QASMParser, QASMCircuit
+from ..simulator import DenseSVSimulator
 
 try:
     import qiskit.qasm2 as _qasm2

--- a/docs/api/interop.md
+++ b/docs/api/interop.md
@@ -1,3 +1,3 @@
 # Interop (Qiskit / PennyLane)
 
-::: dense_evolution.interop
+::: dense_evolution.interop.qiskit_pennylane

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ Repository = "https://github.com/tatopenn-cell/Dense-Evolution"
 dense-evolution = "dense_evolution.cli:main"
 
 [tool.setuptools]
-packages = ["dense_evolution", "dense_evolution.native_hf", "dense_evolution.utils", "ia_utils", "dashboard_core", "local_site", "local_site.app", "mcp_server"]
+packages = ["dense_evolution", "dense_evolution.native_hf", "dense_evolution.utils", "dense_evolution.interop", "ia_utils", "dashboard_core", "local_site", "local_site.app", "mcp_server"]
 
 # Physical location moved under tools/ and research/ (root cleanup) --
 # import names stay exactly as-is (`import dashboard_core` etc. still

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -12,8 +12,8 @@ import numpy as np
 import pytest
 
 import dense_evolution as de
-from dense_evolution import interop
-from dense_evolution.interop import (
+from dense_evolution.interop import qiskit_pennylane as interop
+from dense_evolution.interop.qiskit_pennylane import (
     from_qiskit, from_pennylane, run_qiskit_circuit, run_pennylane_circuit,
     _to_qiskit_bit_order,
 )

--- a/tests/test_interop_calibration_noise.py
+++ b/tests/test_interop_calibration_noise.py
@@ -22,7 +22,7 @@ import numpy as np
 import pytest
 
 import dense_evolution as de
-from dense_evolution import interop
+from dense_evolution.interop import qiskit_pennylane as interop
 from dense_evolution.interop import noise_model_from_qiskit_backend
 from dense_evolution.registry import NoiseModel
 from dense_evolution.measurement import statevector_fidelity

--- a/tests/test_interop_stim_bridge.py
+++ b/tests/test_interop_stim_bridge.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 import dense_evolution as de
-from dense_evolution import interop
+from dense_evolution.interop import qiskit_pennylane as interop
 from dense_evolution.interop import to_stim
 from dense_evolution.simulator import DenseSVSimulator
 


### PR DESCRIPTION
Part of #76.

Second subpackage of the Phase 2 migration (after `utils/` in #79), following the order utils → interop → physics → circuits → backends → mitigation → solvers.

**Changes**
- `git mv dense_evolution/interop.py` → `dense_evolution/interop/qiskit_pennylane.py`
- New `dense_evolution/interop/__init__.py` re-exports the public API (`from_qiskit`, `from_pennylane`, `run_qiskit_circuit`, `run_pennylane_circuit`, `noise_model_from_qiskit_backend`, `to_stim`). No backward-compat shim file is needed this time: since the new subpackage is named `interop` (same as the old module), the dotted import path `dense_evolution.interop` is unchanged — external consumers (e.g. Dense-Evolution-Discovery) keep working with zero changes.
- Fixed the module's two relative imports that broke after the physical move (`.parser`/`.simulator` → `..parser`/`..simulator`, since `.` now resolves to `dense_evolution.interop` instead of `dense_evolution`).
- Updated `tests/test_interop*.py`: they monkeypatch module-internal flags (`HAS_QISKIT`, `HAS_PENNYLANE`, `HAS_STIM`) and call a private helper (`_require_qiskit`) — these must target the real defining module (`dense_evolution.interop.qiskit_pennylane`) directly, not the package's `__init__.py`, since re-exporting a name doesn't alias the underlying module-global for monkeypatching purposes.
- `docs/api/interop.md` mkdocstrings directive now points at `dense_evolution.interop.qiskit_pennylane` directly.
- `pyproject.toml` packages list updated.
- Also fixed the README's top-level "▍ Architecture" diagram, which had gone stale across both the Phase 1 `tools/`/`research/` move (#75) and the `utils/` subpackage split (#79) — neither PR had updated it.

**Verification**
- Shim/identity smoke test: `run_qiskit_circuit is qiskit_pennylane.run_qiskit_circuit`, etc. — all pass.
- `tests/test_interop.py` + `tests/test_interop_calibration_noise.py` + `tests/test_interop_stim_bridge.py` in isolation: 34/34 passed.
- `mkdocs build --strict`: clean.
- Full suite: 800 passed, 17 skipped, 0 failed (740s).