### PR TITLE
Fix Chunk gate-dispatch staleness: GPhase gate missing from both switch tables

### DIFF
--- a/dense_evolution/chunk.py
+++ b/dense_evolution/chunk.py
@@ -278,7 +278,7 @@ if HAS_JAX:
             exp_neg_half = jnp.exp(-1j * half_p).astype(dtype)
 
             # 1-qubit gate matrix — identical table to _apply_gate_fast_step
-            safe_gid = jnp.clip(g_id, 0, 13)
+            safe_gid = jnp.clip(g_id, 0, 14)
             g_1q = jax.lax.switch(
                 safe_gid,
                 [
@@ -296,6 +296,10 @@ if HAS_JAX:
                     lambda _: jnp.array([[jnp.exp(-1j * half_p), 0.0 + 0j], [0.0 + 0j, jnp.exp(1j * half_p)]], dtype=dtype),
                     lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, exp_pos]], dtype=dtype),
                     lambda _: jnp.array([[0.5 + 0.5j, 0.5 - 0.5j], [0.5 - 0.5j, 0.5 + 0.5j]], dtype=dtype),
+                    # 14  GPhase(alpha) = e^{i*alpha} * I -- see compiler.py's
+                    # _apply_gate_fast_step index 14 for the derivation; this
+                    # table must stay in sync with that one (see comment above).
+                    lambda _: jnp.array([[exp_pos, 0.0 + 0j], [0.0 + 0j, exp_pos]], dtype=dtype),
                 ],
                 operand=None,
             )
@@ -486,7 +490,7 @@ if HAS_JAX:
             exp_pos_half = jnp.exp(1j * half_p).astype(dtype)
             exp_neg_half = jnp.exp(-1j * half_p).astype(dtype)
 
-            safe_gid = jnp.clip(g_id, 0, 13)
+            safe_gid = jnp.clip(g_id, 0, 14)
             g_1q = jax.lax.switch(
                 safe_gid,
                 [
@@ -504,6 +508,10 @@ if HAS_JAX:
                     lambda _: jnp.array([[jnp.exp(-1j * half_p), 0.0 + 0j], [0.0 + 0j, jnp.exp(1j * half_p)]], dtype=dtype),
                     lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, exp_pos]], dtype=dtype),
                     lambda _: jnp.array([[0.5 + 0.5j, 0.5 - 0.5j], [0.5 - 0.5j, 0.5 + 0.5j]], dtype=dtype),
+                    # 14  GPhase(alpha) = e^{i*alpha} * I -- must stay in sync
+                    # with _apply_gate_fast_step (compiler.py) and the
+                    # non-distributed copy of this table above.
+                    lambda _: jnp.array([[exp_pos, 0.0 + 0j], [0.0 + 0j, exp_pos]], dtype=dtype),
                 ],
                 operand=None,
             )

--- a/tests/unit/test_chunk.py
+++ b/tests/unit/test_chunk.py
@@ -335,6 +335,38 @@ class TestChunkMultiPieceJIT:
             print(f"\n[multi-chunk JIT speed] n_qubits={n_qubits} num_chunks=4 "
                   f"200 gates: {elapsed:.4f}s (pre-fix Python-loop dispatch: ~2.2s)")
 
