### PR TITLE
Phase 4a: update internal imports to canonical Phase-2 subpackage paths

### DIFF
--- a/research/experiments/matrix_healing_fixed_budget.py
+++ b/research/experiments/matrix_healing_fixed_budget.py
@@ -20,7 +20,7 @@ import jax.numpy as jnp
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import dense_evolution as de
-from dense_evolution.registry import NoiseModel
+from dense_evolution.circuits.registry import NoiseModel
 from dense_evolution.mitigation import (
     uhlmann_fidelity, richardson_extrapolate, project_to_physical, zne_density_matrix,
 )

--- a/research/experiments/matrix_healing_zne.py
+++ b/research/experiments/matrix_healing_zne.py
@@ -25,7 +25,7 @@ import jax.numpy as jnp
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import dense_evolution as de
-from dense_evolution.registry import NoiseModel
+from dense_evolution.circuits.registry import NoiseModel
 from dense_evolution.mitigation import uhlmann_fidelity, zne_density_matrix
 
 N_QUBITS = 2

--- a/research/experiments/matrix_healing_zne_sweep.py
+++ b/research/experiments/matrix_healing_zne_sweep.py
@@ -31,7 +31,7 @@ import jax.numpy as jnp
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import dense_evolution as de
-from dense_evolution.registry import NoiseModel
+from dense_evolution.circuits.registry import NoiseModel
 from dense_evolution.mitigation import uhlmann_fidelity, zne_density_matrix
 
 QUBIT_COUNTS = (2, 3, 4, 5)

--- a/tests/test_ia_healing.py
+++ b/tests/test_ia_healing.py
@@ -15,11 +15,14 @@ class TestEnhancedDenseHealingHybrid(unittest.TestCase):
         # a bare ModuleNotFoundError with no hint this function needed it.
         # Force a REAL ImportError (not a monkeypatched downstream
         # consequence) via builtins.__import__, matching how this failure
-        # actually happens at import time.
+        # actually happens at import time. (Phase 4: vector_healing.py now
+        # imports from the canonical dense_evolution.mitigation.healing
+        # path rather than the flat backward-compat shim -- intercept that
+        # exact name, matching what actually gets imported.)
         real_import = builtins.__import__
 
         def fake_import(name, *args, **kwargs):
-            if name == 'dense_evolution.healing':
+            if name == 'dense_evolution.mitigation.healing':
                 raise ImportError('simulated missing module')
             return real_import(name, *args, **kwargs)
 

--- a/tools/ia_utils/adversarial_vector_attack.py
+++ b/tools/ia_utils/adversarial_vector_attack.py
@@ -37,7 +37,7 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 
-from dense_evolution.healing import calculate_phi_ab, calculate_vettore_dinamico, GLOBAL_CONSTANTS
+from dense_evolution.mitigation.healing import calculate_phi_ab, calculate_vettore_dinamico, GLOBAL_CONSTANTS
 
 __all__ = ['craft_adversarial_healing_perturbation']
 

--- a/tools/ia_utils/vector_healing.py
+++ b/tools/ia_utils/vector_healing.py
@@ -90,7 +90,7 @@ def enhanced_dense_healing_hybrid(
     """
     try:
         import jax.numpy as jnp
-        from dense_evolution.healing import (
+        from dense_evolution.mitigation.healing import (
             calculate_phi_ab,
             calculate_vettore_dinamico,
             evaluate_phi_trigger,


### PR DESCRIPTION
Part of #76.

First half of Phase 4 (the "update internal imports" bullet), done as its own small PR separate from the larger `tests/` reorganization (Phase 4b), which needs its own categorization plan given its size.

**Changes**
- `tools/ia_utils/adversarial_vector_attack.py`, `tools/ia_utils/vector_healing.py`: `dense_evolution.healing` → `dense_evolution.mitigation.healing`.
- `research/experiments/matrix_healing_fixed_budget.py`, `matrix_healing_zne.py`, `matrix_healing_zne_sweep.py`: `dense_evolution.registry` → `dense_evolution.circuits.registry`. Their `dense_evolution.mitigation` imports were left unchanged — that's a real package, not a shim, since `mitigation.py`'s basename matched the subpackage name (per #84's finding).
- `tests/test_ia_healing.py`: updated the `builtins.__import__` interception test to check for the literal string `'dense_evolution.mitigation.healing'` instead of `'dense_evolution.healing'`, matching what `vector_healing.py` now actually imports — otherwise the simulated-`ImportError` test would silently stop intercepting anything.

Rationale: first-party code in this repo (`tools/`, `research/`) should use the canonical Phase-2 subpackage paths directly, reserving the backward-compat shims for external consumers (Dense-Evolution-Discovery, other PyPI users) per the policy established in #76.

**Verification**
- `tests/test_ia_healing.py`'s 9 tests pass, including the fixed interception test.
- All 3 research scripts import cleanly standalone.
- `mkdocs build --strict`: clean.
- Full suite: 802 passed, 17 skipped, 6 failed on first run — all `MemoryPressureError` (known resource-contention pattern), confirmed via isolated re-run: all 6 pass individually.