### PR TITLE
Phase 5: packaging audit + fix a comment-escaping typo from earlier PRs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,12 +154,12 @@ local_site = "research/local_site"
 # Phase 4b (see prog.txt): tests/ is now split into tests/unit/ and
 # tests/integration/, but tests/_helpers.py stays at tests/ root as shared
 # infra. Without __init__.py files (a deliberate choice -- keeps test
-# collection simple), pytest'''s default "prepend" import mode only adds
-# each test file'''s OWN directory to sys.path, which would break the bare
-# `from _helpers import probs` used by a few test files once they'''re no
+# collection simple), pytest's default "prepend" import mode only adds
+# each test file's OWN directory to sys.path, which would break the bare
+# `from _helpers import probs` used by a few test files once they're no
 # longer siblings of _helpers.py. This adds tests/ to sys.path
 # unconditionally regardless of which subdirectory the running test file
-# lives in -- pytest'''s own sanctioned mechanism for exactly this case.
+# lives in -- pytest's own sanctioned mechanism for exactly this case.
 pythonpath = ["tests"]
 
 [tool.black]

--- a/tests/unit/test_autodiff.py
+++ b/tests/unit/test_autodiff.py
@@ -18,7 +18,7 @@ def test_backward_compat_shim_autodiff_reexports_circuit_to_energy_fn():
     # dense_evolution.autodiff is the Phase 2 backward-compat shim left at
     # the old top-level path -- nothing else in this suite imports through
     # it (the tests above target dense_evolution.solvers.autodiff directly,
-    # for the HAS_JAX monkeypatch), so without this the shim'''s own lines
+    # for the HAS_JAX monkeypatch), so without this the shim's own lines
     # go uncovered and a broken shim would go undetected by CI.
     from dense_evolution.autodiff import circuit_to_energy_fn as shim_ctef
     assert shim_ctef is autodiff.circuit_to_energy_fn

--- a/tests/unit/test_entropy.py
+++ b/tests/unit/test_entropy.py
@@ -15,7 +15,7 @@ def test_backward_compat_shim_entropy_reexports_public_api():
     # the old top-level path -- nothing in this suite imports through it
     # directly (everything sources these three from the top-level
     # dense_evolution package instead, which now gets them from
-    # dense_evolution.physics.entropy), so without this the shim'''s own
+    # dense_evolution.physics.entropy), so without this the shim's own
     # lines go uncovered and a broken shim would go undetected by CI.
     from dense_evolution.entropy import partial_trace as shim_pt, von_neumann_entropy as shim_vne, mutual_information as shim_mi
     assert shim_pt is partial_trace

--- a/tests/unit/test_fermions.py
+++ b/tests/unit/test_fermions.py
@@ -15,7 +15,7 @@ def test_backward_compat_shim_fermions_reexports_majorana_pauli_terms():
     # the old top-level path -- nothing in this suite imports through it
     # directly (everything sources majorana_pauli_terms from the top-level
     # dense_evolution package instead, which now gets it from
-    # dense_evolution.physics.fermions), so without this the shim'''s own
+    # dense_evolution.physics.fermions), so without this the shim's own
     # lines go uncovered and a broken shim would go undetected by CI.
     from dense_evolution.fermions import majorana_pauli_terms as shim_mpt
     assert shim_mpt is majorana_pauli_terms

--- a/tests/unit/test_mps.py
+++ b/tests/unit/test_mps.py
@@ -24,7 +24,7 @@ def test_backward_compat_shim_mps_reexports_mpssimulator():
     # dense_evolution.mps is the Phase 2 backward-compat shim left at the
     # old top-level path -- nothing else in this suite imports through it
     # (the tests above target dense_evolution.backends.mps directly, for
-    # the private helpers), so without this the shim'''s own lines go
+    # the private helpers), so without this the shim's own lines go
     # uncovered and a broken shim would go undetected by CI.
     from dense_evolution.mps import MPSSimulator as shim_mpssimulator
     assert shim_mpssimulator is MPSSimulator

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -20,7 +20,7 @@ def test_backward_compat_shim_parser_reexports_qasmparser_and_qasmcircuit():
     # it (this file, like everything else, gets QASMParser/QASMCircuit via
     # the top-level dense_evolution package, which now sources them from
     # dense_evolution.circuits.parser directly), so without this the
-    # shim'''s own lines go uncovered and a broken shim would go undetected
+    # shim's own lines go uncovered and a broken shim would go undetected
     # by CI.
     from dense_evolution.parser import QASMParser as shim_qasmparser, QASMCircuit as shim_qasmcircuit
     assert shim_qasmparser is QASMParser


### PR DESCRIPTION
Part of #76.

Phase 5 of Sezione 1 — the last phase of the refactor plan.

**Audit findings**
1. `pyproject.toml`'s `[tool.setuptools] packages` list is complete and correct: cross-checked against `find -name __init__.py` across the whole repo, all 14 real packages (9 `dense_evolution.*` subpackages from Phase 2 + `ia_utils`, `dashboard_core`, `mcp_server`, `local_site`, `local_site.app`) are present, nothing missing.
2. Built the actual wheel (`python -m build --wheel`) and installed it into a clean venv end to end — confirmed every subpackage imports correctly from the **installed** package (not the local editable source), every backward-compat shim resolves to the identical object as its canonical counterpart (`dense_evolution.mps`/`.healing` checked explicitly via `is`), and the `dense-evolution` CLI console script works.
3. **Found and fixed a real but purely cosmetic bug**: a bash string-escaping mistake in earlier PRs (#83's shim-coverage test comments, #88's pytest `pythonpath` config comment) had inserted literal triple single-quotes (`'''s`) into 6 code comments instead of a plain apostrophe (`'s`) — fixed in `pyproject.toml` (4 instances) and `tests/unit/test_autodiff.py`, `test_entropy.py`, `test_fermions.py`, `test_mps.py`, `test_parser.py` (1 each). Carefully distinguished from the legitimate Python triple-quoted string literals in the same files (`test_parser.py` has 16 real QASM triple-quoted strings, left untouched; same for `research/legacy/dash.py`'s QASM strings).
4. `[tool.setuptools.package-data]`'s list (only 3 of 14 packages, a `["*.py"]` pattern) was found but deliberately left untouched: the wheel-build test in (2) confirms every `.py` file is already correctly included via `packages` without needing `package_data` for that purpose, so this entry appears vestigial rather than broken — not worth touching without understanding its original intent.

**This completes Phase 5, and with it all of Sezione 1 (Fasi 1–5).**

**Verification**
- Isolated tests for the 5 modified test files: 146 passed, 1 `MemoryPressureError` (known resource-contention pattern, unrelated to this comment-only change).
- Full wheel-build + clean-venv-install end-to-end check (see above).