+    @pytest.mark.parametrize("gate_op", [
+        ("u3", ('u3', 2, 0.3, 0.5, 0.7)),
+        ("u2", ('u2', 2, 0.4, 0.9)),
+        ("ecr", ('ecr', 2, 3)),
+        ("iswap", ('iswap', 2, 3)),
+    ], ids=lambda p: p[0])
+    def test_gphase_derived_gates_match_reference(self, force_chunk_bits, gate_op):
+        # Regression test: QuantumTranspiler.transpile decomposes u2/u3/ecr/
+        # iswap into sequences that include a 'gphase' op (GATE_IDS['gphase']
+        # = 14). This kernel's own 1-qubit jax.lax.switch table used to be
+        # clipped to jnp.clip(g_id, 0, 13) -- one branch short of the 15
+        # _apply_gate_fast_step (compiler.py) has -- so gate_id 14 silently
+        # aliased to branch 13 (SX) instead of applying e^{i*alpha}*I. Caught
+        # by forcing num_chunks>1 (the bug only lives in this multi-chunk
+        # kernel, not the single-chunk path, which just forwards to
+        # DenseSVSimulator) and comparing against it as ground truth.
+        _, op = gate_op
+        force_chunk_bits(4)
+        n = 6
+        circuit = [('h', 0), ('cx', 0, 1), op, ('h', 4), ('cx', 4, 5)]
+
+        chunk_sim = Chunk(n, use_float32=False)
+        assert chunk_sim.num_chunks > 1
+        chunk_sim.run_chunk(circuit)
+        sv_chunk = np.asarray(chunk_sim.get_statevector())
+
+        ref = DenseSVSimulator(n, use_float32=False)
+        ref.run_circuit(circuit, transpile=True)
+        sv_ref = np.asarray(ref.get_statevector())
+
+        np.testing.assert_allclose(sv_chunk, sv_ref, atol=1e-9)
+
 
 class TestChunkUtilities:
     """Coverage-driven tests for chunk.py's smaller utility surfaces --
@@ -559,3 +591,19 @@ class TestChunkDistributed:
         monkeypatch.setattr(jax, "device_count", lambda: 4)
         with pytest.raises(RuntimeError, match="devices"):
             c.run_chunk_distributed([('h', 0)])
+
+    @pytest.mark.parametrize("gate_op", [
+        ("u3", ('u3', 4, 0.3, 0.5, 0.7)),
+        ("ecr", ('ecr', 4, 5)),
+    ], ids=lambda p: p[0])
+    def test_gphase_derived_gates_match_reference(self, force_chunk_bits, gate_op):
+        # Same GATE_IDS['gphase']=14 staleness bug as
+        # TestChunkMultiPieceJIT.test_gphase_derived_gates_match_reference,
+        # but in _build_distributed_chunk_step's own separately-duplicated
+        # 1-qubit switch table (a third copy of the same table, independent
+        # of the non-distributed kernel's).
+        _, op = gate_op
+        force_chunk_bits(3)  # n_qubits=6 -> num_chunks=8, m=3
+        sv_dist, sv_ref = self._compare_to_reference(
+            6, [('h', 0), ('h', 1), ('h', 2), op])
+        np.testing.assert_allclose(sv_dist, sv_ref, atol=1e-9)


### PR DESCRIPTION
## Cosa c'era che non andava

`dense_evolution/chunk.py` mantiene due copie duplicate a mano della tabella `jax.lax.switch` a 1-qubit di `compiler.py`'s `_apply_gate_fast_step` (una nel kernel multi-chunk non distribuito, una nel kernel distribuito su mesh JAX). Entrambe erano rimaste a 14 branch (indici 0-13, `jnp.clip(g_id, 0, 13)`) da quando oggi era stato aggiunto il gate `GPhase` (`GATE_IDS['gphase'] = 14`) alla tabella di `compiler.py`, usato dalla decomposizione esatta di `u2`/`u3`/`ecr`/`iswap`.

Poiché `chunk.py` condivide lo stesso `QuantumTranspiler.transpile()` e lo stesso `GATE_IDS`, un circuito con `u2`/`u3`/`ecr`/`iswap` eseguito tramite `Chunk` con `num_chunks > 1` troncava silenziosamente l'id del gate `gphase` al branch 13 (SX) invece di applicare `e^{iα}·I` — un **risultato numerico sbagliato senza errore**, non un crash.

## Fix

Estese entrambe le tabelle a 15 branch (0-14), rispecchiando esattamente il branch 14 di `compiler.py`. Verificato: differenza massima passata da 0.35 a esattamente 0.0 su circuiti di test con u2/u3/ecr/iswap.

## Test

6 nuovi test di regressione in `tests/unit/test_chunk.py`:
- 4 nel kernel non distribuito (`TestChunkMultiPieceJIT`), forzando `num_chunks > 1`, confrontati contro `DenseSVSimulator` come riferimento.
- 2 nel kernel distribuito (`TestChunkDistributed`), che girano nello step CI dedicato con 8 device forzati (`XLA_FLAGS=--xla_force_host_platform_device_count=8`).

Suite completa locale: 610 passed, 19 skipped (i test a 8 device, attesi qui), 2 fail isolati e riconfermati passare — sono il flake noto da RAM bassa (`MemoryPressureError` in `test_mps.py`/`test_parser.py`), non correlati a questo fix.