### PR TITLE
Phase 3: define explicit __all__ for dense_evolution's public API surface

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -36,3 +36,38 @@ from .circuits.trotter import pauli_rotation_ops, trotter_evolve_ops
 from .physics.qec import pauli_commutes, compute_syndrome, erasure_aware_decode
 
 __version__ = "8.1.60"
+
+__all__ = [
+    "__version__",
+    # Backends -- the compute engines
+    "DenseSVSimulator", "MPSSimulator",
+    # Circuits -- representation, parsing, compilation
+    "QASMParser", "QASMCircuit", "QuantumTranspiler",
+    "NoiseModel", "NoiseSpec", "QuantumHardwareRegistry",
+    "GATES", "PARAMETRIC_GATES", "GATE_IDS",
+    "entangling_layer", "qft",
+    "pauli_rotation_ops", "trotter_evolve_ops",
+    # Chunking / anti-OOM
+    "Chunk",
+    # Interop -- Qiskit / PennyLane / STIM bridges
+    "from_qiskit", "from_pennylane", "run_qiskit_circuit", "run_pennylane_circuit",
+    "noise_model_from_qiskit_backend", "to_stim",
+    # Solvers -- VQE/autodiff, tight-binding
+    "circuit_to_energy_fn",
+    "HARRISON_ELEMENTS", "HARRISON_ETA", "sp3_dimer_hamiltonian", "zincblende_hamiltonian",
+    "VHD_MATERIALS", "sp3s_star_hamiltonian", "direct_gap_at_gamma", "band_extrema_along_path",
+    # Mitigation -- Zero-Noise Extrapolation
+    "richardson_extrapolate", "zero_noise_extrapolation", "polynomial_extrapolate",
+    "project_to_physical", "uhlmann_fidelity", "zne_density_matrix",
+    "jsd_predictive_zne_density_matrix",
+    "richardson_extrapolate_jit", "zero_noise_extrapolation_jit",
+    "polynomial_extrapolate_jit", "uhlmann_fidelity_jit", "zne_density_matrix_jit",
+    # Physics -- states, observables, entropy, fermions, QEC
+    "ghz_state",
+    "pauli_expectation", "pauli_sum_expectation", "pauli_hamiltonian_to_matrix",
+    "partial_trace", "von_neumann_entropy", "mutual_information",
+    "majorana_pauli_terms",
+    "pauli_commutes", "compute_syndrome", "erasure_aware_decode",
+    # Utils -- drawing, measurement, random circuits
+    "draw_circuit", "sample_counts", "statevector_fidelity", "random_circuit",
+]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,29 @@
+"""
+Unit tests for dense_evolution/__init__.py's __all__ -- the explicit
+public API surface added in Phase 3 of the architectural refactor (see
+prog.txt). Nothing here tests the individual functions themselves (each
+has its own dedicated test file); this only guards the __all__ list
+itself against typos/staleness as the package evolves.
+"""
+import dense_evolution as de
+
+
+def test_all_names_resolve_and_are_not_none():
+    assert len(de.__all__) > 0
+    for name in de.__all__:
+        assert hasattr(de, name), f"__all__ lists {name!r}, but dense_evolution has no such attribute"
+        assert getattr(de, name) is not None, f"dense_evolution.{name} is None"
+
+
+def test_all_has_no_duplicates():
+    assert len(de.__all__) == len(set(de.__all__))
+
+
+def test_star_import_only_binds_all_names():
+    # `from dense_evolution import *` in a fresh namespace must bind
+    # exactly __all__, not every module-level name (submodules like
+    # `chunk`, `backends`, `circuits`, ... would otherwise leak in too).
+    ns = {}
+    exec("from dense_evolution import *", ns)
+    bound = {k for k in ns if k != "__builtins__"}
+    assert bound == set(de.__all__)


### PR DESCRIPTION
Part of #76.

Phase 3 of Sezione 1, following Phase 2's subpackage split (7 PRs, #79–#85, now fully merged).

**Changes**
- Added an explicit `__all__` to `dense_evolution/__init__.py`, listing exactly the 59 names actually re-exported via its own `from .X import Y` lines — verified programmatically via AST parsing against the real import statements (0 missing, 0 extra, 0 duplicates), not transcribed by hand.
- Without this, `from dense_evolution import *` would also leak every auto-registered submodule attribute (`backends`, `circuits`, `chunk`, `mitigation`, `physics`, `utils`, `solvers`, `interop`, `random_circuit`) as a side effect of Python's import machinery, alongside the real public API.
- New `tests/test_public_api.py` guards this going forward: every `__all__` name resolves and isn't `None` (catches typos/staleness as the package evolves), no duplicates, and `from dense_evolution import *` in a fresh namespace binds exactly `__all__`, nothing more.

**Found and flagged (not fixed, out of scope)**: a second instance of the `dense_evolution.qft` self-shadowing landmine already tracked in #76 — `dense_evolution/random_circuit.py`'s `from .random_circuit import random_circuit` has the identical module/function name collision.

**Verification**
- All 3 new tests pass.
- `mkdocs build --strict`: clean.
- Full suite: 808 passed, 17 skipped, 0 failed.