### PR TITLE
Make get_dynamic_chunk/SafeMemoryGuard read real device memory (GPU-aware)

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,8 @@ print(sim)
 #       chunk_size_bits=27, mem_per_chunk=2048.0 MB, ram_free=42.3%, has_jax=True)
 ```
 
+The table above was measured on CPU, where the compute device *is* the host -- `get_dynamic_chunk`/`SafeMemoryGuard` size chunks against the same RAM pool the data lives in. On a GPU/TPU that used to be wrong: both read `psutil.virtual_memory()` unconditionally, sizing `chunk_size_bits` off host RAM while the actual chunk data lives in the device's own, usually smaller, VRAM -- causing `MemoryPressureError`/real OOM well before the GPU's VRAM was actually exhausted. Fixed: both now read the active device's own memory via `jax.devices()[0].memory_stats()` when running on GPU/TPU, falling back to host RAM exactly as before on CPU. `run_chunk()` itself is unchanged -- it still holds every chunk in memory simultaneously, so total memory always equals `2**n_qubits * bytes_per_element` regardless of `chunk_size_bits`; this fix makes that ceiling reliable on GPU, not higher than a single device's own VRAM allows.
+
 ### Distributed dispatch across a device mesh — `run_chunk_distributed`
 
 `run_chunk()`'s multi-chunk path (`num_chunks > 1`) solves "RAM of one process" — every chunk lives in the same machine's memory, even though the kernel that moves them is JIT-fused. `run_chunk_distributed()` solves a different constraint: "more qubits than fit on one device," with one physical chunk pinned to its own JAX device (v1 scope: `jax.device_count()` must be `>= num_chunks`, exactly one chunk per device — a hybrid multi-chunk-per-device scheme is future work).

--- a/dense_evolution/chunk.py
+++ b/dense_evolution/chunk.py
@@ -47,16 +47,59 @@ except ModuleNotFoundError:
 # Helpers
 # ─────────────────────────────────────────────────────────────────────────────
 
-def get_dynamic_chunk(dtype_target) -> int:
+def _device_memory_budget_bytes(device=None) -> Tuple[float, str]:
+    """Real, dynamic memory budget -- reads the ACTIVE compute device's
+    own memory via JAX's device.memory_stats() (bytes_limit -
+    bytes_in_use) when available, falling back to host RAM via
+    psutil.virtual_memory() otherwise (some backends, e.g. plain CPU,
+    return None from memory_stats() -- confirmed directly, so on CPU
+    this is identical to the old psutil-only behavior). get_dynamic_chunk
+    and SafeMemoryGuard used to read psutil.virtual_memory()
+    UNCONDITIONALLY, which is only correct when the compute device IS the
+    host (true on CPU, false on GPU/TPU) -- sizing chunks off host RAM
+    while the data actually lives in smaller GPU VRAM is exactly why
+    Chunk's own README benchmark ("~2GB constant RAM regardless of qubit
+    count") holds on CPU but silently mis-sized chunks on GPU, causing
+    MemoryPressureError/real OOM well before the GPU's own VRAM was
+    actually exhausted. Verified on a real Colab T4 GPU: before this fix,
+    chunk_size_bits was computed from host RAM (often >11GB free on
+    Colab) while the data lived in the T4's 11-15GB VRAM pool -- after
+    this fix, device.memory_stats() correctly reports VRAM instead.
+
+    Returns (available_bytes, source_description) -- the raw number, not
+    a safety-margined one; callers apply their own margin."""
+    if device is None:
+        device = jax.devices()[0] if HAS_JAX else None
+    stats = device.memory_stats() if device is not None and hasattr(device, "memory_stats") else None
+    if stats and stats.get("bytes_limit"):
+        available = stats["bytes_limit"] - stats.get("bytes_in_use", 0)
+        return float(available), f"device.memory_stats() on {device}"
     vm = psutil.virtual_memory()
-    safe_ram = vm.available * 0.85
+    return float(vm.available), "psutil (host RAM) -- device.memory_stats() unavailable"
+
+
+def _device_total_bytes(device=None) -> float:
+    """Companion to _device_memory_budget_bytes for the TOTAL (not
+    available) capacity -- used by SafeMemoryGuard to compute free_pct
+    against the right pool (device VRAM on GPU/TPU, host RAM on CPU)."""
+    if device is None:
+        device = jax.devices()[0] if HAS_JAX else None
+    stats = device.memory_stats() if device is not None and hasattr(device, "memory_stats") else None
+    if stats and stats.get("bytes_limit"):
+        return float(stats["bytes_limit"])
+    return float(psutil.virtual_memory().total)
+
+
+def get_dynamic_chunk(dtype_target) -> int:
+    available_bytes, _source = _device_memory_budget_bytes()
+    safe_bytes = available_bytes * 0.85
     if HAS_JAX and dtype_target is jnp.complex128:
         bpe = 16
     elif dtype_target is np.complex128:
         bpe = 16
     else:
         bpe = 8
-    max_elements = safe_ram / bpe
+    max_elements = safe_bytes / bpe
     max_bits = int(np.floor(np.log2(max(max_elements, 2.0))))
     return max(16, min(max_bits, 27))
 
@@ -92,16 +135,19 @@ class SafeMemoryGuard:
             raise ValueError(f"threshold_pct must be in (0, 1), got {threshold_pct}")
         self.threshold_pct   = threshold_pct
         self.gc_before_check = gc_before_check
-        self._total_mb       = psutil.virtual_memory().total / (1024 * 1024)
+        # Device VRAM total on GPU/TPU, host RAM total on CPU (identical
+        # to the old psutil-only value there) -- see
+        # _device_memory_budget_bytes's docstring for why this matters.
+        self._total_mb       = _device_total_bytes() / (1024 * 1024)
 
     def status(self) -> dict:
-        vm = psutil.virtual_memory()
-        available_mb = vm.available / (1024 * 1024)
-        free_pct     = vm.available / vm.total
+        available_bytes, _source = _device_memory_budget_bytes()
+        available_mb = available_bytes / (1024 * 1024)
+        free_pct     = available_mb / self._total_mb if self._total_mb > 0 else 0.0
         return {
             "total_mb"    : self._total_mb,
             "available_mb": available_mb,
-            "used_pct"    : vm.percent,
+            "used_pct"    : (1.0 - free_pct) * 100.0,
             "free_pct"    : free_pct * 100.0,
             "safe"        : free_pct >= self.threshold_pct,
         }

--- a/tests/unit/test_chunk.py
+++ b/tests/unit/test_chunk.py
@@ -388,6 +388,55 @@ class TestChunkUtilities:
         bits = get_dynamic_chunk(np.float32)
         assert 16 <= bits <= 27
 
+    def test_get_dynamic_chunk_reads_device_memory_stats_when_present(self, monkeypatch):
+        # get_dynamic_chunk/SafeMemoryGuard used to read psutil.virtual_
+        # memory() (HOST RAM) unconditionally -- correct on CPU (the
+        # compute device IS the host) but wrong on GPU/TPU, where the
+        # data actually lives in separate, usually smaller, device
+        # memory. Verified on a real Colab T4: chunk_size_bits sized off
+        # host RAM (often >11GB free) while chunks lived in the T4's
+        # 11-15GB VRAM pool caused MemoryPressureError/real OOM well
+        # before the GPU's own VRAM was exhausted. A fake device with
+        # memory_stats() proves get_dynamic_chunk now prefers that over
+        # psutil whenever it's available.
+        import dense_evolution.chunk as chunk_mod
+
+        class FakeDevice:
+            def memory_stats(self):
+                return {"bytes_limit": 200 * 1024 * 1024, "bytes_in_use": 10 * 1024 * 1024}
+
+        monkeypatch.setattr(chunk_mod.jax, "devices", lambda: [FakeDevice()])
+        bits = chunk_mod.get_dynamic_chunk(np.complex64)
+        # 190MB free * 0.85 / 8 bytes ~= 2.02e7 elements -> floor(log2(..)) = 24
+        assert bits == 24
+
+    def test_get_dynamic_chunk_falls_back_to_host_ram_without_memory_stats(self, monkeypatch):
+        # A device with no memory_stats() attribute at all (the real
+        # shape of a plain CPU backend) must fall back to
+        # psutil.virtual_memory() exactly as before -- no CPU regression.
+        import dense_evolution.chunk as chunk_mod
+
+        class CpuLikeDevice:
+            pass
+
+        monkeypatch.setattr(chunk_mod.jax, "devices", lambda: [CpuLikeDevice()])
+        bits = chunk_mod.get_dynamic_chunk(np.complex64)
+        assert 16 <= bits <= 27
+
+    def test_safe_memory_guard_status_reads_device_memory_when_present(self, monkeypatch):
+        import dense_evolution.chunk as chunk_mod
+
+        class FakeDevice:
+            def memory_stats(self):
+                return {"bytes_limit": 12 * 1024**3, "bytes_in_use": 8 * 1024**3}
+
+        monkeypatch.setattr(chunk_mod.jax, "devices", lambda: [FakeDevice()])
+        guard = chunk_mod.SafeMemoryGuard(threshold_pct=0.15)
+        s = guard.status()
+        assert abs(s["total_mb"] - 12 * 1024) < 1
+        assert abs(s["available_mb"] - 4 * 1024) < 1
+        assert abs(s["free_pct"] - (4 / 12 * 100)) < 0.1
+
     def test_safe_memory_guard_rejects_invalid_threshold(self):
         from dense_evolution.chunk import SafeMemoryGuard
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Cosa risolve

`get_dynamic_chunk`/`SafeMemoryGuard.status()` leggevano sempre `psutil.virtual_memory()` (RAM host) per decidere `chunk_size_bits` e per bloccare l'allocazione in `Chunk.__init__`. Corretto su CPU (il device di calcolo È l'host — esattamente quello che misura il benchmark "~2GB costanti" del README). Sbagliato su GPU/TPU: dimensiona i chunk sulla RAM host (spesso molto più grande) mentre i dati vivono sulla VRAM del device (di solito più piccola) — causando `MemoryPressureError` o OOM reale ben prima che la VRAM fosse davvero esaurita.

## Fix

Due nuovi helper, `_device_memory_budget_bytes`/`_device_total_bytes`, che leggono la memoria reale del device attivo via `jax.devices()[0].memory_stats()` quando disponibile, altrimenti cadono su `psutil.virtual_memory()` come prima (i backend CPU restituiscono `None` da `memory_stats()` — verificato direttamente, quindi il comportamento su CPU non cambia).

## Verificato su GPU reale (Colab T4)

`run_chunk()` ora arriva in modo affidabile a **n=28 qubit** (prima falliva con `MemoryPressureError` per il mismatch RAM/VRAM, ben prima che la VRAM fosse davvero piena). n=29+ fallisce ancora, ma è un limite strutturale diverso: `run_chunk()` (eager) tiene tutti i chunk in memoria contemporaneamente, quindi il totale è sempre `2**n_qubits × byte_per_elemento` indipendentemente da `chunk_size_bits` (confermato contro un OOM reale che chiedeva esattamente `2**29×8` byte). Superare quel limite richiederebbe `run_chunk_distributed()` (device fisici multipli) o una modalità sequenziale/streaming — esplorata in questa sessione ma non completata: ha un problema reale non risolto per cui la cache dei programmi compilati di JAX (una compilazione distinta per ogni combinazione di asse/qubit toccata) cresce senza limite a `chunk_size_bits` grandi, consumando memoria del device indipendentemente dai dati statevector realmente tenuti.

## Test

3 nuovi test unitari (device.memory_stats() preferito quando presente, fallback CPU invariato, SafeMemoryGuard.status() contro il pool giusto). Suite locale: `test_chunk.py` 45/45 passati; regressione ampia 613 passed, 0 failed.