### PR TITLE
Docs: document pauli_sum_matvec and ground_state_energy_sparse (PR #106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ dense_evolution/
 │   └── mps.py              MPSSimulator — matrix-product-state backend, JAX-backed
 ├── physics/              [subpackage] quantum-information primitives
 │   ├── entropy.py          partial_trace · von_neumann_entropy · mutual_information (multi-qubit, MSB-first)
-│   ├── observables.py      Pauli-string expectation values, O(2ⁿ) direct from a statevector
+│   ├── observables.py      Pauli-string expectation values, O(2ⁿ) direct from a statevector · pauli_sum_matvec (matrix-free H·v)
 │   ├── states.py           common state-preparation circuits (Bell, GHZ, W, ...) as gate tuples
 │   ├── fermions.py         majorana_pauli_terms — Majorana-fermion → qubit (Jordan-Wigner) mapping
 │   └── qec.py              pauli_commutes · compute_syndrome · erasure_aware_decode (code-agnostic stabilizer QEC)

--- a/docs/api/dashboard_core_hamiltonians.md
+++ b/docs/api/dashboard_core_hamiltonians.md
@@ -22,6 +22,17 @@ range, not an interior point. Stated in the catalog entry's own comment
 rather than silently picking a geometry that flatters the active-space
 choice.
 
+**Ground state without the dense matrix**: `ground_state_energy` needs a
+dense `(2**n_qubits, 2**n_qubits)` Hamiltonian, which is exactly what
+blocked Si2 in practice (805 MB required, refused by `SafeMemoryGuard` on
+modest hardware). `ground_state_energy_sparse` never builds it —
+`scipy.sparse.linalg.eigsh` (Lanczos) against a `LinearOperator` wrapping
+[`pauli_sum_matvec`](observables.md), matrix-free by construction. Purely
+additive: `ground_state_energy`/`build_molecular_hamiltonian` are
+unchanged, this is a separate opt-in path for systems too large to
+densify at all — verified to match the dense path to ~1e-15 on H2/HeH+,
+and to actually succeed on Si2 where the dense path fails.
+
 ::: dashboard_core.hamiltonians
 
 ---

--- a/docs/api/observables.md
+++ b/docs/api/observables.md
@@ -1,7 +1,10 @@
 # Observables (Pauli-string expectation values)
 
 Exact expectation values of Pauli strings, computed directly from a statevector in O(dim) via
-bit manipulation -- the 2^n_qubits Hamiltonian matrix is never built.
+bit manipulation -- the 2^n_qubits Hamiltonian matrix is never built. `pauli_sum_matvec` uses
+the same technique for `H @ vector` (not reduced to a scalar) -- the matrix-free primitive
+behind [`ground_state_energy_sparse`](dashboard_core_hamiltonians.md)'s
+`scipy.sparse.linalg.eigsh` path for molecules too large to diagonalize densely.
 
 ::: dense_evolution.physics.observables
 


### PR DESCRIPTION
PR #106 (Fase 1, already merged) shipped `pauli_sum_matvec` and `ground_state_energy_sparse` without doc updates -- README file-tree line and both functions' docs/api/*.md pages. Docs-only, no code changes. Not merging automatically.