### PR TITLE
Promote plot_circuit and global_depolarizing_channel from Discovery Experiment 33

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -16,9 +16,10 @@ from .solvers.autodiff import circuit_to_energy_fn
 from .backends.mps import MPSSimulator
 from .mitigation.zne import (richardson_extrapolate, zero_noise_extrapolation, polynomial_extrapolate,
                           project_to_physical, uhlmann_fidelity, zne_density_matrix,
-                          jsd_predictive_zne_density_matrix,
+                          jsd_predictive_zne_density_matrix, global_depolarizing_channel,
                           richardson_extrapolate_jit, zero_noise_extrapolation_jit,
                           polynomial_extrapolate_jit, uhlmann_fidelity_jit, zne_density_matrix_jit)
+from .circuits.diagram import plot_circuit
 from .circuits.topology import entangling_layer
 from .physics.observables import pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix, pauli_sum_matvec
 from .physics.states import ghz_state
@@ -59,7 +60,7 @@ __all__ = [
     # Mitigation -- Zero-Noise Extrapolation
     "richardson_extrapolate", "zero_noise_extrapolation", "polynomial_extrapolate",
     "project_to_physical", "uhlmann_fidelity", "zne_density_matrix",
-    "jsd_predictive_zne_density_matrix",
+    "jsd_predictive_zne_density_matrix", "global_depolarizing_channel",
     "richardson_extrapolate_jit", "zero_noise_extrapolation_jit",
     "polynomial_extrapolate_jit", "uhlmann_fidelity_jit", "zne_density_matrix_jit",
     # Physics -- states, observables, entropy, fermions, QEC
@@ -69,5 +70,5 @@ __all__ = [
     "majorana_pauli_terms",
     "pauli_commutes", "compute_syndrome", "erasure_aware_decode", "pymatching_decode", "blind_minimum_weight_decode",
     # Utils -- drawing, measurement, random circuits
-    "draw_circuit", "sample_counts", "statevector_fidelity", "random_circuit",
+    "draw_circuit", "plot_circuit", "sample_counts", "statevector_fidelity", "random_circuit",
 ]

--- a/dense_evolution/circuits/diagram.py
+++ b/dense_evolution/circuits/diagram.py
@@ -1,0 +1,94 @@
+"""
+Quirk-style box-diagram circuit drawing (matplotlib), promoted from
+Dense-Evolution-Discovery Experiment 33's `draw_circuit` utility.
+
+Draws circuits directly in this package's own native gate-tuple format
+(the same list DenseSVSimulator.run_circuit accepts) -- integers after the
+gate name are qubit indices, floats are parameters, so no gate-name table
+needs to be kept in sync with circuits/registry.py's own GATE_IDS.
+"""
+import matplotlib.pyplot as plt
+from matplotlib.patches import Rectangle, Circle
+
+__all__ = ["plot_circuit"]
+
+
+def plot_circuit(circuit, n_qubits, title=None, figsize=None):
+    """Draw a circuit in dense_evolution's native tuple format as a
+    Quirk-style box diagram.
+
+    circuit : list[tuple]
+        E.g. [('x', 1), ('cx', 0, 1), ('iswap', 0, 1), ('rz', 0, 0.5)].
+    n_qubits : int
+
+    Returns the matplotlib Figure (not shown/saved automatically).
+    """
+    WIRE_COLOR = "#4a5266"
+    BG = "#0a0a0d"
+    TEXT = "#9aa3b2"
+    LABEL_COLOR = "#ff5c5c"
+    G1_FILL, G1_EDGE = "#0f2a30", "#00e5ff"   # single-qubit gate
+    G2_FILL, G2_EDGE = "#0f2a22", "#00ff9d"   # multi-qubit gate
+    CHAR_W = 0.145
+    MIN_BOX_W, BOX_H, GAP = 0.62, 0.5, 0.18
+
+    def box_width_for(label):
+        return max(MIN_BOX_W, len(label) * CHAR_W + 0.22)
+
+    next_free_x = [0.5] * n_qubits
+    boxes = []
+    for op in circuit:
+        name = op[0]
+        qubits = [a for a in op[1:] if isinstance(a, int) and not isinstance(a, bool)]
+        params = [a for a in op[1:] if isinstance(a, float)]
+        if not qubits:
+            continue
+        label = name.upper() if not params else f"{name.upper()}({params[0]:.2f})"
+        w = box_width_for(label)
+        x = max(next_free_x[q] for q in qubits) + w / 2
+        boxes.append((x, qubits, label, w))
+        for q in qubits:
+            next_free_x[q] = x + w / 2 + GAP
+
+    total_w = max(next_free_x) + 0.3
+    fig_w = figsize[0] if figsize else max(4.0, total_w * 0.9)
+    fig_h = figsize[1] if figsize else 0.9 * n_qubits + 0.6
+    fig, ax = plt.subplots(figsize=(fig_w, fig_h), facecolor=BG)
+    ax.set_facecolor(BG)
+
+    for q in range(n_qubits):
+        y = n_qubits - 1 - q
+        ax.plot([0, total_w], [y, y], color=WIRE_COLOR, lw=1.5, zorder=1)
+        ax.text(-0.15, y, f"q{q}", ha="right", va="center", color=TEXT,
+                 fontsize=11, family="monospace")
+
+    for x, qubits, label, box_w in boxes:
+        ys = [n_qubits - 1 - q for q in qubits]
+        y_lo, y_hi = min(ys), max(ys)
+        is_multi = len(qubits) > 1
+        fill, edge = (G2_FILL, G2_EDGE) if is_multi else (G1_FILL, G1_EDGE)
+        if is_multi:
+            ax.plot([x, x], [y_lo, y_hi], color=edge, lw=1.3, zorder=2)
+            for y in ys:
+                ax.add_patch(Circle((x, y), 0.045, color=edge, zorder=4))
+            rect = Rectangle((x - box_w / 2, y_lo - BOX_H / 2),
+                              box_w, (y_hi - y_lo) + BOX_H,
+                              facecolor=fill, edgecolor=edge, lw=1.4, zorder=3)
+            ax.add_patch(rect)
+            ax.text(x, (y_lo + y_hi) / 2, label, ha="center", va="center",
+                     color=LABEL_COLOR, fontsize=10.5, family="monospace", fontweight="bold", zorder=5)
+        else:
+            y = ys[0]
+            rect = Rectangle((x - box_w / 2, y - BOX_H / 2), box_w, BOX_H,
+                              facecolor=fill, edgecolor=edge, lw=1.4, zorder=3)
+            ax.add_patch(rect)
+            ax.text(x, y, label, ha="center", va="center", color=LABEL_COLOR,
+                     fontsize=10.5, family="monospace", fontweight="bold", zorder=4)
+
+    ax.set_xlim(-0.6, total_w)
+    ax.set_ylim(-0.6, n_qubits - 0.4)
+    ax.axis("off")
+    if title:
+        ax.set_title(title, color=TEXT, fontsize=12, family="monospace", pad=12)
+    plt.tight_layout()
+    return fig

--- a/dense_evolution/mitigation/zne.py
+++ b/dense_evolution/mitigation/zne.py
@@ -20,7 +20,7 @@ from .healing import calculate_delta_preemp
 
 __all__ = ["richardson_extrapolate", "zero_noise_extrapolation", "polynomial_extrapolate",
            "project_to_physical", "uhlmann_fidelity", "zne_density_matrix",
-           "jsd_predictive_zne_density_matrix",
+           "jsd_predictive_zne_density_matrix", "global_depolarizing_channel",
            "richardson_extrapolate_jit", "zero_noise_extrapolation_jit",
            "polynomial_extrapolate_jit", "uhlmann_fidelity_jit", "zne_density_matrix_jit"]
 
@@ -400,6 +400,24 @@ def uhlmann_fidelity(rho_A: jnp.ndarray, rho_B: jnp.ndarray) -> float:
     rho_A = jnp.asarray(rho_A, dtype=jnp.complex128)
     rho_B = jnp.asarray(rho_B, dtype=jnp.complex128)
     return float(_uhlmann_fidelity_core(rho_A, rho_B))
+
+
+def global_depolarizing_channel(rho: jnp.ndarray, p: float) -> jnp.ndarray:
+    """Global n-qubit depolarizing channel, D_p(rho) = (1-p)*rho + (p/dim)*I.
+
+    Distinct from `NoiseModel`'s `'depolarizing'` model in `circuits.registry`,
+    which applies an independent PER-QUBIT local Kraus channel -- a different
+    physical map from this GLOBAL channel, which mixes the whole `dim`-
+    dimensional state toward the fully mixed state as one unit. Use this one
+    when modeling e.g. state-prep/measurement (SPAM) error reported as a
+    single joint depolarizing parameter over the whole register, not per-
+    qubit gate noise (promoted from a real reproduction of arXiv:2608.16716's
+    own SPAM model, Dense-Evolution-Discovery Experiment 33).
+    """
+    rho = jnp.asarray(rho, dtype=jnp.complex128)
+    dim = rho.shape[0]
+    identity = jnp.eye(dim, dtype=jnp.complex128)
+    return (1.0 - p) * rho + (p / dim) * identity
 
 
 def _uhlmann_fidelity_core(rho_A: jnp.ndarray, rho_B: jnp.ndarray) -> jnp.ndarray:

--- a/tests/unit/test_diagram_and_depolarizing.py
+++ b/tests/unit/test_diagram_and_depolarizing.py
@@ -1,0 +1,33 @@
+import matplotlib
+matplotlib.use("Agg")
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from dense_evolution import plot_circuit, global_depolarizing_channel
+
+
+def test_plot_circuit_returns_figure_with_single_and_multi_qubit_gates():
+    fig = plot_circuit([('x', 1), ('rz', 0, 0.5), ('iswap', 0, 1)], n_qubits=2)
+    assert isinstance(fig, plt.Figure)
+    plt.close(fig)
+
+
+def test_global_depolarizing_channel_preserves_trace():
+    rho = np.zeros((4, 4), dtype=complex)
+    rho[0, 0] = 1.0
+    out = global_depolarizing_channel(rho, 0.3)
+    assert abs(complex(np.trace(out)) - 1.0) < 1e-9
+
+
+def test_global_depolarizing_channel_at_p_zero_is_identity_map():
+    rho = np.array([[0.6, 0.1], [0.1, 0.4]], dtype=complex)
+    out = global_depolarizing_channel(rho, 0.0)
+    assert np.allclose(out, rho)
+
+
+def test_global_depolarizing_channel_at_p_one_is_maximally_mixed():
+    rho = np.zeros((4, 4), dtype=complex)
+    rho[0, 0] = 1.0
+    out = global_depolarizing_channel(rho, 1.0)
+    assert np.allclose(out, np.eye(4) / 4)


### PR DESCRIPTION
Two utilities built for the germanium iSWAP validation (Dense-Evolution-Discovery #74/#75), promoted here as they proved generally useful:

- `plot_circuit`: Quirk-style matplotlib box-diagram circuit drawer. Distinct from the existing `draw_circuit` (text-based), so it's exported under a new name to avoid collision.
- `global_depolarizing_channel`: n-qubit global depolarizing map `D_p(rho)=(1-p)*rho+(p/dim)*I`, distinct from `NoiseModel`'s per-qubit local depolarizing channel.

4/4 new tests passing; verified no regression to the existing `draw_circuit`.