### PR TITLE
Release prep: bump to v8.1.66

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -35,7 +35,7 @@ from .physics.entropy import partial_trace, von_neumann_entropy, mutual_informat
 from .circuits.trotter import pauli_rotation_ops, trotter_evolve_ops
 from .physics.qec import pauli_commutes, compute_syndrome, erasure_aware_decode, pymatching_decode, blind_minimum_weight_decode
 
-__version__ = "8.1.65"
+__version__ = "8.1.66"
 
 __all__ = [
     "__version__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dense-evolution"
-version = "8.1.65"
+version = "8.1.66"
 description = "Micro-optimized High-Performance NISQ Statevector Quantum Circuit Simulator (Hardware-Adaptive Integration of Native NumPy and CPU/GPU/TPU JAX JIT/XLA Compilation, with Linear Kernel Fusion)"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Version bump only, no functional changes -- packages the README/docs fixes from #117/#118 into a taggable release.