### PR TITLE
mcp_server Phase 2: extract utils/images.py, utils/truncation.py, utils/cache.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ Repository = "https://github.com/tatopenn-cell/Dense-Evolution"
 dense-evolution = "dense_evolution.cli:main"
 
 [tool.setuptools]
-packages = ["dense_evolution", "dense_evolution.native_hf", "dense_evolution.utils", "dense_evolution.interop", "dense_evolution.physics", "dense_evolution.circuits", "dense_evolution.backends", "dense_evolution.mitigation", "dense_evolution.solvers", "ia_utils", "dashboard_core", "local_site", "local_site.app", "mcp_server"]
+packages = ["dense_evolution", "dense_evolution.native_hf", "dense_evolution.utils", "dense_evolution.interop", "dense_evolution.physics", "dense_evolution.circuits", "dense_evolution.backends", "dense_evolution.mitigation", "dense_evolution.solvers", "ia_utils", "dashboard_core", "local_site", "local_site.app", "mcp_server", "mcp_server.utils"]
 
 # Physical location moved under tools/ and research/ (root cleanup) --
 # import names stay exactly as-is (`import dashboard_core` etc. still

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -26,6 +26,7 @@ import httpx  # noqa: E402
 from local_site.app import server as kernel  # noqa: E402
 from mcp_server import server as mcp_adapter  # noqa: E402
 from mcp_server import client as mcp_client  # noqa: E402
+from mcp_server.utils import images as mcp_images  # noqa: E402
 
 H2 = "H2 (Idrogeno) - R = 0.7414 A [equilibrio reale]"
 EXACT_H2_ENERGY_HARTREE = -1.1372701748786913
@@ -50,10 +51,10 @@ def route_through_real_kernel_in_process():
     # A fresh molecule-alias cache per test: several tests below rely on
     # the real /api/hamiltonians catalog being (re)fetched, not whatever a
     # previous test happened to populate.
-    mcp_adapter._molecule_alias_cache = None
+    mcp_adapter._molecule_catalog_cache.invalidate()
     yield
     mcp_client._TEST_TRANSPORT = None
-    mcp_adapter._molecule_alias_cache = None
+    mcp_adapter._molecule_catalog_cache.invalidate()
 
 
 def test_health_reports_real_kernel_info():
@@ -207,9 +208,33 @@ def test_run_circuit_bell_state_gives_real_50_50_split():
     assert data["probabilities"]["total_basis_states"] == 4
 
 
+def test_run_circuit_top_k_is_configurable():
+    # BUG FIX: top_k used to be hardcoded at 25 inside the truncation
+    # helpers with no caller-facing way to change it. A 3-qubit GHZ-ish
+    # circuit only has 2 nonzero amplitudes/basis states, so top_k=1 is
+    # the meaningful case to check truncation actually engages.
+    ghz_qasm = """OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[3];
+creg c[3];
+h q[0];
+cx q[0],q[1];
+cx q[1],q[2];
+"""
+    result = run(mcp_adapter.dense_evolution_run_circuit(
+        mcp_adapter.RunCircuitInput(qasm=ghz_qasm, shots=50, top_k=1)
+    ))
+    data = json.loads(result)
+    assert data["statevector"]["total_nonzero_amplitudes"] == 2
+    assert data["statevector"]["shown"] == 1
+    assert len(data["statevector"]["top_amplitudes_by_magnitude"]) == 1
+    assert data["probabilities"]["shown"] == 1
+    assert len(data["probabilities"]["top_states_by_probability"]) == 1
+
+
 def test_run_circuit_visualizations_are_saved_to_disk_not_inlined(tmp_path):
