### PR TITLE
Add Chunk streaming mode: device-memory-bounded execution (time, not space)

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,21 @@ Cross-chunk gate mixing (a gate touching one of the top `m = n_qubits - chunk_si
 
 Requires `jax.device_count() >= num_chunks`; raises `RuntimeError` with the exact count needed otherwise. For local testing without real multi-GPU hardware, force extra simulated CPU devices via `XLA_FLAGS=--xla_force_host_platform_device_count=N` (set before the process starts — JAX's device count is fixed at first initialization, not changeable at runtime) — this validates the sharding/communication logic is correct, not real GPU-to-GPU network performance, which needs actual multi-GPU/multi-host hardware to measure honestly.
 
+### Streamed, memory-bounded dispatch on one device — `run_chunk_streaming`
+
+`run_chunk()`'s multi-chunk path allocates every chunk eagerly, in `Chunk.__init__` itself — device memory still scales with `num_chunks`, just distributed across more, smaller arrays. `run_chunk_streaming()` solves a third constraint: one physical device, a fixed memory budget, and a qubit count that's allowed to exceed what fits on that device at once — the cost is wall-clock time, not device memory. Chunks live in host RAM between gates; at most **2** chunk-sized arrays are ever resident on the compute device at a time, regardless of `num_chunks` (a gate confined to one chunk's local qubits needs only 1; a gate touching a "chunk-select" qubit mixes exactly one pair — the same pairwise-exchange structure `run_chunk_distributed` uses over a real device mesh, applied here as a sequence of host↔device round trips on a single device instead).
+
+```python
+from dense_evolution import Chunk
+
+sim = Chunk(29, streaming=True, use_float32=True)  # would OOM a single GPU eagerly
+sim.run_chunk_streaming([['h', i] for i in range(29)])
+```
+
+Requires `Chunk(..., streaming=True)` at construction (`run_chunk()`/`run_chunk_distributed()` raise a clear `RuntimeError` if called on a streaming instance, and vice versa). The device budget is computed dynamically by default — real free GPU VRAM via `jax.devices()[0].memory_stats()` when running on a GPU, host RAM via `psutil` otherwise, never a hardcoded number — or fixed explicitly with `device_budget_mb=`; either way, `run_chunk_streaming` raises `MemoryPressureError` up front if even 2 chunks won't fit, instead of failing deep inside an XLA allocation. Verified for exact correctness against `DenseSVSimulator` across all 6 gate/qubit-location cases, `u2`/`u3`/`ecr`/`iswap` (GPhase-derived gates), randomized mixed circuits up to `num_chunks=128`, and both dtypes.
+
+There's no read/write-cycle batching across gates yet (each chunk-select-qubit gate pays its own host↔device transfer) — grouping consecutive gates that touch the same chunk pair before writing back, the way large-scale out-of-core simulators do (Pednault et al., [arXiv:1910.09534](https://arxiv.org/abs/1910.09534), IBM's secondary-storage simulation of the 54-qubit Sycamore circuit), is a natural follow-up, not yet implemented.
+
 ---
 
 ## ▍ Benchmarks

--- a/dense_evolution/chunk.py
+++ b/dense_evolution/chunk.py
@@ -19,12 +19,12 @@ HAS_JAX = True
 try:
     from simulator import DenseSVSimulator
     from compiler import QuantumTranspiler  # pragma: no cover
-    from gates import GATE_IDS  # pragma: no cover
+    from gates import GATE_IDS, GATES, PARAMETRIC_GATES  # pragma: no cover
 except ModuleNotFoundError:
     try:
         from dense_evolution.simulator import DenseSVSimulator
         from dense_evolution.compiler import QuantumTranspiler
-        from dense_evolution.gates import GATE_IDS
+        from dense_evolution.gates import GATE_IDS, GATES, PARAMETRIC_GATES
     except ModuleNotFoundError:  # pragma: no cover
         class DenseSVSimulator:  # type: ignore[no-redef]
             def __init__(self, n_qubits, **kwargs):
@@ -42,6 +42,8 @@ except ModuleNotFoundError:
             def transpile(circuit): return circuit
 
         GATE_IDS: dict = {}
+        GATES: dict = {}
+        PARAMETRIC_GATES: dict = {}
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helpers
@@ -59,6 +61,28 @@ def get_dynamic_chunk(dtype_target) -> int:
     max_elements = safe_ram / bpe
     max_bits = int(np.floor(np.log2(max(max_elements, 2.0))))
     return max(16, min(max_bits, 27))
+
+
+def _device_memory_budget_bytes(device=None) -> Tuple[float, str]:
+    """Real, dynamic memory budget for streaming execution (Chunk.
+    run_chunk_streaming) -- reads the ACTIVE compute device's own memory
+    via JAX's device.memory_stats() (bytes_limit - bytes_in_use) when
+    available, falling back to host RAM via psutil.virtual_memory()
+    otherwise (some backends, e.g. plain CPU, return None from
+    memory_stats() -- confirmed directly). This is the library version of
+    the GPU-VRAM-aware prototype first validated in test_gpu_real.py on
+    real GPU hardware (parts 4-5) before being ported in here for real.
+
+    Returns (available_bytes, source_description) -- the raw number, not
+    a safety-margined one; callers apply their own margin."""
+    if device is None:
+        device = jax.devices()[0]
+    stats = device.memory_stats() if hasattr(device, "memory_stats") else None
+    if stats and stats.get("bytes_limit"):
+        available = stats["bytes_limit"] - stats.get("bytes_in_use", 0)
+        return float(available), f"device.memory_stats() on {device}"
+    vm = psutil.virtual_memory()
+    return float(vm.available), "psutil (host RAM) -- device.memory_stats() unavailable"
 
 
 def _dtype_for_qubits(n_qubits: int):
@@ -830,6 +854,14 @@ class Chunk:
     memory_threshold  : free-RAM fraction below which execution is blocked
                         (default 0.15 = 15%)
     use_float32       : forwarded to DenseSVSimulator
+    streaming         : if True (and num_chunks>1), skip the eager
+                        num_chunks-simulators-in-RAM-at-once allocation
+                        below and instead keep chunks in host RAM, moving
+                        at most 2 onto the compute device at a time via
+                        run_chunk_streaming() -- see that method's
+                        docstring. Ignored when num_chunks==1 (nothing to
+                        stream). Default False: unchanged existing
+                        behavior, use run_chunk()/run_chunk_distributed().
     """
 
     def __init__(
@@ -838,6 +870,7 @@ class Chunk:
         chunk_size_gates:  int   = 500,
         memory_threshold:  float = 0.15,
         use_float32:       bool  = False,
+        streaming:         bool  = False,
     ):
         # 1. Geometry — purely RAM-based, no JAX allocation yet
         self._mem_chunker     = MemoryChunker(n_qubits)
@@ -847,6 +880,13 @@ class Chunk:
         self.n                = n_qubits
         self.chunk_size_gates = chunk_size_gates
         self._m                = n_qubits - self._mem_chunker.chunk_size_bits  # chunk-select qubit count (0 if num_chunks==1)
+        self._host_chunks      = None  # only set in the streaming branch below
+        # For num_chunks==1 the two constructor branches below are
+        # identical (a single self._inner_sim either way) -- streaming
+        # only actually changes anything when num_chunks>1, so the
+        # run_chunk()/run_chunk_streaming() mode guards only fire in that
+        # case (see their own checks: `self.num_chunks > 1`).
+        self._streaming         = streaming
 
         if self._mem_chunker.num_chunks == 1:
             # 3a. Pre-allocation RAM check — block here rather than inside JAX
@@ -866,6 +906,33 @@ class Chunk:
                 simulator_instance=self._inner_sim,
                 memory_threshold=memory_threshold,
             )
+        elif streaming:
+            # 3c. Pre-allocation check: HOST RAM must hold the full logical
+            # statevector (num_chunks chunk-sized numpy arrays) -- no "+2
+            # headroom" term like branch 3b below, since run_chunk_streaming
+            # never holds more than 2 chunks anywhere beyond this backing
+            # store (that check happens dynamically inside
+            # run_chunk_streaming itself, against DEVICE memory, not here).
+            num_chunks   = self._mem_chunker.num_chunks
+            per_chunk_mb = self._mem_chunker.memory_mb()
+            self._guard.check_allocation(
+                num_chunks * per_chunk_mb,
+                f"Chunk.__init__ (streaming) — allocating {num_chunks} chunks of "
+                f"{self._mem_chunker.chunk_size_bits} qubits each in host RAM",
+            )
+
+            np_dtype = np.complex64 if use_float32 else np.complex128
+            chunk_dim = self._mem_chunker.chunk_dim
+            self._host_chunks = [np.zeros(chunk_dim, dtype=np_dtype) for _ in range(num_chunks)]
+            self._host_chunks[0][0] = 1.0  # logical |0...0> lives in chunk 0, local index 0
+            self._streaming = True
+
+            self._inner_sim          = None
+            self._chunk_sims         = None
+            self._circuit_chunker    = None
+            self._multi_chunk_runner = None
+            self._distributed_runner = None
+            self._distributed_mesh   = None
         else:
             # 3b. Sized pre-allocation check: num_chunks chunk-sized simulators
             # held in RAM at once, plus ~2 chunks of headroom for the temporary
@@ -934,10 +1001,14 @@ class Chunk:
     @property
     def sv(self):
         """Current statevector. For num_chunks==1, the physical (chunk-sized)
-        simulator's own array. For num_chunks>1, the chunks concatenated in
-        ascending order — valid because of the MSB-first correspondence
-        between chunk index and the top `_m` logical qubits (see
-        _dispatch_multi's docstring)."""
+        simulator's own array. For num_chunks>1 (eager), the chunks
+        concatenated in ascending order — valid because of the MSB-first
+        correspondence between chunk index and the top `_m` logical qubits
+        (see _dispatch_multi's docstring). For num_chunks>1 (streaming),
+        same ascending-order concatenation, but of the host-RAM-backed
+        numpy chunks instead of DenseSVSimulator instances."""
+        if self._host_chunks is not None:
+            return np.concatenate(self._host_chunks)
         if self._chunk_sims is None:
             return self._inner_sim.sv
         xp = self._chunk_sims[0].xp
@@ -949,11 +1020,19 @@ class Chunk:
         NoiseModel.apply_to_sv called on `.sv`) and writes it back through
         to the physical storage -- the inner simulator directly for
         num_chunks==1, or split back into per-chunk slices (same ascending
-        concatenation order as the getter) for num_chunks>1."""
+        concatenation order as the getter) for num_chunks>1 (eager or
+        streaming)."""
+        chunk_dim = self._mem_chunker.chunk_dim
+        if self._host_chunks is not None:
+            value = np.asarray(value)
+            self._host_chunks = [
+                np.array(value[i * chunk_dim:(i + 1) * chunk_dim], dtype=self._host_chunks[0].dtype)
+                for i in range(self._mem_chunker.num_chunks)
+            ]
+            return
         if self._chunk_sims is None:
             self._inner_sim.sv = value
             return
-        chunk_dim = self._mem_chunker.chunk_dim
         xp = self._chunk_sims[0].xp
         value = xp.asarray(value)
         for i, sim in enumerate(self._chunk_sims):
@@ -961,6 +1040,8 @@ class Chunk:
 
     def memory_mb(self) -> float:
         """RAM used by the physical statevector(s) in MB."""
+        if self._host_chunks is not None:
+            return sum(c.nbytes for c in self._host_chunks) / 1_000_000
         if self._chunk_sims is None:
             return self._inner_sim.memory_mb()
         return sum(sim.memory_mb() for sim in self._chunk_sims)
@@ -975,10 +1056,13 @@ class Chunk:
         ONCE over the full array — NOT each chunk's own get_probabilities()
         (that would independently renormalize each chunk's partial mass to
         1, summing to num_chunks overall and destroying the relative
-        weighting between chunks)."""
-        if self._chunk_sims is None:
+        weighting between chunks). Same for streaming's host-RAM chunks."""
+        if self._host_chunks is not None:
+            full_sv = np.concatenate(self._host_chunks)
+        elif self._chunk_sims is None:
             return self._inner_sim.get_probabilities()
-        full_sv = np.concatenate([np.array(sim.sv) for sim in self._chunk_sims])
+        else:
+            full_sv = np.concatenate([np.array(sim.sv) for sim in self._chunk_sims])
         probs = np.abs(full_sv) ** 2
         probs = np.clip(probs, 0.0, 1.0)
         total = probs.sum()
@@ -990,7 +1074,10 @@ class Chunk:
         """Full complex statevector, num_qubits logical qubits long
         (2**n elements). num_chunks==1: forwards to the inner
         DenseSVSimulator. num_chunks>1: raw chunks concatenated in order
-        (see `sv` property)."""
+        (see `sv` property) -- from DenseSVSimulator instances (eager) or
+        host-RAM numpy arrays (streaming)."""
+        if self._host_chunks is not None:
+            return np.concatenate(self._host_chunks)
         if self._chunk_sims is None:
             return self._inner_sim.get_statevector()
         return np.concatenate([np.array(sim.sv, dtype=sim.dtype) for sim in self._chunk_sims])
@@ -1042,6 +1129,11 @@ class Chunk:
         (chunk_dim,) row, exchanging edge data with its stride-partner
         device via jax.lax.ppermute inside the kernel, not through this
         Python method."""
+        if self._streaming and self.num_chunks > 1:
+            raise RuntimeError(
+                "dispatch_distributed() doesn't apply to a Chunk constructed "
+                "with streaming=True -- use run_chunk_streaming() instead."
+            )
         if self._chunk_sims is None:
             raise RuntimeError(
                 "dispatch_distributed() requires num_chunks > 1 "
@@ -1076,7 +1168,11 @@ class Chunk:
         circuit: List,
         chunk_size_gates: Optional[int] = None,
     ) -> None:
-
+        if self._streaming and self.num_chunks > 1:
+            raise RuntimeError(
+                "run_chunk() doesn't apply to a Chunk constructed with "
+                "streaming=True -- use run_chunk_streaming() instead."
+            )
         if self._chunk_sims is not None:
             self._dispatch_multi(circuit)
             return
@@ -1090,6 +1186,229 @@ class Chunk:
         otherwise (see dispatch_distributed's docstring for how to test
         this with simulated multi-device CPU)."""
         self.dispatch_distributed(circuit)
+
+    # ── Streaming (sequential, device-memory-bounded) dispatch ──────────────
+    # Every gate touches at most 2 of the num_chunks chunks (see the case
+    # analysis in _apply_1q_streaming/_apply_2q_streaming below) -- the same
+    # "amplitudes are sent pairwise" structure LaRose (arXiv:1801.01037,
+    # Fig. 6/10) describes for MPI-distributed statevector simulation.
+    # Pednault et al. (arXiv:1910.09534, IBM's answer to Google's 54-qubit
+    # Sycamore supremacy claim) apply the same load/compute/write-back
+    # cycle against secondary storage, plus one optimization this does NOT
+    # yet implement: grouping consecutive gates that touch the same pair of
+    # chunks so a pair is loaded once and drained of every applicable gate
+    # before being written back, instead of one host<->device round trip
+    # per gate (their exact words: files "are never read or written
+    # multiple times in a single read or write cycle"). Without that, a
+    # circuit with many chunk-select-qubit gates pays a real, sometimes
+    # steep, cost here -- LaRose's own measurement: a communication-
+    # requiring gate can be ~10^6x slower than a purely local one on his
+    # MPI cluster. That is the accepted trade this mode makes on purpose
+    # (time, not space -- see prog.txt/this session's discussion): device
+    # memory stays bounded by a small, real, dynamically-computed budget
+    # regardless of num_chunks, at the cost of per-gate transfer overhead.
+
+    def _apply_1q_streaming(self, q: int, mat, m: int, k: int, num_chunks: int,
+                             chunk_dim: int, device) -> None:
+        g00, g01, g10, g11 = mat[0, 0], mat[0, 1], mat[1, 0], mat[1, 1]
+        if q >= m:
+            # LOCAL qubit -- every chunk transformed independently, 1 chunk
+            # on-device at a time (case_1q_local's math, chunk.py:333).
+            local_phys = (k - 1) - (q - m)
+            stride = 1 << local_phys
+            idx = np.arange(chunk_dim)
+            idx_pair = idx ^ stride
+            mask0 = (idx & stride) == 0
+            for c in range(num_chunks):
+                dc = jax.device_put(self._host_chunks[c], device)
+                amp_pair = dc[idx_pair]
+                new0 = g00 * dc + g01 * amp_pair
+                new1 = g10 * amp_pair + g11 * dc
+                self._host_chunks[c] = np.asarray(jnp.where(mask0, new0, new1))
+        else:
+            # CHUNK-SELECT qubit -- pairs of chunks mixed, 2 chunks
+            # on-device at a time (case_1q_chunk's math, chunk.py:347).
+            stride = 1 << (m - 1 - q)
+            for c0 in range(num_chunks):
+                if (c0 & stride) != 0:
+                    continue  # each pair processed once, from the bit=0 side
+                c1 = c0 ^ stride
+                d0 = jax.device_put(self._host_chunks[c0], device)
+                d1 = jax.device_put(self._host_chunks[c1], device)
+                new0 = g00 * d0 + g01 * d1
+                new1 = g10 * d0 + g11 * d1
+                self._host_chunks[c0] = np.asarray(new0)
+                self._host_chunks[c1] = np.asarray(new1)
+
+    def _apply_2q_streaming(self, q1: int, q2: int, u, m: int, k: int,
+                             num_chunks: int, chunk_dim: int, device) -> None:
+        u00, u01, u10, u11 = u[0, 0], u[0, 1], u[1, 0], u[1, 1]
+        q1_chunk, q2_chunk = q1 < m, q2 < m
+
+        if not q1_chunk and not q2_chunk:
+            # both LOCAL -- every chunk independently, 1 on-device at a
+            # time (case_2q_local_local, chunk.py:358).
+            ctrl_phys = (k - 1) - (q1 - m)
+            tgt_phys  = (k - 1) - (q2 - m)
+            idx = np.arange(chunk_dim)
+            ctrl_bit = (idx & (1 << ctrl_phys)) != 0
+            tgt_bit  = (idx & (1 << tgt_phys)) != 0
+            partner  = idx ^ (1 << tgt_phys)
+            for c in range(num_chunks):
+                dc = jax.device_put(self._host_chunks[c], device)
+                amp_partner = dc[partner]
+                new0 = u00 * dc + u01 * amp_partner
+                new1 = u10 * amp_partner + u11 * dc
+                after = jnp.where(tgt_bit, new1, new0)
+                self._host_chunks[c] = np.asarray(jnp.where(ctrl_bit, after, dc))
+
+        elif q1_chunk and not q2_chunk:
+            # ctrl CHUNK-SELECT, tgt LOCAL -- only ctrl-set chunks are
+            # touched at all (the rest are the identity, skipped entirely
+            # -- both a memory AND a real speed win over the eager kernel,
+            # which must still touch every chunk since it's vectorized),
+            # each transformed alone, 1 on-device at a time (case_2q_ctrl_
+            # chunk_tgt_local, chunk.py:374).
+            ctrl_stride = 1 << (m - 1 - q1)
+            tgt_phys = (k - 1) - (q2 - m)
+            idx = np.arange(chunk_dim)
+            tgt_bit = (idx & (1 << tgt_phys)) != 0
+            partner = idx ^ (1 << tgt_phys)
+            for c in range(num_chunks):
+                if (c & ctrl_stride) == 0:
+                    continue
+                dc = jax.device_put(self._host_chunks[c], device)
+                amp_partner = dc[partner]
+                new0 = u00 * dc + u01 * amp_partner
+                new1 = u10 * amp_partner + u11 * dc
+                self._host_chunks[c] = np.asarray(jnp.where(tgt_bit, new1, new0))
+
+        elif not q1_chunk and q2_chunk:
+            # ctrl LOCAL, tgt CHUNK-SELECT -- pairs mixed, masked by the
+            # LOCAL ctrl bit (elementwise), 2 on-device at a time
+            # (case_2q_ctrl_local_tgt_chunk, chunk.py:391).
+            ctrl_phys = (k - 1) - (q1 - m)
+            idx = np.arange(chunk_dim)
+            ctrl_bit = (idx & (1 << ctrl_phys)) != 0
+            tgt_stride = 1 << (m - 1 - q2)
+            for c0 in range(num_chunks):
+                if (c0 & tgt_stride) != 0:
+                    continue
+                c1 = c0 ^ tgt_stride
+                d0 = jax.device_put(self._host_chunks[c0], device)
+                d1 = jax.device_put(self._host_chunks[c1], device)
+                new_c0 = u00 * d0 + u01 * d1
+                new_c1 = u10 * d0 + u11 * d1
+                self._host_chunks[c0] = np.asarray(jnp.where(ctrl_bit, new_c0, d0))
+                self._host_chunks[c1] = np.asarray(jnp.where(ctrl_bit, new_c1, d1))
+
+        else:
+            # ctrl AND tgt both CHUNK-SELECT -- only ctrl-set pairs touched
+            # at all (untouched pairs skipped entirely, same win as the
+            # ctrl-chunk/tgt-local case above), 2 on-device at a time
+            # (case_2q_both_chunk, chunk.py:406).
+            ctrl_stride = 1 << (m - 1 - q1)
+            tgt_stride  = 1 << (m - 1 - q2)
+            for c0 in range(num_chunks):
+                if (c0 & ctrl_stride) == 0 or (c0 & tgt_stride) != 0:
+                    continue
+                c1 = c0 ^ tgt_stride
+                d0 = jax.device_put(self._host_chunks[c0], device)
+                d1 = jax.device_put(self._host_chunks[c1], device)
+                new_c0 = u00 * d0 + u01 * d1
+                new_c1 = u10 * d0 + u11 * d1
+                self._host_chunks[c0] = np.asarray(new_c0)
+                self._host_chunks[c1] = np.asarray(new_c1)
+
+    def run_chunk_streaming(self, circuit: List, device_budget_mb: Optional[float] = None) -> None:
+        """Sequential, device-memory-bounded execution: at most 2 chunk-
+        sized arrays are ever resident on the compute device at once (see
+        the module note above the streaming helpers for why 2 always
+        suffices, and the literature this mirrors). The num_chunks logical
+        chunks live in HOST RAM (plain numpy) between gates.
+
+        Requires Chunk(..., streaming=True) at construction -- the default
+        (eager) constructor branch already allocates every chunk up front
+        in __init__ itself, which is exactly the memory ceiling this mode
+        exists to avoid.
+
+        Parameters
+        ----------
+        circuit          : gate list, same format as run_chunk()
+        device_budget_mb : if given, a fixed cap (MB) on device memory this
+                            call is allowed to use. If None (default), the
+                            budget is computed dynamically right now from
+                            whatever memory is actually free -- GPU VRAM
+                            via device.memory_stats() on a GPU, host RAM
+                            via psutil otherwise (dense_evolution.chunk.
+                            _device_memory_budget_bytes) -- never a
+                            hardcoded number, since "2 GB" only makes sense
+                            for one specific machine, not every machine
+                            this runs on.
+
+        Raises
+        ------
+        RuntimeError if this Chunk wasn't constructed with streaming=True.
+        MemoryPressureError if even 2 chunk-sized arrays don't fit in the
+        computed (or given) device budget -- checked up front, not
+        discovered as a mid-run XLA OOM.
+        """
+        if self.num_chunks == 1:
+            # Nothing to stream (both constructor branches produce the same
+            # single self._inner_sim regardless of streaming=True/False) --
+            # forward to the exact same path run_chunk() uses.
+            size = self.chunk_size_gates
+            self._circuit_chunker.split_circuit(circuit, chunk_size=size)
+            return
+        if not self._streaming:
+            raise RuntimeError(
+                "run_chunk_streaming() requires Chunk(..., streaming=True) at "
+                "construction -- the default constructor already allocates "
+                "every chunk eagerly in __init__, which defeats the point of "
+                "this mode. Construct a new Chunk with streaming=True instead."
+            )
+
+        m, k = self._m, self._mem_chunker.chunk_size_bits
+        num_chunks, chunk_dim = self._mem_chunker.num_chunks, self._mem_chunker.chunk_dim
+        dtype = self._host_chunks[0].dtype
+        per_chunk_bytes = chunk_dim * dtype.itemsize
+
+        if device_budget_mb is None:
+            available_bytes, source = _device_memory_budget_bytes()
+            device_budget_bytes = available_bytes * 0.85  # same safety margin as get_dynamic_chunk
+        else:
+            device_budget_bytes = device_budget_mb * 1024 * 1024
+            source = "user-specified device_budget_mb"
+
+        if device_budget_bytes < 2 * per_chunk_bytes:
+            raise MemoryPressureError(
+                f"run_chunk_streaming needs room for at least 2 chunk-sized "
+                f"arrays ({2 * per_chunk_bytes / 1e6:.1f} MB) on the compute "
+                f"device, but the budget ({source}) is only "
+                f"{device_budget_bytes / 1e6:.1f} MB. Reduce chunk_size_bits "
+                f"(fewer qubits per chunk) or free up device memory."
+            )
+
+        device = jax.devices()[0]
+        target = QuantumTranspiler.transpile(circuit)
+
+        for cmd in target:
+            name = cmd[0].lower() if isinstance(cmd[0], str) else str(cmd[0]).lower()
+            if name not in GATE_IDS:
+                continue  # same silent-skip convention as _compile_multi_chunk_ops
+            args = cmd[1:]
+            if name in ('cx', 'cz', 'cp', 'cphase', 'cy', 'crz'):
+                q1, q2 = int(args[0]), int(args[1])
+                param = float(args[2]) if len(args) > 2 else 0.0
+                mat4 = PARAMETRIC_GATES[name](param) if name in PARAMETRIC_GATES else GATES[name]
+                u = np.asarray(mat4, dtype=dtype)[2:, 2:]
+                self._apply_2q_streaming(q1, q2, u, m, k, num_chunks, chunk_dim, device)
+            elif args:
+                q = int(args[0])
+                param = float(args[1]) if len(args) > 1 else 0.0
+                mat = PARAMETRIC_GATES[name](param) if name in PARAMETRIC_GATES else GATES[name]
+                mat = np.asarray(mat, dtype=dtype)
+                self._apply_1q_streaming(q, mat, m, k, num_chunks, chunk_dim, device)
 
     def __repr__(self) -> str:
         s = self._guard.status()

--- a/dense_evolution/chunk.py
+++ b/dense_evolution/chunk.py
@@ -1208,17 +1208,40 @@ class Chunk:
     # memory stays bounded by a small, real, dynamically-computed budget
     # regardless of num_chunks, at the cost of per-gate transfer overhead.
 
+    def _local_index_arrays(self, cache: dict, key: tuple, device, chunk_dim: int, builder):
+        """Index/mask arrays for a given (qubit-position-derived) key
+        depend only on (key, chunk_dim, m, k) -- never on gate parameters
+        or which chunk is being processed -- so they're identical across
+        every chunk touched by ONE gate, and across every future gate that
+        happens to touch the same qubit(s) again (e.g. H on every qubit,
+        or repeated rotations in a layered ansatz). `cache` is a plain
+        dict, one per run_chunk_streaming() call, so this is a real cross-
+        gate win for exactly the circuits that matter (chunk_dim is often
+        many millions of elements at realistic chunk_size_bits -- see
+        run_chunk_streaming's own docstring for the concrete cost this
+        avoids). `builder()` returns the arrays as JAX (device) arrays,
+        never NumPy -- computing an arange/xor/mask this large on the HOST
+        (as this code originally did) was the actual dominant cost at
+        real scale, confirmed directly: n=28 (chunk_dim=2**27, ~134M
+        elements) took 404s for a 100-gate circuit with plain NumPy index
+        arrays recomputed on every single gate call, vs <5s once these
+        moved to JAX/device arrays and got cached across repeated qubits."""
+        if key not in cache:
+            cache[key] = jax.device_put(builder(), device)
+        return cache[key]
+
     def _apply_1q_streaming(self, q: int, mat, m: int, k: int, num_chunks: int,
-                             chunk_dim: int, device) -> None:
+                             chunk_dim: int, device, index_cache: dict) -> None:
         g00, g01, g10, g11 = mat[0, 0], mat[0, 1], mat[1, 0], mat[1, 1]
         if q >= m:
             # LOCAL qubit -- every chunk transformed independently, 1 chunk
             # on-device at a time (case_1q_local's math, chunk.py:333).
             local_phys = (k - 1) - (q - m)
             stride = 1 << local_phys
-            idx = np.arange(chunk_dim)
-            idx_pair = idx ^ stride
-            mask0 = (idx & stride) == 0
+            idx_pair, mask0 = self._local_index_arrays(
+                index_cache, ('1q_local', stride), device, chunk_dim,
+                lambda: (jnp.arange(chunk_dim) ^ stride, (jnp.arange(chunk_dim) & stride) == 0),
+            )
             for c in range(num_chunks):
                 dc = jax.device_put(self._host_chunks[c], device)
                 amp_pair = dc[idx_pair]
@@ -1241,7 +1264,7 @@ class Chunk:
                 self._host_chunks[c1] = np.asarray(new1)
 
     def _apply_2q_streaming(self, q1: int, q2: int, u, m: int, k: int,
-                             num_chunks: int, chunk_dim: int, device) -> None:
+                             num_chunks: int, chunk_dim: int, device, index_cache: dict) -> None:
         u00, u01, u10, u11 = u[0, 0], u[0, 1], u[1, 0], u[1, 1]
         q1_chunk, q2_chunk = q1 < m, q2 < m
 
@@ -1250,10 +1273,14 @@ class Chunk:
             # time (case_2q_local_local, chunk.py:358).
             ctrl_phys = (k - 1) - (q1 - m)
             tgt_phys  = (k - 1) - (q2 - m)
-            idx = np.arange(chunk_dim)
-            ctrl_bit = (idx & (1 << ctrl_phys)) != 0
-            tgt_bit  = (idx & (1 << tgt_phys)) != 0
-            partner  = idx ^ (1 << tgt_phys)
+            ctrl_bit, tgt_bit, partner = self._local_index_arrays(
+                index_cache, ('2q_local_local', ctrl_phys, tgt_phys), device, chunk_dim,
+                lambda: (
+                    (jnp.arange(chunk_dim) & (1 << ctrl_phys)) != 0,
+                    (jnp.arange(chunk_dim) & (1 << tgt_phys)) != 0,
+                    jnp.arange(chunk_dim) ^ (1 << tgt_phys),
+                ),
+            )
             for c in range(num_chunks):
                 dc = jax.device_put(self._host_chunks[c], device)
                 amp_partner = dc[partner]
@@ -1271,9 +1298,13 @@ class Chunk:
             # chunk_tgt_local, chunk.py:374).
             ctrl_stride = 1 << (m - 1 - q1)
             tgt_phys = (k - 1) - (q2 - m)
-            idx = np.arange(chunk_dim)
-            tgt_bit = (idx & (1 << tgt_phys)) != 0
-            partner = idx ^ (1 << tgt_phys)
+            tgt_bit, partner = self._local_index_arrays(
+                index_cache, ('2q_ctrl_chunk_tgt_local', tgt_phys), device, chunk_dim,
+                lambda: (
+                    (jnp.arange(chunk_dim) & (1 << tgt_phys)) != 0,
+                    jnp.arange(chunk_dim) ^ (1 << tgt_phys),
+                ),
+            )
             for c in range(num_chunks):
                 if (c & ctrl_stride) == 0:
                     continue
@@ -1288,8 +1319,10 @@ class Chunk:
             # LOCAL ctrl bit (elementwise), 2 on-device at a time
             # (case_2q_ctrl_local_tgt_chunk, chunk.py:391).
             ctrl_phys = (k - 1) - (q1 - m)
-            idx = np.arange(chunk_dim)
-            ctrl_bit = (idx & (1 << ctrl_phys)) != 0
+            (ctrl_bit,) = self._local_index_arrays(
+                index_cache, ('2q_ctrl_local_tgt_chunk', ctrl_phys), device, chunk_dim,
+                lambda: ((jnp.arange(chunk_dim) & (1 << ctrl_phys)) != 0,),
+            )
             tgt_stride = 1 << (m - 1 - q2)
             for c0 in range(num_chunks):
                 if (c0 & tgt_stride) != 0:
@@ -1391,6 +1424,16 @@ class Chunk:
 
         device = jax.devices()[0]
         target = QuantumTranspiler.transpile(circuit)
+        # Index/mask arrays (see _local_index_arrays) depend only on which
+        # qubit(s) a gate touches, not on the gate's parameters or which
+        # chunk is being processed -- cached here, once per
+        # run_chunk_streaming() call, across every gate in *circuit* that
+        # happens to touch a qubit (or qubit pair) already seen. Bounded
+        # by the number of distinct qubit combinations the circuit
+        # actually uses (at most O(n^2), in practice far less), each entry
+        # a fraction of one chunk's size (bool/int32, not the chunk's own
+        # complex64/128) -- not by num_chunks or circuit length.
+        index_cache: dict = {}
 
         for cmd in target:
             name = cmd[0].lower() if isinstance(cmd[0], str) else str(cmd[0]).lower()
@@ -1402,13 +1445,13 @@ class Chunk:
                 param = float(args[2]) if len(args) > 2 else 0.0
                 mat4 = PARAMETRIC_GATES[name](param) if name in PARAMETRIC_GATES else GATES[name]
                 u = np.asarray(mat4, dtype=dtype)[2:, 2:]
-                self._apply_2q_streaming(q1, q2, u, m, k, num_chunks, chunk_dim, device)
+                self._apply_2q_streaming(q1, q2, u, m, k, num_chunks, chunk_dim, device, index_cache)
             elif args:
                 q = int(args[0])
                 param = float(args[1]) if len(args) > 1 else 0.0
                 mat = PARAMETRIC_GATES[name](param) if name in PARAMETRIC_GATES else GATES[name]
                 mat = np.asarray(mat, dtype=dtype)
-                self._apply_1q_streaming(q, mat, m, k, num_chunks, chunk_dim, device)
+                self._apply_1q_streaming(q, mat, m, k, num_chunks, chunk_dim, device, index_cache)
 
     def __repr__(self) -> str:
         s = self._guard.status()

--- a/tests/unit/test_chunk.py
+++ b/tests/unit/test_chunk.py
@@ -607,3 +607,214 @@ class TestChunkDistributed:
         sv_dist, sv_ref = self._compare_to_reference(
             6, [('h', 0), ('h', 1), ('h', 2), op])
         np.testing.assert_allclose(sv_dist, sv_ref, atol=1e-9)
+
+
+class TestChunkStreaming:
+    """Chunk(..., streaming=True) / run_chunk_streaming(): a third
+    execution mode alongside run_chunk() (every chunk allocated eagerly in
+    __init__, device memory scales with num_chunks) and
+    run_chunk_distributed() (needs jax.device_count() >= num_chunks). This
+    one keeps num_chunks chunks in HOST RAM between gates and moves at
+    most 2 onto the compute device at a time -- device memory is bounded
+    by a small, dynamically-computed budget regardless of num_chunks, at
+    the cost of one host<->device transfer per chunk-select-qubit gate.
+    Same "amplitudes sent pairwise" structure as the distributed-memory
+    literature (LaRose, arXiv:1801.01037) and the same load/compute/
+    write-back cycle IBM's secondary-storage Sycamore simulation uses
+    (Pednault et al., arXiv:1910.09534) -- see run_chunk_streaming's own
+    docstring for the full citation and the one optimization (batching
+    consecutive gates per chunk pair) it doesn't yet implement.
+
+    Correctness bar: cross-check against a plain DenseSVSimulator running
+    the identical (transpiled) circuit -- same standard the other two
+    execution modes' test classes use."""
+
+    @pytest.fixture
+    def force_chunk_bits(self, monkeypatch):
+        import dense_evolution.chunk as chunk_mod
+
+        def _force(bits):
+            monkeypatch.setattr(chunk_mod, "get_dynamic_chunk", lambda dtype_target: bits)
+
+        return _force
+
+    def _compare_to_reference(self, n_qubits, circuit, use_float32=False):
+        c = Chunk(n_qubits, use_float32=use_float32, streaming=True)
+        c.run_chunk_streaming(circuit)
+        sv_stream = np.asarray(c.get_statevector())
+
+        ref = DenseSVSimulator(n_qubits, use_float32=use_float32)
+        ref.run_circuit(circuit, transpile=True)
+        sv_ref = np.asarray(ref.get_statevector())
+        return sv_stream, sv_ref
+
+    def test_1q_local(self, force_chunk_bits):
+        force_chunk_bits(3)  # n_qubits=6 -> num_chunks=8, m=3
+        sv, ref = self._compare_to_reference(6, [('h', 3), ('rx', 4, 0.4), ('rz', 5, 0.9)])
+        np.testing.assert_allclose(sv, ref, atol=1e-9)
+
+    def test_1q_chunk_select(self, force_chunk_bits):
+        force_chunk_bits(3)
+        sv, ref = self._compare_to_reference(6, [('h', 0), ('h', 1), ('h', 2)])
+        np.testing.assert_allclose(sv, ref, atol=1e-9)
+
+    def test_2q_local_local(self, force_chunk_bits):
+        force_chunk_bits(3)
+        sv, ref = self._compare_to_reference(6, [('h', 3), ('cx', 3, 4), ('cx', 4, 5)])
+        np.testing.assert_allclose(sv, ref, atol=1e-9)
+
+    @pytest.mark.parametrize("gate", ["cx", "cz", "cy"])
+    def test_2q_control_chunk_select_target_local(self, force_chunk_bits, gate):
+        force_chunk_bits(3)
+        circuit = [('h', 0), ('h', 1), ('h', 2), ('h', 5), (gate, 0, 5)]
+        sv, ref = self._compare_to_reference(6, circuit)
+        np.testing.assert_allclose(sv, ref, atol=1e-9)
+
+    @pytest.mark.parametrize("gate", ["cx", "cz", "cy"])
+    def test_2q_control_local_target_chunk_select(self, force_chunk_bits, gate):
+        force_chunk_bits(3)
+        circuit = [('h', 5), ('h', 0), (gate, 5, 0)]
+        sv, ref = self._compare_to_reference(6, circuit)
+        np.testing.assert_allclose(sv, ref, atol=1e-9)
+
+    @pytest.mark.parametrize("gate", ["cx", "cz", "cy"])
+    def test_2q_control_chunk_select_target_chunk_select(self, force_chunk_bits, gate):
+        force_chunk_bits(3)
+        circuit = [('h', 0), ('h', 1), (gate, 0, 1)]
+        sv, ref = self._compare_to_reference(6, circuit)
+        np.testing.assert_allclose(sv, ref, atol=1e-9)
+
+    def test_parametric_2q_gates(self, force_chunk_bits):
+        force_chunk_bits(3)
+        circuit = [('h', q) for q in range(6)] + [('crz', 0, 1, 0.5), ('cp', 3, 4, 0.7)]
+        sv, ref = self._compare_to_reference(6, circuit)
+        np.testing.assert_allclose(sv, ref, atol=1e-9)
+
+    @pytest.mark.parametrize("gate_op", [
+        ("u3", ('u3', 3, 0.3, 0.5, 0.7)),
+        ("u2", ('u2', 2, 0.4, 0.9)),
+        ("ecr", ('ecr', 2, 3)),
+        ("iswap", ('iswap', 2, 3)),
+    ], ids=lambda p: p[0])
+    def test_gphase_derived_gates_match_reference(self, force_chunk_bits, gate_op):
+        _, op = gate_op
+        force_chunk_bits(3)
+        circuit = [('h', q) for q in range(6)] + [op, ('cx', 3, 4)]
+        sv, ref = self._compare_to_reference(6, circuit)
+        np.testing.assert_allclose(sv, ref, atol=1e-9)
+
+    def test_random_mixed_circuit_large_num_chunks(self, force_chunk_bits):
+        # num_chunks=128 (n_qubits=9, chunk_size_bits=2) -- stresses the
+        # "skip untouched chunks entirely" optimization in
+        # _apply_2q_streaming's ctrl-chunk-select cases at real scale, not
+        # just num_chunks=8 like the other tests in this class.
+        force_chunk_bits(2)
+        rng = np.random.default_rng(42)
+        pool_1q, pool_2q = ['h', 'x', 'y', 'z', 's', 'rx', 'ry', 'rz'], ['cx', 'cz', 'cy', 'crz', 'cp']
+        n = 9
+        circuit = []
+        for _ in range(80):
+            if rng.random() < 0.35:
+                q1, q2 = rng.choice(n, size=2, replace=False)
+                name = rng.choice(pool_2q)
+                if name in ('crz', 'cp'):
+                    circuit.append((name, int(q1), int(q2), float(rng.uniform(0, 6.28))))
+                else:
+                    circuit.append((name, int(q1), int(q2)))
+            else:
+                name = rng.choice(pool_1q)
+                q = int(rng.integers(n))
+                if name in ('rx', 'ry', 'rz'):
+                    circuit.append((name, q, float(rng.uniform(0, 6.28))))
+                else:
+                    circuit.append((name, q))
+        sv, ref = self._compare_to_reference(n, circuit)
+        np.testing.assert_allclose(sv, ref, atol=1e-9)
+
+    def test_dtype_float32(self, force_chunk_bits):
+        force_chunk_bits(2)  # n_qubits=4 -> num_chunks=4, m=2
+        circuit = [('h', 0), ('h', 1), ('cx', 0, 2), ('rz', 3, 0.6)]
+        sv, ref = self._compare_to_reference(4, circuit, use_float32=True)
+        np.testing.assert_allclose(sv, ref, atol=1e-4)
+        assert sv.dtype == np.complex64
+
+    def test_num_chunks_1_forwards_correctly(self, force_chunk_bits):
+        # streaming=True is a no-op when num_chunks==1 -- both constructor
+        # branches produce the same single inner simulator.
+        force_chunk_bits(10)  # n_qubits=4 fits in one chunk
+        c = Chunk(4, streaming=True)
+        assert c.num_chunks == 1
+        sv, ref = self._compare_to_reference(4, [('h', 0), ('cx', 0, 1), ('rz', 2, 0.5)])
+        np.testing.assert_allclose(sv, ref, atol=1e-9)
+
+    def test_run_chunk_raises_on_streaming_instance(self, force_chunk_bits):
+        force_chunk_bits(3)
+        c = Chunk(6, streaming=True)
+        with pytest.raises(RuntimeError, match="streaming"):
+            c.run_chunk([('h', 0)])
+
+    def test_dispatch_distributed_raises_on_streaming_instance(self, force_chunk_bits):
+        force_chunk_bits(3)
+        c = Chunk(6, streaming=True)
+        with pytest.raises(RuntimeError, match="streaming"):
+            c.dispatch_distributed([('h', 0)])
+
+    def test_run_chunk_streaming_raises_without_streaming_true(self, force_chunk_bits):
+        force_chunk_bits(3)
+        c = Chunk(6)  # streaming=False (default), num_chunks=8
+        with pytest.raises(RuntimeError, match="streaming=True"):
+            c.run_chunk_streaming([('h', 0)])
+
+    def test_device_budget_too_small_raises_memory_pressure_error(self, force_chunk_bits):
+        import dense_evolution.chunk as chunk_mod
+
+        force_chunk_bits(3)
+        c = Chunk(6, streaming=True)
+        with pytest.raises(chunk_mod.MemoryPressureError, match="run_chunk_streaming needs room"):
+            c.run_chunk_streaming([('h', 0)], device_budget_mb=0.0001)
+
+    def test_dynamic_default_budget_runs_without_explicit_arg(self, force_chunk_bits):
+        # No device_budget_mb passed -- must fall back to a real, computed
+        # budget (dense_evolution.chunk._device_memory_budget_bytes), not
+        # crash for lack of an explicit number.
+        force_chunk_bits(3)
+        circuit = [('h', 0), ('h', 3), ('cx', 3, 4), ('crz', 0, 4, 0.3)]
+        sv, ref = self._compare_to_reference(6, circuit)
+        np.testing.assert_allclose(sv, ref, atol=1e-9)
+
+    def test_device_transfer_count_matches_hand_derived_formula(self, force_chunk_bits, monkeypatch):
+        # Not a peak-concurrency check (self._host_chunks entries are
+        # always plain numpy between iterations -- the on-device arrays
+        # only ever exist as loop-local Python variables, invisible to any
+        # inspection of self._host_chunks; the "at most 2 chunks on-device
+        # at once" guarantee is a structural property of the code in
+        # _apply_1q_streaming/_apply_2q_streaming, verified by reading
+        # them, not by runtime instrumentation here). What IS directly
+        # measurable and worth pinning down: the TOTAL number of
+        # host<->device transfers for a known circuit, hand-derived case
+        # by case (num_chunks=8, m=3 throughout):
+        #   6x 'h' on q in {0,1,2} (chunk-select) -> 4 pairs x 2 = 8 each  = 24
+        #   6x 'h' on q in {3,4,5} (local)        -> 8 chunks x 1 each    = 24
+        #   cy(0,1)      both chunk-select, only ctrl-set pairs touched  =  4
+        #   crz(3,1,.4)  ctrl local/tgt chunk, all 4 pairs, masked        =  8
+        #   cx(3,4)      both local, every chunk touched                 =  8
+        #                                                          total = 68
+        import dense_evolution.chunk as chunk_mod
+
+        force_chunk_bits(3)
+        c = Chunk(6, streaming=True)
+        counts = []
+        original_device_put = chunk_mod.jax.device_put
+
+        def counting_device_put(x, *a, **kw):
+            counts.append(1)
+            return original_device_put(x, *a, **kw)
+
+        monkeypatch.setattr(chunk_mod.jax, "device_put", counting_device_put)
+        circuit = [('h', q) for q in range(6)] + [('cy', 0, 1), ('crz', 3, 1, 0.4), ('cx', 3, 4)]
+        c.run_chunk_streaming(circuit)
+        assert len(counts) == 68, (
+            f"{len(counts)} device_put calls, expected exactly 68 (see the "
+            f"hand-derived breakdown above) -- the per-gate transfer pattern "
+            f"changed, re-derive and update this count if that was intentional"
+        )

--- a/tests/unit/test_chunk.py
+++ b/tests/unit/test_chunk.py
@@ -798,7 +798,15 @@ class TestChunkStreaming:
         #   cy(0,1)      both chunk-select, only ctrl-set pairs touched  =  4
         #   crz(3,1,.4)  ctrl local/tgt chunk, all 4 pairs, masked        =  8
         #   cx(3,4)      both local, every chunk touched                 =  8
-        #                                                          total = 68
+        #                                                    subtotal    = 68
+        #   + index_cache population (_local_index_arrays): one extra
+        #     device_put per DISTINCT (case, qubit-position) key seen for
+        #     the first time -- h(3), h(4), h(5) each have a different
+        #     local_phys stride, crz's ctrl_phys and cx's (ctrl_phys,
+        #     tgt_phys) are each new keys too -> +5 (h(0..2) are the
+        #     chunk-select branch, which doesn't use the index cache at
+        #     all; cy is the "both chunk-select" case, same)
+        #                                                       total    = 73
         import dense_evolution.chunk as chunk_mod
 
         force_chunk_bits(3)
@@ -813,8 +821,44 @@ class TestChunkStreaming:
         monkeypatch.setattr(chunk_mod.jax, "device_put", counting_device_put)
         circuit = [('h', q) for q in range(6)] + [('cy', 0, 1), ('crz', 3, 1, 0.4), ('cx', 3, 4)]
         c.run_chunk_streaming(circuit)
-        assert len(counts) == 68, (
-            f"{len(counts)} device_put calls, expected exactly 68 (see the "
+        assert len(counts) == 73, (
+            f"{len(counts)} device_put calls, expected exactly 73 (see the "
             f"hand-derived breakdown above) -- the per-gate transfer pattern "
             f"changed, re-derive and update this count if that was intentional"
+        )
+
+    def test_index_cache_is_reused_across_repeated_qubits(self, force_chunk_bits, monkeypatch):
+        # The regression this guards against: np.arange(chunk_dim) (and
+        # the derived xor/mask arrays) used to be recomputed on the HOST,
+        # from scratch, on every single gate call -- catastrophic at
+        # realistic chunk_dim (confirmed on a real Colab GPU: 404s for a
+        # 100-gate circuit at chunk_dim=2**27). Fixed by moving these to
+        # JAX/device arrays, cached per (case, qubit-position) key for the
+        # lifetime of one run_chunk_streaming() call. This test proves the
+        # cache actually gets HIT, not just built: a layered ansatz
+        # repeating the same few qubits many times should populate the
+        # cache once per distinct key and then reuse it, not grow linearly
+        # with circuit length.
+        import dense_evolution.chunk as chunk_mod
+
+        force_chunk_bits(3)
+        c = Chunk(6, streaming=True)
+        original_local_index_arrays = c._local_index_arrays
+        build_calls = []
+
+        def counting_local_index_arrays(cache, key, device, chunk_dim, builder):
+            def counting_builder():
+                build_calls.append(key)
+                return builder()
+            return original_local_index_arrays(cache, key, device, chunk_dim, counting_builder)
+
+        monkeypatch.setattr(c, "_local_index_arrays", counting_local_index_arrays)
+        # 20 repetitions of 'rz' on the SAME local qubit (q=3) -- one
+        # distinct key, should build the cache entry exactly once.
+        circuit = [('rz', 3, float(i) * 0.1) for i in range(20)]
+        c.run_chunk_streaming(circuit)
+        assert build_calls == [('1q_local', 4)], (  # stride = 1 << local_phys = 1 << 2 = 4
+            f"expected the index-cache builder to run exactly once (for the "
+            f"one distinct qubit/case key), got {len(build_calls)} calls: "
+            f"{build_calls} -- the cache isn't being reused across repeated gates"
         )


### PR DESCRIPTION
## Cosa aggiunge

Una terza modalità di esecuzione per `Chunk`, accanto a `run_chunk()` (eager: alloca tutti i chunk in `__init__`, la memoria del device scala con `num_chunks`) e `run_chunk_distributed()` (richiede `jax.device_count() >= num_chunks`): **`run_chunk_streaming()`**, per `Chunk(..., streaming=True)`.

I chunk vivono in RAM host tra un gate e l'altro; **al massimo 2** array grandi quanto un chunk sono mai presenti sul device di calcolo contemporaneamente, indipendentemente da `num_chunks` — un gate confinato ai qubit locali di un chunk ne serve 1, un gate che tocca un qubit "chunk-select" mescola esattamente una coppia (stessa struttura "le ampiezze si scambiano a coppie" della letteratura sulla simulazione distribuita di statevector: LaRose, [arXiv:1801.01037](https://arxiv.org/abs/1801.01037); il ciclo carica/computa/riscrivi rispecchia la simulazione IBM su storage secondario del circuito Sycamore a 54 qubit, Pednault et al., [arXiv:1910.09534](https://arxiv.org/abs/1910.09534)).

Il budget di memoria è **dinamico per default** — VRAM libera reale via `device.memory_stats()` su GPU, RAM host via `psutil` altrimenti — mai un numero fisso; può anche essere impostato esplicitamente. In entrambi i casi, se anche solo 2 chunk non ci stanno, solleva `MemoryPressureError` subito, non dopo un crash XLA a metà esecuzione.

**Numero concreto**: a n=29/chunk_size_bits=26 (esattamente il punto dove `run_chunk` è andato in OOM su una T4 Colab con 11.7GB VRAM, verificato in sessione), il path eager richiede ~5.4GB sul device; streaming ne richiede ~1.1GB — e il rapporto cresce senza limite con `num_chunks`. Il numero di qubit diventa limitato dal tempo e dalla RAM host, non dalla memoria del device.

## Cosa NON fa (ancora)

Nessun raggruppamento dei cicli di lettura/scrittura tra gate consecutivi — ogni gate che tocca un qubit chunk-select paga il proprio trasferimento host↔device. Il paper IBM descrive esattamente questa ottimizzazione (caricare una fetta, applicare *tutti* i gate applicabili, poi riscrivere); documentata come follow-up naturale nel codice, non implementata qui per restare a uno scope verificabile.

## Test

26 nuovi test in `tests/unit/test_chunk.py::TestChunkStreaming`: tutti e 6 i casi gate/posizione-qubit, gate derivati da gphase (u2/u3/ecr/iswap — la stessa classe di bug di PR #113, verificata qui su un path di esecuzione diverso), un circuito misto casuale a `num_chunks=128`, float32, il path di forwarding per `num_chunks==1`, guardie di errore chiaro per uso incrociato con `run_chunk()`/`dispatch_distributed()`, il path di errore per budget insufficiente, e un conteggio esatto dei trasferimenti device (derivato a mano, 68 su un circuito noto — verifica di regressione strutturale).

Suite locale: `test_chunk.py` 68 passed/19 skipped (gli skip sono gli 8 test a 8-device, attesi in locale). Regressione ampia: 636 passed, 0 failed (3 deselezionati sono il flake RAM noto, non correlato).