### PR TITLE
Fix ComplexWarning: SYK term coefficients now real floats, not complex128

### DIFF
--- a/tests/integration/test_wormhole.py
+++ b/tests/integration/test_wormhole.py
@@ -41,6 +41,47 @@ def _dense_matrix_commuting_pair_count(terms, n_qubits):
 T0, MU, T1 = 0.3, 12.0, 0.60
 
 
+class TestBuildSparseSykTerms:
+    """BUG FIX: coefficients used to carry a complex128 dtype (from
+    _multiply_pauli_dicts's phase, which is genuinely complex for
+    intermediate same-qubit Pauli products) all the way downstream into
+    trotter.py's pauli_rotation_ops, where they were silently truncated
+    to real with a numpy ComplexWarning at the point they're finally used
+    as a gate 'rz' angle -- found investigating that warning during
+    integration test runs, not from a wrong physics result (the value was
+    always exactly real; only the dtype was complex). A bare product of 4
+    anticommuting Majoranas is Hermitian by construction (see this
+    function's own docstring), so this is real by construction, not
+    merely real-valued by coincidence -- now asserted and cast at the
+    source instead of silently truncated far downstream."""
+
+    def test_coefficients_are_plain_python_floats_not_complex(self):
+        _, terms = build_sparse_syk_terms(N_MAJORANA, K_TERMS, J, SEED)
+        for coeff, _ in terms:
+            assert isinstance(coeff, float), f"expected float, got {type(coeff)}: {coeff!r}"
+
+    def test_coefficient_magnitude_matches_the_paper_definition(self):
+        # +-J/sqrt(k_terms), the paper's K=10, J=sqrt(2) definition.
+        _, terms = build_sparse_syk_terms(N_MAJORANA, K_TERMS, J, SEED)
+        expected_magnitude = J / np.sqrt(K_TERMS)
+        for coeff, _ in terms:
+            assert abs(abs(coeff) - expected_magnitude) < 1e-12
+
+    def test_no_complex_warning_when_used_as_a_trotter_gate_angle(self):
+        """The actual regression check: building a Trotter circuit from
+        these terms must not raise/warn on the 'rz' angle cast."""
+        import warnings
+        from dense_evolution.circuits.trotter import trotter_evolve_ops
+
+        _, terms = build_sparse_syk_terms(N_MAJORANA, K_TERMS, J, SEED)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ops = trotter_evolve_ops(terms, t=0.3, n_steps=2)
+        complex_warnings = [w for w in caught if "Complex" in str(w.category)]
+        assert not complex_warnings, f"unexpected ComplexWarning(s): {complex_warnings}"
+        assert len(ops) > 0
+
+
 class TestRunWormholeProtocolFiniteBeta:
 
     def test_beta_zero_matches_existing_beta_zero_backend(self):

--- a/tools/dashboard_core/wormhole.py
+++ b/tools/dashboard_core/wormhole.py
@@ -124,7 +124,28 @@ def build_sparse_syk_terms(n_majorana, k_terms, J, seed):
         sign = rng.choice([-1.0, 1.0])
         dicts = [majorana_pauli_terms(m, n_qubits)[1] for m in quad]
         phase, merged = _multiply_pauli_dicts(dicts)
-        terms.append((sign * coupling * phase, merged))
+        raw_coeff = sign * coupling * phase
+        # BUG FIX: raw_coeff carried a complex128 dtype all the way
+        # downstream into trotter.py's pauli_rotation_ops (angle=coeff*dt),
+        # which silently truncated it to real with a numpy ComplexWarning
+        # at the point it's finally used as a gate parameter -- discovered
+        # investigating that warning, not from a wrong Trotter result (the
+        # value itself was always exactly real; only the dtype was
+        # complex). This module's own docstring already explains why:
+        # a bare product of 4 anticommuting Majoranas is Hermitian by
+        # construction (6 transpositions to reverse, (-1)**6=+1) -- real
+        # by construction, not merely real-valued by coincidence. Verified
+        # here (not just documented) before truncating: imag(raw_coeff)
+        # is exactly 0.0 across 120 (n_majorana, seed) combinations tested
+        # (8/12/16/20 Majoranas x 30 seeds each), so this asserts the
+        # documented physics instead of silently trusting it.
+        assert abs(raw_coeff.imag) < 1e-12, (
+            f"SYK term coefficient has a non-negligible imaginary part "
+            f"({raw_coeff.imag}) -- a real bug (this should be exactly real, "
+            f"see this function's docstring), not the harmless complex128 "
+            f"dtype-with-zero-imaginary-part this assertion normally guards."
+        )
+        terms.append((float(raw_coeff.real), merged))
     return n_qubits, terms
 
 


### PR DESCRIPTION
**Scope: investigation follow-up (`ComplexWarning` found during PR #107/#108 integration test runs, confirmed pre-existing and unrelated to those PRs, tracked and fixed separately as requested).**

`build_sparse_syk_terms`'s coefficients carried a `complex128` dtype (`_multiply_pauli_dicts`'s `phase` is genuinely complex for intermediate same-qubit Pauli products) all the way downstream into `trotter.py`'s `pauli_rotation_ops`, silently truncated to real with a numpy `ComplexWarning` at the point they're finally used as an `'rz'` gate angle in `statevector.py`.

Found investigating that warning during an integration test run, not from a wrong physics result -- the value was always exactly real (verified: `imag()` is exactly `0.0`, not just small, across 120 `(n_majorana, seed)` combinations tested), only the dtype was complex.

This module's own docstring already explains why: a bare product of 4 anticommuting Majoranas is Hermitian by construction (6 transpositions to reverse, `(-1)**6=+1`) -- real by construction, not merely real-valued by coincidence. Now asserts that documented physics and casts to a plain `float` at the source, instead of silently truncating it far downstream in an unrelated function.

**Verified, not just written:**
- `run_wormhole_protocol_trotter`'s own documented reference value (`I(mu=+12)=0.01301` at `seed=61, t0=0.3, t1=0.60`) reproduced exactly with the fix, zero `ComplexWarning`s.
- 18/18 tests in `test_wormhole.py` (3 new).
- 111/111 tests across `test_wormhole.py` + `test_mcp_server.py` + `test_local_site_server.py` (every file touching wormhole functionality).

Not merging automatically -- please review before merge.
