### PR TITLE
Sezione 4, Fase 1: matrix-free ground-state energy for large molecular Hamiltonians

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -20,7 +20,7 @@ from .mitigation.zne import (richardson_extrapolate, zero_noise_extrapolation, p
                           richardson_extrapolate_jit, zero_noise_extrapolation_jit,
                           polynomial_extrapolate_jit, uhlmann_fidelity_jit, zne_density_matrix_jit)
 from .circuits.topology import entangling_layer
-from .physics.observables import pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix
+from .physics.observables import pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix, pauli_sum_matvec
 from .physics.states import ghz_state
 from .utils.measurement import sample_counts, statevector_fidelity
 from .circuits.qft import qft
@@ -64,7 +64,7 @@ __all__ = [
     "polynomial_extrapolate_jit", "uhlmann_fidelity_jit", "zne_density_matrix_jit",
     # Physics -- states, observables, entropy, fermions, QEC
     "ghz_state",
-    "pauli_expectation", "pauli_sum_expectation", "pauli_hamiltonian_to_matrix",
+    "pauli_expectation", "pauli_sum_expectation", "pauli_hamiltonian_to_matrix", "pauli_sum_matvec",
     "partial_trace", "von_neumann_entropy", "mutual_information",
     "majorana_pauli_terms",
     "pauli_commutes", "compute_syndrome", "erasure_aware_decode",

--- a/dense_evolution/observables.py
+++ b/dense_evolution/observables.py
@@ -4,6 +4,8 @@ dense_evolution.physics.observables as part of the Phase 2 subpackage split
 (used by external consumers, e.g. Dense-Evolution-Discovery) keeps working
 unchanged. Import from dense_evolution.physics.observables directly in new code.
 """
-from dense_evolution.physics.observables import pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix
+from dense_evolution.physics.observables import (
+    pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix, pauli_sum_matvec,
+)
 
-__all__ = ['pauli_expectation', 'pauli_sum_expectation', 'pauli_hamiltonian_to_matrix']
+__all__ = ['pauli_expectation', 'pauli_sum_expectation', 'pauli_hamiltonian_to_matrix', 'pauli_sum_matvec']

--- a/dense_evolution/physics/__init__.py
+++ b/dense_evolution/physics/__init__.py
@@ -1,13 +1,13 @@
 """Physics subpackage: state preparation, observables, entropy, fermions, QEC."""
 from .states import ghz_state
-from .observables import pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix
+from .observables import pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix, pauli_sum_matvec
 from .entropy import partial_trace, von_neumann_entropy, mutual_information
 from .fermions import majorana_pauli_terms
 from .qec import pauli_commutes, compute_syndrome, erasure_aware_decode
 
 __all__ = [
     "ghz_state",
-    "pauli_expectation", "pauli_sum_expectation", "pauli_hamiltonian_to_matrix",
+    "pauli_expectation", "pauli_sum_expectation", "pauli_hamiltonian_to_matrix", "pauli_sum_matvec",
     "partial_trace", "von_neumann_entropy", "mutual_information",
     "majorana_pauli_terms",
     "pauli_commutes", "compute_syndrome", "erasure_aware_decode",

--- a/dense_evolution/physics/observables.py
+++ b/dense_evolution/physics/observables.py
@@ -20,7 +20,10 @@ of this internal bit-position detail.
 """
 import numpy as np
 
-__all__ = ['pauli_expectation', 'pauli_sum_expectation', 'pauli_hamiltonian_to_matrix']
+__all__ = [
+    'pauli_expectation', 'pauli_sum_expectation', 'pauli_hamiltonian_to_matrix',
+    'pauli_sum_matvec',
+]
 
 _PAULI_MATRICES = {
     'I': np.eye(2, dtype=np.complex128),
@@ -53,6 +56,40 @@ def _normalize_terms(pauli_terms, n_qubits=None):
         if q < 0:
             raise ValueError(f"qubit index {q} must be >= 0")
     return terms
+
+
+def _apply_pauli_term(statevector, terms, inferred_n_qubits):
+    """P|psi> for a single already-normalized Pauli term (terms: plain
+    dict {qubit: 'X'|'Y'|'Z'}, identity qubits already dropped), computed
+    in O(dim) via the same flip-mask/phase technique pauli_expectation
+    uses -- factored out here so both pauli_expectation (which reduces
+    this to a scalar via vdot) and pauli_sum_matvec (which needs the
+    vector itself, not a scalar) share one tested implementation instead
+    of two copies of the same bit-twiddling."""
+    if not terms:
+        return statevector
+
+    def bit_pos(q):
+        return inferred_n_qubits - 1 - q
+
+    flip_mask = 0
+    for q, p in terms.items():
+        if p in ('X', 'Y'):
+            flip_mask |= (1 << bit_pos(q))
+
+    dim = statevector.shape[0]
+    indices = np.arange(dim)
+    source_idx = indices ^ flip_mask
+
+    coeff = np.ones(dim, dtype=np.complex128)
+    for q, p in terms.items():
+        bit = (source_idx >> bit_pos(q)) & 1
+        if p == 'Y':
+            coeff = coeff * np.where(bit == 0, 1j, -1j)
+        elif p == 'Z':
+            coeff = coeff * np.where(bit == 0, 1.0, -1.0)
+
+    return statevector[source_idx] * coeff
 
 
 def pauli_expectation(statevector, pauli_terms, n_qubits=None):
@@ -106,37 +143,7 @@ def pauli_expectation(statevector, pauli_terms, n_qubits=None):
             f"pauli_terms references qubit {max(terms)}, but the statevector "
             f"only spans {inferred_n_qubits} qubits")
 
-    if not terms:
-        # Identity on every qubit: <psi|I|psi> = <psi|psi>, i.e. the norm
-        # (1.0 for a properly normalized state, computed rather than
-        # assumed so a mis-normalized input surfaces as a wrong answer,
-        # not a silently hidden bug).
-        return float(np.real(np.vdot(statevector, statevector)))
-
-    def bit_pos(q):
-        # qubit q -> bit position in the index (qubit 0 = MSB, see module
-        # docstring).
-        return inferred_n_qubits - 1 - q
-
-    flip_mask = 0
-    for q, p in terms.items():
-        if p in ('X', 'Y'):
-            flip_mask |= (1 << bit_pos(q))
-
-    indices = np.arange(dim)
-    source_idx = indices ^ flip_mask  # source_idx[out] = out ^ flip_mask
-
-    coeff = np.ones(dim, dtype=np.complex128)
-    for q, p in terms.items():
-        bit = (source_idx >> bit_pos(q)) & 1
-        if p == 'Y':
-            coeff = coeff * np.where(bit == 0, 1j, -1j)
-        elif p == 'Z':
-            coeff = coeff * np.where(bit == 0, 1.0, -1.0)
-        # 'X' flips the bit (already folded into flip_mask) and
-        # contributes a coefficient of 1 -- no further action needed.
-
-    p_psi = statevector[source_idx] * coeff
+    p_psi = _apply_pauli_term(statevector, terms, inferred_n_qubits)
     return float(np.real(np.vdot(statevector, p_psi)))
 
 
@@ -236,3 +243,64 @@ def pauli_hamiltonian_to_matrix(terms, n_qubits):
         H += coeff * term_matrix
 
     return H
+
+
+def pauli_sum_matvec(vector, terms, n_qubits=None):
+    """
+    H @ vector for a Hamiltonian given as a weighted sum of Pauli strings,
+    computed in O(dim * n_terms) WITHOUT ever building the (2**n_qubits,
+    2**n_qubits) matrix pauli_hamiltonian_to_matrix materializes -- the
+    matrix-free counterpart needed for an iterative/sparse eigensolver
+    (e.g. scipy.sparse.linalg.eigsh via a LinearOperator wrapping this
+    function), where pauli_hamiltonian_to_matrix's O(dim**2) memory is
+    exactly the thing being avoided.
+
+    Same qubit-0-is-MSB convention as the rest of this module: this
+    agrees with pauli_hamiltonian_to_matrix(terms, n_qubits) @ vector to
+    floating-point precision for the same terms -- same underlying
+    per-term application as pauli_expectation, just returning the vector
+    P|psi> instead of reducing it to <psi|P|psi>.
+
+    Parameters
+    ----------
+    vector : array-like, shape (2**n_qubits,)
+        Not required to be normalized (this is a linear map, not an
+        expectation value) -- e.g. an intermediate Lanczos vector, not
+        necessarily a physical statevector.
+    terms : iterable of (coeff, pauli_terms)
+        Same format pauli_sum_expectation/pauli_hamiltonian_to_matrix
+        accept.
+    n_qubits : int, optional
+        Only used to validate string-form terms' length; inferred from
+        vector's length otherwise (same convention as pauli_expectation).
+
+    Returns
+    -------
+    numpy.ndarray, shape (2**n_qubits,), dtype complex128
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> terms = [(1.0, 'ZZ'), (0.5, {0: 'X'})]
+    >>> v = np.array([1, 0, 0, 0], dtype=complex)
+    >>> pauli_sum_matvec(v, terms, n_qubits=2)
+    array([1. +0.j, 0. +0.j, 0. +0.j, 0.5+0.j])
+    >>> pauli_hamiltonian_to_matrix(terms, n_qubits=2) @ v
+    array([1. +0.j, 0. +0.j, 0. +0.j, 0.5+0.j])
+    """
+    vector = np.asarray(vector, dtype=np.complex128)
+    dim = vector.shape[0]
+    inferred_n_qubits = dim.bit_length() - 1
+    if 1 << inferred_n_qubits != dim:
+        raise ValueError(f"vector length {dim} is not a power of 2")
+
+    result = np.zeros(dim, dtype=np.complex128)
+    for coeff, pauli_terms in terms:
+        normalized = _normalize_terms(pauli_terms, n_qubits)
+        if normalized and max(normalized) >= inferred_n_qubits:
+            raise ValueError(
+                f"term references qubit {max(normalized)}, but vector only "
+                f"spans {inferred_n_qubits} qubits")
+        result += coeff * _apply_pauli_term(vector, normalized, inferred_n_qubits)
+
+    return result

--- a/tests/integration/test_dashboard_hamiltonians.py
+++ b/tests/integration/test_dashboard_hamiltonians.py
@@ -15,7 +15,7 @@ from dashboard_core.hamiltonians import (
     linear_chain_geometry, ring_geometry, MOLECULE_CATALOG,
     build_molecular_hamiltonian, get_molecule_n_qubits, get_all_molecules,
     get_compatible_molecules, get_molecular_hamiltonian_matrix, ground_state_energy,
-    mix_hamiltonians,
+    ground_state_energy_sparse, mix_hamiltonians,
 )
 
 H2_SYMBOLS = ['H', 'H']
@@ -107,6 +107,38 @@ class TestBuildMolecularHamiltonian:
         H_jw, _ = build_molecular_hamiltonian(H2_SYMBOLS, H2_GEOMETRY, charge=0, mapping="jordan_wigner")
         H_bk, _ = build_molecular_hamiltonian(H2_SYMBOLS, H2_GEOMETRY, charge=0, mapping="bravyi_kitaev")
         assert ground_state_energy(H_jw) == pytest.approx(ground_state_energy(H_bk), abs=1e-9)
+
+
+class TestGroundStateEnergySparse:
+    """prog.txt Sezione 4.1 -- matrix-free ground state via
+    dense_evolution.pauli_sum_matvec + scipy.sparse.linalg.eigsh, the fix
+    for the PRIORITARIO gap (ground_state_energy/build_molecular_hamiltonian
+    only had a dense np.linalg.eigvalsh path, blocked concretely on Si2).
+    Same known reference values as TestBuildMolecularHamiltonian above --
+    this must agree with the dense path to machine precision, not just be
+    plausible."""
+
+    def test_h2_matches_known_dense_value(self):
+        e = ground_state_energy_sparse(H2_SYMBOLS, H2_GEOMETRY, charge=0)
+        assert e == pytest.approx(-1.1372701748786913, abs=1e-6)
+
+    def test_hehp_matches_known_dense_value(self):
+        e = ground_state_energy_sparse(HEHP_SYMBOLS, HEHP_GEOMETRY, charge=1)
+        assert e == pytest.approx(-3.0156651781733883, abs=1e-6)
+
+    def test_matches_dense_build_molecular_hamiltonian_path_exactly(self):
+        # Same molecule, both code paths -- not just close to a hardcoded
+        # literature value, but agreeing with the sibling dense function
+        # on the SAME real Hamiltonian object.
+        H_dense, _ = build_molecular_hamiltonian(H2_SYMBOLS, H2_GEOMETRY, charge=0)
+        dense_e = ground_state_energy(H_dense)
+        sparse_e = ground_state_energy_sparse(H2_SYMBOLS, H2_GEOMETRY, charge=0)
+        assert sparse_e == pytest.approx(dense_e, abs=1e-8)
+
+    def test_jordan_wigner_and_bravyi_kitaev_share_the_same_spectrum(self):
+        e_jw = ground_state_energy_sparse(H2_SYMBOLS, H2_GEOMETRY, charge=0, mapping="jordan_wigner")
+        e_bk = ground_state_energy_sparse(H2_SYMBOLS, H2_GEOMETRY, charge=0, mapping="bravyi_kitaev")
+        assert e_jw == pytest.approx(e_bk, abs=1e-8)
 
 
 class TestGeometryValidation:

--- a/tests/unit/test_observables.py
+++ b/tests/unit/test_observables.py
@@ -7,7 +7,9 @@ import numpy as np
 import pytest
 
 from dense_evolution import DenseSVSimulator
-from dense_evolution.observables import pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix
+from dense_evolution.observables import (
+    pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix, pauli_sum_matvec,
+)
 
 _PAULI_MATS = {
     'I': np.eye(2, dtype=complex),
@@ -154,3 +156,51 @@ class TestPauliHamiltonianToMatrix:
     def test_invalid_n_qubits_raises(self):
         with pytest.raises(ValueError):
             pauli_hamiltonian_to_matrix([(1.0, {0: 'Z'})], n_qubits=0)
+
+
+class TestPauliSumMatvec:
+    """prog.txt Sezione 4.1 -- the matrix-free H @ vector primitive behind
+    ground_state_energy_sparse's scipy.sparse.linalg.eigsh path. Must
+    agree with pauli_hamiltonian_to_matrix(terms, n_qubits) @ vector to
+    machine precision -- that's the whole point, it's the same H, just
+    never materialized as a (2**n, 2**n) array."""
+
+    def test_matches_dense_matrix_matvec(self):
+        rng = np.random.default_rng(21)
+        n_qubits, dim = 4, 16
+        letters = ['I', 'X', 'Y', 'Z']
+        for _ in range(50):
+            n_terms = rng.integers(1, 6)
+            terms = [
+                (float(rng.normal()), ''.join(rng.choice(letters) for _ in range(n_qubits)))
+                for _ in range(n_terms)
+            ]
+            v = rng.normal(size=dim) + 1j * rng.normal(size=dim)
+            H = pauli_hamiltonian_to_matrix(terms, n_qubits=n_qubits)
+            expected = H @ v
+            actual = pauli_sum_matvec(v, terms, n_qubits=n_qubits)
+            assert np.allclose(actual, expected, atol=1e-9)
+
+    def test_not_required_to_be_normalized(self):
+        # A linear map, not an expectation value -- must work on an
+        # arbitrary (non-unit-norm) vector, e.g. an intermediate Lanczos
+        # vector from eigsh, not just a physical statevector.
+        terms = [(1.0, 'ZZ'), (0.5, {0: 'X'})]
+        v = np.array([2.0, 0.0, 0.0, 0.0], dtype=complex)
+        H = pauli_hamiltonian_to_matrix(terms, n_qubits=2)
+        assert np.allclose(pauli_sum_matvec(v, terms, n_qubits=2), H @ v)
+
+    def test_bell_state_zz_ground_truth(self):
+        sim = DenseSVSimulator(2, use_float32=False)
+        sim.run_circuit([('h', 0), ('cx', 0, 1)])
+        psi = sim.get_statevector()
+        Hpsi = pauli_sum_matvec(psi, [(1.0, 'ZZ')], n_qubits=2)
+        assert float(np.real(np.conj(psi) @ Hpsi)) == pytest.approx(1.0, abs=1e-9)
+
+    def test_vector_length_not_a_power_of_two_raises(self):
+        with pytest.raises(ValueError):
+            pauli_sum_matvec(np.zeros(5, dtype=complex), [(1.0, {0: 'Z'})])
+
+    def test_qubit_out_of_range_raises(self):
+        with pytest.raises(ValueError):
+            pauli_sum_matvec(np.zeros(4, dtype=complex), [(1.0, {5: 'Z'})])

--- a/tools/dashboard_core/__init__.py
+++ b/tools/dashboard_core/__init__.py
@@ -23,7 +23,7 @@ from .circuit_builder_component import mount_circuit_builder
 from .hamiltonians import (
     MOLECULE_CATALOG, build_molecular_hamiltonian, get_compatible_molecules,
     get_all_molecules, get_molecule_n_qubits,
-    get_molecular_hamiltonian_matrix, ground_state_energy,
+    get_molecular_hamiltonian_matrix, ground_state_energy, ground_state_energy_sparse,
     linear_chain_geometry, ring_geometry, mix_hamiltonians,
 )
 from .mitigation import (
@@ -50,7 +50,7 @@ __all__ = [
     'mount_circuit_builder',
     'MOLECULE_CATALOG', 'build_molecular_hamiltonian', 'get_compatible_molecules',
     'get_all_molecules', 'get_molecule_n_qubits',
-    'get_molecular_hamiltonian_matrix', 'ground_state_energy',
+    'get_molecular_hamiltonian_matrix', 'ground_state_energy', 'ground_state_energy_sparse',
     'linear_chain_geometry', 'ring_geometry', 'mix_hamiltonians',
     'MitigationResult', 'run_zne_mitigation',
     'DensityMatrixZNEResult', 'run_density_matrix_zne',

--- a/tools/dashboard_core/hamiltonians.py
+++ b/tools/dashboard_core/hamiltonians.py
@@ -28,7 +28,7 @@ import dense_evolution as de
 __all__ = [
     'MOLECULE_CATALOG', 'build_molecular_hamiltonian',
     'get_compatible_molecules', 'get_all_molecules', 'get_molecule_n_qubits',
-    'get_molecular_hamiltonian_matrix', 'ground_state_energy',
+    'get_molecular_hamiltonian_matrix', 'ground_state_energy', 'ground_state_energy_sparse',
     'linear_chain_geometry', 'ring_geometry',
 ]
 
@@ -427,6 +427,69 @@ def ground_state_energy(H_dense) -> float:
     checkable number (Hartree) for a Hamiltonian this small (H2/HeH+/H3+
     all fit well within exact diagonalization), not an estimate."""
     eigvals = np.linalg.eigvalsh(H_dense)
+    return float(eigvals.min())
+
+
+def ground_state_energy_sparse(symbols, geometry, charge: int = 0, mapping: str = "jordan_wigner",
+                                active_electrons=None, active_orbitals=None) -> float:
+    """Ground-state energy without ever materializing the dense
+    (2**n_qubits, 2**n_qubits) Hamiltonian matrix build_molecular_hamiltonian
+    + ground_state_energy require -- the fix for the PRIORITARIO gap
+    recorded in prog.txt (Sezione 4.1): that pair was blocked concretely
+    on Si2 (12 qubits, 805MB needed, SafeMemoryGuard refused it with only
+    1.37GB free). This path uses scipy.sparse.linalg.eigsh (Lanczos, ARPACK)
+    against a LinearOperator wrapping dense_evolution.pauli_sum_matvec --
+    same real Pauli terms _get_hamiltonian/_pennylane_hamiltonian_to_pauli_terms
+    already produce, just never densified. Memory need drops from O(dim**2)
+    to O(dim * ncv) (ncv = ARPACK's Lanczos basis size, a small constant),
+    the same qualitative jump the wormhole/VQE code already relies on
+    elsewhere in this file for anything past ~12-14 qubits on modest
+    hardware.
+
+    Same caveat as build_molecular_hamiltonian: mapping choice (Jordan-
+    Wigner vs Bravyi-Kitaev) only changes the qubit basis, never the
+    energy spectrum this returns.
+
+    Not a drop-in replacement for ground_state_energy: that function
+    still exists unchanged for callers that already have a small dense
+    H_dense (e.g. an already-built/cached catalog matrix) and want the
+    exact, non-iterative answer -- this is the new, separate opt-in path
+    for systems too large to densify at all, not a behavior change to
+    the existing one.
+    """
+    import scipy.sparse.linalg as sla
+
+    H, n_qubits = _get_hamiltonian(symbols, geometry, charge, mapping, active_electrons, active_orbitals)
+    terms = _pennylane_hamiltonian_to_pauli_terms(H, n_qubits)
+    dim = 2 ** n_qubits
+
+    if dim < 4:
+        # ARPACK's eigsh needs k < N-1; below 4 basis states there isn't
+        # room for even k=1 -- these sizes are exact-diagonalization
+        # territory anyway (ground_state_energy on a dense matrix this
+        # small costs nothing), not what this function exists for.
+        raise ValueError(
+            f"ground_state_energy_sparse needs at least 2 qubits (dim >= 4), got "
+            f"n_qubits={n_qubits} (dim={dim}) -- use build_molecular_hamiltonian + "
+            f"ground_state_energy for systems this small."
+        )
+
+    k = 1
+    ncv = min(dim - 1, max(2 * k + 1, 20))
+    # Lanczos needs ncv vectors of length dim in memory at once (complex128
+    # = 16 bytes), on top of a few fixed-size scratch vectors ARPACK keeps --
+    # the x3 mirrors build_molecular_hamiltonian's own safety margin, sized
+    # here for what eigsh actually allocates instead of a dense matrix.
+    required_mb = dim * ncv * 16 / 1e6 * 3
+    de.chunk.SafeMemoryGuard().check_allocation(
+        required_mb, context=f"{n_qubits}-qubit molecular Hamiltonian (sparse ground state)"
+    )
+
+    def matvec(v):
+        return de.pauli_sum_matvec(v, terms, n_qubits=n_qubits)
+
+    op = sla.LinearOperator(shape=(dim, dim), matvec=matvec, dtype=np.complex128)
+    eigvals = sla.eigsh(op, k=k, which='SA', ncv=ncv, return_eigenvectors=False)
     return float(eigvals.min())
 
 


### PR DESCRIPTION
**Scope: Sezione 4, Fase 1 (level-up track, separate from the daedalOS desktop plan in Sezione 2).**

`build_molecular_hamiltonian` + `ground_state_energy` only had a dense `np.linalg.eigvalsh` path -- blocked concretely on the Si2 catalog entry (805MB required, refused by `SafeMemoryGuard` on modest hardware).

- `dense_evolution/physics/observables.py`: new `pauli_sum_matvec(vector, terms, n_qubits=None)` -- computes `H @ vector` without ever building the `(2**n, 2**n)` matrix, in `O(dim * n_terms)`. Factored out of `pauli_expectation`'s existing (tested) bit-manipulation technique via a shared `_apply_pauli_term` helper, not duplicated. Exposed everywhere `pauli_expectation` already is (`dense_evolution.physics`, the `dense_evolution.observables` shim, top-level `dense_evolution`).
- `tools/dashboard_core/hamiltonians.py`: new `ground_state_energy_sparse(symbols, geometry, ...)` -- `scipy.sparse.linalg.eigsh` (Lanczos, `which='SA'`) against a `LinearOperator` wrapping `pauli_sum_matvec`. Purely additive: `ground_state_energy`/`build_molecular_hamiltonian` are unchanged, zero regression risk to existing callers.

**Verified, not just written:**
- 56/56 tests pass (`tests/unit/test_observables.py` + `tests/integration/test_dashboard_hamiltonians.py`), 9 new tests added.
- `pauli_sum_matvec` cross-checked against the dense matrix (`pauli_hamiltonian_to_matrix`) on random Hamiltonians -- diff ~1e-15.
- H2/HeH+: sparse ground state matches the existing known reference values AND `ground_state_energy(build_molecular_hamiltonian(...))` on the same Hamiltonian, diff ~1e-15.
- **Si2 (the concretely-blocked case) now succeeds**: `-571.0169825891` Hartree via the sparse path, where the dense path previously failed on memory.

Not merging automatically -- please review before merge.
