### PR TITLE
Update citation metadata with the real v8.1.61 Zenodo DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,12 +12,12 @@ authors:
 repository-code: "https://github.com/tatopenn-cell/Dense-Evolution"
 url: "https://github.com/tatopenn-cell/Dense-Evolution"
 license: "BUSL-1.1"
-version: "8.1.60"
-doi: "10.5281/zenodo.21918045"
+version: "8.1.61"
+doi: "10.5281/zenodo.22009005"
 identifiers:
   - type: doi
     value: "10.5281/zenodo.21855643"
     description: "The concept DOI for all versions of this software."
   - type: doi
-    value: "10.5281/zenodo.21918045"
-    description: "The version-specific DOI for v8.1.60."
+    value: "10.5281/zenodo.22009005"
+    description: "The version-specific DOI for v8.1.61."

--- a/README.md
+++ b/README.md
@@ -1169,7 +1169,7 @@ If Dense-Evolution is useful in academic work, please cite it via the metadata i
 Archived on [Zenodo](https://zenodo.org/):
 
 - **Concept DOI** (always resolves to the latest version): [10.5281/zenodo.21855643](https://doi.org/10.5281/zenodo.21855643)
-- **This release (v8.1.60)**: [10.5281/zenodo.21918045](https://doi.org/10.5281/zenodo.21918045)
+- **This release (v8.1.61)**: [10.5281/zenodo.22009005](https://doi.org/10.5281/zenodo.22009005)
 
 ---
 


### PR DESCRIPTION
Zenodo auto-archived the v8.1.61 GitHub release: `10.5281/zenodo.22009005`, published 2026-08-19, confirmed live via the DOI resolver.

Updates `CITATION.cff`'s `version`/`doi`/`identifiers` and README's "This release" DOI line to match. The concept DOI (`10.5281/zenodo.21855643`, always resolves to the latest version) is unchanged. Historical changelog DOI mentions (v8.1.54, v8.1.60) are left untouched, same policy as every other historical reference this session.

Metadata-only change, no functional code touched.