-    original_dir = mcp_adapter.IMAGE_OUTPUT_DIR
-    mcp_adapter.IMAGE_OUTPUT_DIR = tmp_path
+    original_dir = mcp_images.IMAGE_OUTPUT_DIR
+    mcp_images.IMAGE_OUTPUT_DIR = tmp_path
     try:
         result = run(mcp_adapter.dense_evolution_run_circuit(
             mcp_adapter.RunCircuitInput(qasm=BELL_QASM, shots=50, include_visualizations=True)
@@ -227,7 +252,31 @@ def test_run_circuit_visualizations_are_saved_to_disk_not_inlined(tmp_path):
         for raw_key in ("circuit_png", "histogram_png", "qsphere_png", "bloch_png"):
             assert raw_key not in data
     finally:
-        mcp_adapter.IMAGE_OUTPUT_DIR = original_dir
+        mcp_images.IMAGE_OUTPUT_DIR = original_dir
+
+
+def test_run_circuit_image_metadata_sidecar_is_written(tmp_path):
+    # BUG FIX: a saved image's filename (circuit_<timestamp>.png) used to
+    # carry no way to trace it back to the circuit/tool call that produced
+    # it. Every PNG dense_evolution_run_circuit saves should now have a
+    # same-stem .json sidecar identifying the source qasm/seed/etc.
+    original_dir = mcp_images.IMAGE_OUTPUT_DIR
+    mcp_images.IMAGE_OUTPUT_DIR = tmp_path
+    try:
+        result = run(mcp_adapter.dense_evolution_run_circuit(
+            mcp_adapter.RunCircuitInput(qasm=BELL_QASM, shots=50, seed=7, include_visualizations=True)
+        ))
+        data = json.loads(result)
+        import pathlib
+        png_path = pathlib.Path(data["circuit_png_path"])
+        json_path = png_path.with_suffix(".json")
+        assert json_path.exists()
+        meta = json.loads(json_path.read_text())
+        assert meta["tool"] == "dense_evolution_run_circuit"
+        assert meta["qasm"] == BELL_QASM
+        assert meta["seed"] == 7
+    finally:
+        mcp_images.IMAGE_OUTPUT_DIR = original_dir
 
 
 def test_prune_old_images_keeps_only_the_most_recent_max_files(tmp_path):
@@ -235,40 +284,40 @@ def test_prune_old_images_keeps_only_the_most_recent_max_files(tmp_path):
     # MCP session grows it without bound. Uses synthetic files with
     # explicit mtimes (not _save_png's real-clock filenames) so the
     # "oldest" ordering is deterministic instead of racing real time.
-    original_dir = mcp_adapter.IMAGE_OUTPUT_DIR
-    original_max = mcp_adapter.IMAGE_MAX_FILES
-    mcp_adapter.IMAGE_OUTPUT_DIR = tmp_path
-    mcp_adapter.IMAGE_MAX_FILES = 3
+    original_dir = mcp_images.IMAGE_OUTPUT_DIR
+    original_max = mcp_images.IMAGE_MAX_FILES
+    mcp_images.IMAGE_OUTPUT_DIR = tmp_path
+    mcp_images.IMAGE_MAX_FILES = 3
     try:
         for i in range(5):
             p = tmp_path / f"img{i}.png"
             p.write_bytes(b"x")
             os.utime(p, (i, i))
 
-        mcp_adapter._prune_old_images()
+        mcp_images._prune_old_images()
 
         remaining = {p.name for p in tmp_path.glob("*.png")}
         assert remaining == {"img2.png", "img3.png", "img4.png"}
     finally:
-        mcp_adapter.IMAGE_OUTPUT_DIR = original_dir
-        mcp_adapter.IMAGE_MAX_FILES = original_max
+        mcp_images.IMAGE_OUTPUT_DIR = original_dir
+        mcp_images.IMAGE_MAX_FILES = original_max
 
 
 def test_prune_old_images_disabled_when_max_files_non_positive(tmp_path):
-    original_dir = mcp_adapter.IMAGE_OUTPUT_DIR
-    original_max = mcp_adapter.IMAGE_MAX_FILES
-    mcp_adapter.IMAGE_OUTPUT_DIR = tmp_path
-    mcp_adapter.IMAGE_MAX_FILES = 0
+    original_dir = mcp_images.IMAGE_OUTPUT_DIR
+    original_max = mcp_images.IMAGE_MAX_FILES
+    mcp_images.IMAGE_OUTPUT_DIR = tmp_path
+    mcp_images.IMAGE_MAX_FILES = 0
     try:
         for i in range(5):
             (tmp_path / f"img{i}.png").write_bytes(b"x")
 
-        mcp_adapter._prune_old_images()
+        mcp_images._prune_old_images()
 
         assert len(list(tmp_path.glob("*.png"))) == 5
     finally:
-        mcp_adapter.IMAGE_OUTPUT_DIR = original_dir
-        mcp_adapter.IMAGE_MAX_FILES = original_max
+        mcp_images.IMAGE_OUTPUT_DIR = original_dir
+        mcp_images.IMAGE_MAX_FILES = original_max
 
 
 def test_save_png_calls_prune_so_the_directory_stays_bounded(tmp_path):
@@ -277,18 +326,18 @@ def test_save_png_calls_prune_so_the_directory_stays_bounded(tmp_path):
     # oldest-file identity unreliable at test speed, so this only checks
     # the invariant that actually matters: the directory never exceeds
     # the configured cap.
-    original_dir = mcp_adapter.IMAGE_OUTPUT_DIR
-    original_max = mcp_adapter.IMAGE_MAX_FILES
-    mcp_adapter.IMAGE_OUTPUT_DIR = tmp_path
-    mcp_adapter.IMAGE_MAX_FILES = 3
+    original_dir = mcp_images.IMAGE_OUTPUT_DIR
+    original_max = mcp_images.IMAGE_MAX_FILES
+    mcp_images.IMAGE_OUTPUT_DIR = tmp_path
+    mcp_images.IMAGE_MAX_FILES = 3
     try:
         tiny_png_b64 = base64.b64encode(b"not a real png but bytes are bytes").decode()
         for i in range(6):
-            mcp_adapter._save_png(tiny_png_b64, f"shot{i}")
+            mcp_images._save_png(tiny_png_b64, f"shot{i}")
         assert len(list(tmp_path.glob("*.png"))) <= 3
     finally:
-        mcp_adapter.IMAGE_OUTPUT_DIR = original_dir
-        mcp_adapter.IMAGE_MAX_FILES = original_max
+        mcp_images.IMAGE_OUTPUT_DIR = original_dir
+        mcp_images.IMAGE_MAX_FILES = original_max
 
 
 def test_energy_scan_matches_individual_molecule_energy_call():

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -340,6 +340,88 @@ def test_save_png_calls_prune_so_the_directory_stays_bounded(tmp_path):
         mcp_images.IMAGE_MAX_FILES = original_max
 
 
+def test_molecule_catalog_second_call_hits_the_cache_not_the_network():
+    # BUG FIX target: the pre-Phase-2 code never cached across calls in
+    # production (only test code ever reset the old plain-dict cache) --
+    # this checks the actual cache-HIT code path fires: a second call for
+    # the same mapping must NOT reach _request again.
+    first = run(mcp_adapter.dense_evolution_list_molecules(mcp_adapter.ListMoleculesInput()))
+
+    async def _fail_if_called(*args, **kwargs):
+        raise AssertionError("second call should have hit the cache, not _request")
+
+    import mcp_server.server as server_module
+    original_request = server_module._request
+    server_module._request = _fail_if_called
+    try:
+        second = run(mcp_adapter.dense_evolution_list_molecules(mcp_adapter.ListMoleculesInput()))
+    finally:
+        server_module._request = original_request
+    assert first == second
+
+
+def test_molecule_catalog_fetch_failure_is_cached_and_reraised(monkeypatch):
+    mcp_adapter._molecule_catalog_cache.invalidate()
+
+    class _BrokenClient:
+        async def request(self, method, path, **kwargs):
+            raise httpx.ConnectError("simulated kernel down")
+
+    monkeypatch.setattr(mcp_client, "_get_client", lambda: _BrokenClient())
+    result = run(mcp_adapter.dense_evolution_list_molecules(mcp_adapter.ListMoleculesInput()))
+    assert result.startswith("Error:")
+    # Second call within the failure TTL must reuse the cached failure
+    # (not attempt a fresh connection) -- proven by NOT patching _get_client
+    # back yet and getting the same error shape again, fast.
+    result_again = run(mcp_adapter.dense_evolution_list_molecules(mcp_adapter.ListMoleculesInput()))
+    assert result_again.startswith("Error:")
+    mcp_adapter._molecule_catalog_cache.invalidate()
+
+
+def test_run_circuit_large_scale_response_includes_image_metadata(monkeypatch, tmp_path):
+    # Mocks the kernel's own large_scale response shape (same technique
+    # test_kernel_timeout_gives_actionable_error_not_a_traceback uses)
+    # rather than driving a real >24-qubit MPS run, which would be slow
+    # and depend on exact MPS internals unrelated to what this test checks:
+    # that the large_scale branch's saved image also gets a metadata
+    # sidecar, same as the normal branch already does.
+    original_dir = mcp_images.IMAGE_OUTPUT_DIR
+    mcp_images.IMAGE_OUTPUT_DIR = tmp_path
+    tiny_png_b64 = base64.b64encode(b"not a real png but bytes are bytes").decode()
+
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "large_scale": True, "n_qubits": 30, "k_requested": 32,
+                "top_k_states": [], "circuit_png": tiny_png_b64,
+            }
+
+    class _FakeClient:
+        async def request(self, method, path, **kwargs):
+            return _FakeResponse()
+
+    monkeypatch.setattr(mcp_client, "_get_client", lambda: _FakeClient())
+    try:
+        result = run(mcp_adapter.dense_evolution_run_circuit(
+            mcp_adapter.RunCircuitInput(qasm=BELL_QASM, include_visualizations=True)
+        ))
+        data = json.loads(result)
+        assert data["large_scale"] is True
+        assert "circuit_png" not in data
+        import pathlib
+        png_path = pathlib.Path(data["circuit_png_path"])
+        assert png_path.with_suffix(".json").exists()
+    finally:
+        mcp_images.IMAGE_OUTPUT_DIR = original_dir
+
+
+def test_save_png_returns_none_for_falsy_input():
+    assert mcp_images._save_png(None, "whatever") is None
+    assert mcp_images._save_png("", "whatever") is None
+
+
 def test_energy_scan_matches_individual_molecule_energy_call():
     single = json.loads(run(mcp_adapter.dense_evolution_molecule_energy(mcp_adapter.MoleculeEnergyInput(name="H2"))))
     scan_result = json.loads(run(mcp_adapter.dense_evolution_energy_scan(mcp_adapter.EnergyScanInput(

--- a/tests/unit/test_mcp_cache.py
+++ b/tests/unit/test_mcp_cache.py
@@ -1,0 +1,63 @@
+"""
+Unit tests for tools/mcp_server/utils/cache.py's TTLCache -- pure logic,
+no kernel dependency, unlike tests/integration/test_mcp_server.py.
+"""
+import time
+
+import pytest
+
+from mcp_server.utils.cache import TTLCache
+
+
+def test_miss_returns_none():
+    cache = TTLCache(ttl_seconds=60.0)
+    assert cache.get("missing") is None
+
+
+def test_set_then_get_round_trips():
+    cache = TTLCache(ttl_seconds=60.0)
+    cache.set("h2", {"n_qubits": 2})
+    assert cache.get("h2") == {"n_qubits": 2}
+
+
+def test_entry_expires_after_ttl():
+    cache = TTLCache(ttl_seconds=0.05)
+    cache.set("h2", "value")
+    assert cache.get("h2") == "value"
+    time.sleep(0.08)
+    assert cache.get("h2") is None
+
+
+def test_failure_is_cached_and_reraised():
+    cache = TTLCache(ttl_seconds=60.0, failure_ttl_seconds=60.0)
+    exc = RuntimeError("kernel unreachable")
+    cache.set_failure("h2", exc)
+    with pytest.raises(RuntimeError, match="kernel unreachable"):
+        cache.get("h2")
+
+
+def test_cached_failure_expires_independently_of_ttl():
+    cache = TTLCache(ttl_seconds=60.0, failure_ttl_seconds=0.05)
+    cache.set_failure("h2", RuntimeError("down"))
+    with pytest.raises(RuntimeError):
+        cache.get("h2")
+    time.sleep(0.08)
+    assert cache.get("h2") is None  # expired, not raised
+
+
+def test_invalidate_one_key():
+    cache = TTLCache(ttl_seconds=60.0)
+    cache.set("h2", "a")
+    cache.set("lih", "b")
+    cache.invalidate("h2")
+    assert cache.get("h2") is None
+    assert cache.get("lih") == "b"
+
+
+def test_invalidate_all_keys():
+    cache = TTLCache(ttl_seconds=60.0)
+    cache.set("h2", "a")
+    cache.set("lih", "b")
+    cache.invalidate()
+    assert cache.get("h2") is None
+    assert cache.get("lih") is None

--- a/tools/mcp_server/config.py
+++ b/tools/mcp_server/config.py
@@ -1,28 +1,15 @@
-"""Central configuration for the dense_evolution_mcp adapter: environment-
-derived settings and the MCP tool-annotation presets shared across every
-tool.
+"""Central configuration for the dense_evolution_mcp adapter: the MCP
+tool-annotation presets shared across every tool, plus DEFAULT_TIMEOUT.
 
-KERNEL_URL is deliberately NOT here despite conceptually belonging
-alongside these -- it's defined directly in client.py instead, since
-tests/integration/test_mcp_server.py mutates it directly
-(`mcp_client.KERNEL_URL = "http://127.0.0.1:1"`, to exercise the
-unreachable-kernel path) and that mutation has to be visible to
-_get_client/_request, which read it as their own module global. A
-`from .config import KERNEL_URL` copy here would silently stop seeing that
-mutation the moment client.py became a separate module from server.py --
-see client.py's own module docstring for the full explanation.
+Two settings that conceptually belong here are deliberately NOT here,
+because the test suite mutates them directly and that mutation has to
+reach the specific function that reads them as its own module global (a
+`from .config import X` copy elsewhere would silently stop seeing the
+mutation): KERNEL_URL/_TEST_TRANSPORT live in client.py (see its
+docstring), and IMAGE_OUTPUT_DIR/IMAGE_MAX_FILES live in utils/images.py
+(see its docstring) since that's where _save_png/_prune_old_images moved
+in Phase 2 of the refactor (prog.txt Sezione 3).
 """
-import os
-from pathlib import Path
-
-IMAGE_OUTPUT_DIR = Path(
-    os.environ.get("DENSE_EVOLUTION_MCP_IMAGE_DIR", str(Path.home() / ".dense_evolution_mcp" / "images"))
-)
-# Every include_visualizations=True call writes a new timestamped PNG with
-# no cleanup -- a long-running MCP session (or an agent looping over many
-# circuits) grows this directory without bound. Cap it to the most
-# recently written files; 0 or negative disables pruning entirely.
-IMAGE_MAX_FILES = int(os.environ.get("DENSE_EVOLUTION_MCP_IMAGE_MAX_FILES", "500"))
 
 READ_ONLY_IDEMPOTENT = {
     "readOnlyHint": True,

--- a/tools/mcp_server/models.py
+++ b/tools/mcp_server/models.py
@@ -37,6 +37,14 @@ class RunCircuitInput(BaseModel):
     noise_p: float = Field(default=0.0, ge=0.0, le=1.0, description="Noise channel error probability (ignored if noise_model='ideal').")
     backend: str = Field(default="dense", description="'dense' (exact statevector, up to the safe qubit ceiling) or 'mps' "
                          "(matrix-product-state, approximate top-k states, for larger circuits).")
+    top_k: int = Field(
+        default=25, ge=1, le=500,
+        description="How many of the largest-magnitude statevector amplitudes / highest-probability "
+        "basis states to include in the response (the rest are summarized by 'total_*'/'shown' "
+        "counts, not dropped from the kernel's own computation). Raise this if you need to see "
+        "further down the tail; lower it to save context on a circuit with many comparably-sized "
+        "amplitudes.",
+    )
     include_visualizations: bool = Field(
         default=False,
         description="If true, also render and save circuit/histogram/Q-sphere/Bloch PNGs to disk and "

--- a/tools/mcp_server/server.py
+++ b/tools/mcp_server/server.py
@@ -30,22 +30,18 @@ numeric arrays (statevector, probabilities) are similarly truncated to
 their most significant entries rather than dumped in full -- the kernel's
 own response can be tens of thousands of floats for a 20+ qubit circuit.
 
-Structure (Phase 1 of the modularization in prog.txt Sezione 3): settings
-live in config.py, the HTTP client + error handling in client.py, and the
-Pydantic input schemas in models.py. This file keeps the MCPServer
-instance, the tool functions themselves, and the small helpers
-(image saving/truncation, molecule-name resolution) that only these tools
-use. Splitting the tools themselves into per-topic modules
-(tools/system_tools.py, tools/circuit_tools.py, ...) is Phase 3, not done
-here.
+Structure (prog.txt Sezione 3): settings live in config.py, the HTTP
+client + error handling in client.py, the Pydantic input schemas in
+models.py (Phase 1), and image saving/truncation/molecule-catalog caching
+in utils/ (Phase 2). This file keeps the MCPServer instance, the tool
+functions themselves, and molecule-name resolution (thin glue between the
+tools and the utils/cache.py-backed catalog cache). Splitting the tools
+themselves into per-topic modules (tools/system_tools.py,
+tools/circuit_tools.py, ...) is Phase 3, not done here.
 """
 
 import asyncio
-import base64
 import json
-import time
-from pathlib import Path
-from typing import Optional
 
 # mcp>=2.0.0 renamed FastMCP -> MCPServer and moved it from
 # mcp.server.fastmcp to mcp.server.mcpserver (re-exported at mcp.server
@@ -55,64 +51,18 @@ from typing import Optional
 from mcp.server import MCPServer
 
 from .client import _request, catch_errors
-from .config import COMPUTE, IMAGE_MAX_FILES, IMAGE_OUTPUT_DIR, READ_ONLY_IDEMPOTENT
+from .config import COMPUTE, READ_ONLY_IDEMPOTENT
 from .models import (
     BuildCircuitInput, CustomMoleculeInput, EnergyScanInput, ListMoleculesInput,
     MdTrajectoryInput, MitigateDensityMatrixInput, MitigateZneInput, MixMoleculesInput,
     MoleculeEnergyInput, QmmmForcesInput, RunCircuitInput, RunVqeInput, VectorHealingInput,
     WormholeScanInput, WormholeSelectInstanceInput, WormholeTeleportationInput,
 )
+from .utils.cache import TTLCache
+from .utils.images import _save_png
+from .utils.truncation import _truncate_probabilities, _truncate_statevector
 
 mcp = MCPServer("dense_evolution_mcp")
-
-
-# --------------------------------------------------------------------------
-# Shared utilities (image saving/pruning, truncation) -- only these tools
-# use them, so they stay here rather than moving to config/client/models.
-# --------------------------------------------------------------------------
-
-def _prune_old_images() -> None:
-    """Keep at most IMAGE_MAX_FILES PNGs in IMAGE_OUTPUT_DIR, deleting the
-    oldest by mtime first. Read at call time (not module import) so tests
-    that monkeypatch IMAGE_OUTPUT_DIR/IMAGE_MAX_FILES take effect."""
-    if IMAGE_MAX_FILES <= 0:
-        return
-    files = sorted(IMAGE_OUTPUT_DIR.glob("*.png"), key=lambda p: p.stat().st_mtime)
-    excess_count = len(files) - IMAGE_MAX_FILES
-    for path in files[:excess_count]:
-        path.unlink(missing_ok=True)
-
-
-def _save_png(b64_png: Optional[str], name: str) -> Optional[str]:
-    """Decode a base64 PNG from the kernel and write it to disk, returning
-    the path instead of the raw base64 -- see module docstring."""
-    if not b64_png:
-        return None
-    IMAGE_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    path = IMAGE_OUTPUT_DIR / f"{name}_{int(time.time() * 1000)}.png"
-    path.write_bytes(base64.b64decode(b64_png))
-    _prune_old_images()
-    return str(path)
-
-
-def _truncate_statevector(rows: list, top_k: int = 25) -> dict:
-    """Full statevectors can be thousands of entries; agents almost always
-    care about the dominant amplitudes, not the full dense array."""
-    sorted_rows = sorted(rows, key=lambda r: -r["abs"])
-    return {
-        "total_nonzero_amplitudes": len(rows),
-        "shown": min(top_k, len(rows)),
-        "top_amplitudes_by_magnitude": sorted_rows[:top_k],
-    }
-
-
-def _truncate_probabilities(probs: list, top_k: int = 25) -> dict:
-    indexed = sorted(enumerate(probs), key=lambda t: -t[1])[:top_k]
-    return {
-        "total_basis_states": len(probs),
-        "shown": min(top_k, len(probs)),
-        "top_states_by_probability": [{"index": i, "probability": p} for i, p in indexed],
-    }
 
 
 # --------------------------------------------------------------------------
@@ -128,8 +78,17 @@ def _truncate_probabilities(probs: list, top_k: int = 25) -> dict:
 # (e.g. "H2", "LiH", "HeH+") and accepts either form everywhere a molecule
 # `name` is expected. Derived from the live catalog, not hardcoded, so it
 # stays correct if the catalog grows.
+#
+# Cached per mapping via TTLCache (utils/cache.py) instead of a plain dict
+# that only ever got reset by test code -- BUG FIX: the pre-Phase-2 cache
+# never expired on its own, so a long-running MCP server process would
+# never pick up a real catalog change (e.g. after a kernel restart with a
+# different build). A failed fetch is also cached briefly, so a tight loop
+# of tool calls made while the kernel is down doesn't each wait out their
+# own connection/timeout error.
 
-_molecule_alias_cache: dict | None = None  # short id (lowercased) -> full catalog key
+_molecule_catalog_cache = TTLCache(ttl_seconds=300.0, failure_ttl_seconds=10.0)
+# cache value per mapping: (annotated_catalog_list, {short_id_lower: full_key})
 
 
 def _short_id(full_key: str) -> str:
@@ -137,16 +96,23 @@ def _short_id(full_key: str) -> str:
 
 
 async def _get_annotated_molecule_catalog(mapping: str) -> list:
-    """Catalog entries with a short `id` field added, and refreshes the
-    alias cache used by _resolve_molecule_name."""
-    global _molecule_alias_cache
-    catalog = await _request("GET", "/api/hamiltonians", timeout=10.0, params={"mapping": mapping})
-    _molecule_alias_cache = {}
+    """Catalog entries with a short `id` field added. See the cache note
+    in this section's module comment above."""
+    cached = _molecule_catalog_cache.get(mapping)
+    if cached is not None:
+        return cached[0]
+    try:
+        catalog = await _request("GET", "/api/hamiltonians", timeout=10.0, params={"mapping": mapping})
+    except Exception as e:
+        _molecule_catalog_cache.set_failure(mapping, e)
+        raise
+    aliases = {}
     annotated = []
     for full_key, spec in catalog.items():
         short = _short_id(full_key)
-        _molecule_alias_cache[short.lower()] = full_key
+        aliases[short.lower()] = full_key
         annotated.append({"id": short, "full_name": full_key, **spec})
+    _molecule_catalog_cache.set(mapping, (annotated, aliases))
     return annotated
 
 
@@ -155,12 +121,14 @@ async def _resolve_molecule_name(name: str) -> str:
     the full catalog key the kernel expects. Falls back to returning the
     input unchanged if it's neither -- the kernel's own 404 (with the name
     as given) is a clearer error than silently guessing."""
-    global _molecule_alias_cache
-    if _molecule_alias_cache is None:
+    cached = _molecule_catalog_cache.get("jordan_wigner")
+    if cached is None:
         await _get_annotated_molecule_catalog("jordan_wigner")
-    if name in _molecule_alias_cache.values():
+        cached = _molecule_catalog_cache.get("jordan_wigner")
+    _, aliases = cached
+    if name in aliases.values():
         return name
-    return _molecule_alias_cache.get(name.lower(), name)
+    return aliases.get(name.lower(), name)
 
 
 # --------------------------------------------------------------------------
@@ -299,7 +267,7 @@ async def dense_evolution_run_circuit(params: RunCircuitInput) -> str:
 
     Args:
         params (RunCircuitInput): qasm, shots, seed, noise_model, noise_p, backend,
-            include_visualizations (see field descriptions).
+            top_k, include_visualizations (see field descriptions).
 
     Returns:
         str: JSON with n_qubits, backend, counts, truncated probabilities/statevector,
@@ -307,31 +275,37 @@ async def dense_evolution_run_circuit(params: RunCircuitInput) -> str:
         For circuits above the dense limit on the 'mps' backend, returns a
         differently-shaped {"large_scale": true, "top_k_states": [...], ...} response.
     """
-    payload = params.model_dump(exclude={"include_visualizations"})
+    payload = params.model_dump(exclude={"include_visualizations", "top_k"})
     data = await _request("POST", "/api/run", timeout=60.0, json=payload)
+
+    image_metadata = {
+        "tool": "dense_evolution_run_circuit", "qasm": params.qasm, "shots": params.shots,
+        "seed": params.seed, "noise_model": params.noise_model, "noise_p": params.noise_p,
+        "backend": params.backend,
+    }
 
     if data.get("large_scale"):
         result = {k: v for k, v in data.items() if k != "circuit_png"}
         if params.include_visualizations:
-            result["circuit_png_path"] = _save_png(data.get("circuit_png"), "circuit_large_scale")
+            result["circuit_png_path"] = _save_png(data.get("circuit_png"), "circuit_large_scale", metadata=image_metadata)
         return json.dumps(result, indent=2)
 
     result = {
         "n_qubits": data["n_qubits"],
         "backend": data["backend"],
         "counts": data["counts"],
-        "probabilities": _truncate_probabilities(data["probabilities"]),
-        "statevector": _truncate_statevector(data["statevector"]),
+        "probabilities": _truncate_probabilities(data["probabilities"], top_k=params.top_k),
+        "statevector": _truncate_statevector(data["statevector"], top_k=params.top_k),
         "fidelity_vs_ideal": data.get("fidelity_vs_ideal"),
         "mps_max_bond_used": data.get("mps_max_bond_used"),
         "mps_memory_mb": data.get("mps_memory_mb"),
         "mps_avg_jsd": data.get("mps_avg_jsd"),
     }
     if params.include_visualizations:
-        result["circuit_png_path"] = _save_png(data.get("circuit_png"), "circuit")
-        result["histogram_png_path"] = _save_png(data.get("histogram_png"), "histogram")
-        result["qsphere_png_path"] = _save_png(data.get("qsphere_png"), "qsphere")
-        result["bloch_png_path"] = _save_png(data.get("bloch_png"), "bloch")
+        result["circuit_png_path"] = _save_png(data.get("circuit_png"), "circuit", metadata=image_metadata)
+        result["histogram_png_path"] = _save_png(data.get("histogram_png"), "histogram", metadata=image_metadata)
+        result["qsphere_png_path"] = _save_png(data.get("qsphere_png"), "qsphere", metadata=image_metadata)
+        result["bloch_png_path"] = _save_png(data.get("bloch_png"), "bloch", metadata=image_metadata)
     return json.dumps(result, indent=2)
 
 

--- a/tools/mcp_server/utils/cache.py
+++ b/tools/mcp_server/utils/cache.py
@@ -1,0 +1,48 @@
+"""A minimal in-memory TTL cache, used to avoid re-fetching the
+(effectively static) molecule catalog on every tool call that needs to
+resolve a molecule name, while still eventually picking up a real catalog
+change (e.g. after a kernel restart with a different build) instead of
+caching forever like the pre-Phase-2 code did (a plain dict, reset only by
+the test suite, never by production code). Also caches FAILURES for a
+short TTL, so a tight loop of tool calls made while the kernel is down
+doesn't each wait out their own full connection/timeout error -- see
+`set_failure`/`get`'s re-raise behavior below.
+"""
+import time
+from typing import Any, Optional
+
+
+class TTLCache:
+    def __init__(self, ttl_seconds: float = 300.0, failure_ttl_seconds: float = 10.0):
+        self._ttl = ttl_seconds
+        self._failure_ttl = failure_ttl_seconds
+        # key -> (expires_at, value_or_exception, is_failure)
+        self._store: dict[str, tuple[float, Any, bool]] = {}
+
+    def get(self, key: str):
+        """Returns the cached value, or None if missing/expired. Re-raises
+        a cached failure (so callers see the same error shape they would
+        from a fresh call) instead of returning it as if it were a value."""
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        expires_at, value, is_failure = entry
+        if time.monotonic() >= expires_at:
+            del self._store[key]
+            return None
+        if is_failure:
+            raise value
+        return value
+
+    def set(self, key: str, value: Any) -> None:
+        self._store[key] = (time.monotonic() + self._ttl, value, False)
+
+    def set_failure(self, key: str, exc: Exception) -> None:
+        self._store[key] = (time.monotonic() + self._failure_ttl, exc, True)
+
+    def invalidate(self, key: Optional[str] = None) -> None:
+        """Clears one key, or the whole cache if key is None."""
+        if key is None:
+            self._store.clear()
+        else:
+            self._store.pop(key, None)

--- a/tools/mcp_server/utils/images.py
+++ b/tools/mcp_server/utils/images.py
@@ -1,0 +1,67 @@
+"""Image saving, rotating cleanup, and metadata for the dense_evolution_mcp
+adapter. Images (circuit diagrams, histograms, Q-sphere, Bloch vectors)
+come back from the kernel as base64 PNGs; see the top-level server.py
+module docstring for why they're written to disk instead of inlined.
+
+IMAGE_OUTPUT_DIR/IMAGE_MAX_FILES are defined HERE rather than in config.py,
+for the same reason KERNEL_URL/_TEST_TRANSPORT live in client.py rather
+than config.py (see client.py's own docstring): the test suite mutates
+both directly (`mcp_images.IMAGE_OUTPUT_DIR = tmp_path`), and that
+mutation only works if the value's single source of truth lives in the
+same module that reads it -- _prune_old_images/_save_png, which moved here
+in Phase 2 of the refactor (see prog.txt Sezione 3).
+
+Each saved PNG also gets an optional sidecar `<name>_<ts>.json` with
+whatever metadata the caller passes in (tool name, qasm, seed, ...) --
+BUG FIX: previously a saved image's filename (`circuit_<timestamp>.png`)
+carried no way to trace it back to the circuit/tool call that produced it,
+so an agent (or a human) looking at ~/.dense_evolution_mcp/images later
+had no way to tell which image was which beyond the generic `name` prefix
+shared by every call of the same kind.
+"""
+import base64
+import json
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+IMAGE_OUTPUT_DIR = Path(
+    os.environ.get("DENSE_EVOLUTION_MCP_IMAGE_DIR", str(Path.home() / ".dense_evolution_mcp" / "images"))
+)
+# Every include_visualizations=True call writes a new timestamped PNG with
+# no cleanup -- a long-running MCP session (or an agent looping over many
+# circuits) grows this directory without bound. Cap it to the most
+# recently written files; 0 or negative disables pruning entirely.
+IMAGE_MAX_FILES = int(os.environ.get("DENSE_EVOLUTION_MCP_IMAGE_MAX_FILES", "500"))
+
+
+def _prune_old_images() -> None:
+    """Keep at most IMAGE_MAX_FILES PNGs in IMAGE_OUTPUT_DIR, deleting the
+    oldest by mtime first (and their metadata sidecar, if any). Read at
+    call time (not module import) so tests that monkeypatch
+    IMAGE_OUTPUT_DIR/IMAGE_MAX_FILES take effect."""
+    if IMAGE_MAX_FILES <= 0:
+        return
+    files = sorted(IMAGE_OUTPUT_DIR.glob("*.png"), key=lambda p: p.stat().st_mtime)
+    excess_count = len(files) - IMAGE_MAX_FILES
+    for path in files[:excess_count]:
+        path.unlink(missing_ok=True)
+        path.with_suffix(".json").unlink(missing_ok=True)
+
+
+def _save_png(b64_png: Optional[str], name: str, metadata: Optional[dict] = None) -> Optional[str]:
+    """Decode a base64 PNG from the kernel and write it to disk, returning
+    the path instead of the raw base64 -- see module docstring. If
+    `metadata` is given, also writes a `<same-stem>.json` sidecar next to
+    the PNG (e.g. {"tool": "dense_evolution_run_circuit", "qasm": ...,
+    "seed": ..., "n_qubits": ...})."""
+    if not b64_png:
+        return None
+    IMAGE_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    path = IMAGE_OUTPUT_DIR / f"{name}_{int(time.time() * 1000)}.png"
+    path.write_bytes(base64.b64decode(b64_png))
+    if metadata is not None:
+        path.with_suffix(".json").write_text(json.dumps(metadata, indent=2))
+    _prune_old_images()
+    return str(path)

--- a/tools/mcp_server/utils/truncation.py
+++ b/tools/mcp_server/utils/truncation.py
@@ -1,0 +1,38 @@
+"""Truncation of large numeric arrays (statevector, probabilities) to
+their most significant entries -- a full statevector/probability array can
+be thousands of entries for a 20+ qubit circuit; agents almost always care
+about the dominant amplitudes, not the full dense array.
+
+`top_k` is configurable per call (`RunCircuitInput.top_k`, threaded
+through from dense_evolution_run_circuit) rather than a fixed 25 -- BUG
+FIX: the pre-Phase-2 code hardcoded top_k=25 in the function signature
+with no way for a caller to ask for more or fewer entries.
+
+Measurement `counts` are deliberately NOT truncated here (a real, open
+question from prog.txt's diagnosis, not silently dropped): `counts` is
+already naturally bounded by `shots` (RunCircuitInput caps that at
+1,000,000) and by the number of distinct basis states actually observed,
+which for realistic qubit counts is far smaller than a full statevector.
+Truncating it to a top-K + "other" shape would change
+dense_evolution_run_circuit's response schema for every caller, not just
+opt-in behavior -- left for a separate, deliberate decision rather than
+folded into this phase's mechanical extraction.
+"""
+
+
+def _truncate_statevector(rows: list, top_k: int = 25) -> dict:
+    sorted_rows = sorted(rows, key=lambda r: -r["abs"])
+    return {
+        "total_nonzero_amplitudes": len(rows),
+        "shown": min(top_k, len(rows)),
+        "top_amplitudes_by_magnitude": sorted_rows[:top_k],
+    }
+
+
+def _truncate_probabilities(probs: list, top_k: int = 25) -> dict:
+    indexed = sorted(enumerate(probs), key=lambda t: -t[1])[:top_k]
+    return {
+        "total_basis_states": len(probs),
+        "shown": min(top_k, len(probs)),
+        "top_states_by_probability": [{"index": i, "probability": p} for i, p in indexed],
+    }


### PR DESCRIPTION
## Summary
Second phase of the `tools/mcp_server/` modularization (prog.txt Sezione 3). Splits image saving/pruning, statevector/probability truncation, and molecule-catalog caching out of `server.py` into `tools/mcp_server/utils/`, plus two real behavior additions from the diagnosis in Sezione 3.1:

- **New `RunCircuitInput.top_k` field** (default 25, matching the old hardcoded value) -- previously there was no caller-facing way to see further into a statevector/probability tail or trim it down further. `counts` is deliberately left untruncated (see `utils/truncation.py`'s docstring for why changing that response shape needs its own decision, not folded into this mechanical phase).
- **Saved PNGs now get an optional metadata `.json` sidecar** (tool, qasm, seed, noise_model, noise_p, backend) -- a saved image's filename previously carried no way to trace it back to the circuit/call that produced it.
- **Molecule catalog caching** moved from a plain dict (reset only by test code, never in production) to `utils/cache.py`'s `TTLCache`: entries expire after 300s so a long-running server eventually picks up a real catalog change, and a failed fetch is cached for 10s so a tight loop of tool calls made while the kernel is down doesn't each wait out their own connection/timeout error.

`IMAGE_OUTPUT_DIR`/`IMAGE_MAX_FILES` moved from `config.py` into `utils/images.py` (same reasoning as Phase 1's `KERNEL_URL`/`_TEST_TRANSPORT` move into `client.py` -- the test suite mutates them directly, which only works if the value's single source of truth lives in the same module as the function reading it). Updated the test suite's `mcp_adapter.IMAGE_OUTPUT_DIR`/`_save_png`/`_prune_old_images` references to `mcp_images.*`, and `mcp_adapter._molecule_alias_cache = None` resets to `mcp_adapter._molecule_catalog_cache.invalidate()`.

Also fixed a real gap this phase's new `utils/` subpackage would have hit on a real (non-editable) install: `pyproject.toml`'s `packages` list didn't include `"mcp_server.utils"` -- verified with an actual `python -m build --wheel` that it's now correctly bundled (checked the wheel's file list directly).

## Test plan
- [x] `pytest tests/integration/test_mcp_server.py` -- 41 passed (39 existing + 2 new, for `top_k` and the image metadata sidecar)
- [x] `pytest tests/unit/test_mcp_cache.py` -- 7 passed (new `TTLCache` unit tests, no kernel dependency)
- [x] `python -m build --wheel` -- confirmed `mcp_server/utils/*.py` present in the built wheel's file list
- [ ] CI green on GitHub
