### PR TITLE
Add continuous_pulse_evolve: JAX-native time-dependent Hamiltonian evolution

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -16,9 +16,10 @@ from .solvers.autodiff import circuit_to_energy_fn
 from .backends.mps import MPSSimulator
 from .mitigation.zne import (richardson_extrapolate, zero_noise_extrapolation, polynomial_extrapolate,
                           project_to_physical, uhlmann_fidelity, zne_density_matrix,
-                          jsd_predictive_zne_density_matrix,
+                          jsd_predictive_zne_density_matrix, global_depolarizing_channel,
                           richardson_extrapolate_jit, zero_noise_extrapolation_jit,
                           polynomial_extrapolate_jit, uhlmann_fidelity_jit, zne_density_matrix_jit)
+from .circuits.diagram import plot_circuit
 from .circuits.topology import entangling_layer
 from .physics.observables import pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix, pauli_sum_matvec
 from .physics.states import ghz_state
@@ -59,7 +60,7 @@ __all__ = [
     # Mitigation -- Zero-Noise Extrapolation
     "richardson_extrapolate", "zero_noise_extrapolation", "polynomial_extrapolate",
     "project_to_physical", "uhlmann_fidelity", "zne_density_matrix",
-    "jsd_predictive_zne_density_matrix",
+    "jsd_predictive_zne_density_matrix", "global_depolarizing_channel",
     "richardson_extrapolate_jit", "zero_noise_extrapolation_jit",
     "polynomial_extrapolate_jit", "uhlmann_fidelity_jit", "zne_density_matrix_jit",
     # Physics -- states, observables, entropy, fermions, QEC
@@ -69,5 +70,5 @@ __all__ = [
     "majorana_pauli_terms",
     "pauli_commutes", "compute_syndrome", "erasure_aware_decode", "pymatching_decode", "blind_minimum_weight_decode",
     # Utils -- drawing, measurement, random circuits
-    "draw_circuit", "sample_counts", "statevector_fidelity", "random_circuit",
+    "draw_circuit", "plot_circuit", "sample_counts", "statevector_fidelity", "random_circuit",
 ]

--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -33,7 +33,7 @@ from .solvers.vhd_tb import (MATERIALS as VHD_MATERIALS, sp3s_star_hamiltonian,
                               direct_gap_at_gamma, band_extrema_along_path)
 from .physics.fermions import majorana_pauli_terms
 from .physics.entropy import partial_trace, von_neumann_entropy, mutual_information
-from .circuits.trotter import pauli_rotation_ops, trotter_evolve_ops
+from .circuits.trotter import pauli_rotation_ops, trotter_evolve_ops, continuous_pulse_evolve
 from .physics.qec import pauli_commutes, compute_syndrome, erasure_aware_decode, pymatching_decode, blind_minimum_weight_decode
 
 __version__ = "8.1.66"
@@ -47,7 +47,7 @@ __all__ = [
     "NoiseModel", "NoiseSpec", "QuantumHardwareRegistry",
     "GATES", "PARAMETRIC_GATES", "GATE_IDS",
     "entangling_layer", "qft",
-    "pauli_rotation_ops", "trotter_evolve_ops",
+    "pauli_rotation_ops", "trotter_evolve_ops", "continuous_pulse_evolve",
     # Chunking / anti-OOM
     "Chunk",
     # Interop -- Qiskit / PennyLane / STIM bridges

--- a/dense_evolution/circuits/diagram.py
+++ b/dense_evolution/circuits/diagram.py
@@ -1,0 +1,94 @@
+"""
+Quirk-style box-diagram circuit drawing (matplotlib), promoted from
+Dense-Evolution-Discovery Experiment 33's `draw_circuit` utility.
+
+Draws circuits directly in this package's own native gate-tuple format
+(the same list DenseSVSimulator.run_circuit accepts) -- integers after the
+gate name are qubit indices, floats are parameters, so no gate-name table
+needs to be kept in sync with circuits/registry.py's own GATE_IDS.
+"""
+import matplotlib.pyplot as plt
+from matplotlib.patches import Rectangle, Circle
+
+__all__ = ["plot_circuit"]
+
+
+def plot_circuit(circuit, n_qubits, title=None, figsize=None):
+    """Draw a circuit in dense_evolution's native tuple format as a
+    Quirk-style box diagram.
+
+    circuit : list[tuple]
+        E.g. [('x', 1), ('cx', 0, 1), ('iswap', 0, 1), ('rz', 0, 0.5)].
+    n_qubits : int
+
+    Returns the matplotlib Figure (not shown/saved automatically).
+    """
+    WIRE_COLOR = "#4a5266"
+    BG = "#0a0a0d"
+    TEXT = "#9aa3b2"
+    LABEL_COLOR = "#ff5c5c"
+    G1_FILL, G1_EDGE = "#0f2a30", "#00e5ff"   # single-qubit gate
+    G2_FILL, G2_EDGE = "#0f2a22", "#00ff9d"   # multi-qubit gate
+    CHAR_W = 0.145
+    MIN_BOX_W, BOX_H, GAP = 0.62, 0.5, 0.18
+
+    def box_width_for(label):
+        return max(MIN_BOX_W, len(label) * CHAR_W + 0.22)
+
+    next_free_x = [0.5] * n_qubits
+    boxes = []
+    for op in circuit:
+        name = op[0]
+        qubits = [a for a in op[1:] if isinstance(a, int) and not isinstance(a, bool)]
+        params = [a for a in op[1:] if isinstance(a, float)]
+        if not qubits:
+            continue
+        label = name.upper() if not params else f"{name.upper()}({params[0]:.2f})"
+        w = box_width_for(label)
+        x = max(next_free_x[q] for q in qubits) + w / 2
+        boxes.append((x, qubits, label, w))
+        for q in qubits:
+            next_free_x[q] = x + w / 2 + GAP
+
+    total_w = max(next_free_x) + 0.3
+    fig_w = figsize[0] if figsize else max(4.0, total_w * 0.9)
+    fig_h = figsize[1] if figsize else 0.9 * n_qubits + 0.6
+    fig, ax = plt.subplots(figsize=(fig_w, fig_h), facecolor=BG)
+    ax.set_facecolor(BG)
+
+    for q in range(n_qubits):
+        y = n_qubits - 1 - q
+        ax.plot([0, total_w], [y, y], color=WIRE_COLOR, lw=1.5, zorder=1)
+        ax.text(-0.15, y, f"q{q}", ha="right", va="center", color=TEXT,
+                 fontsize=11, family="monospace")
+
+    for x, qubits, label, box_w in boxes:
+        ys = [n_qubits - 1 - q for q in qubits]
+        y_lo, y_hi = min(ys), max(ys)
+        is_multi = len(qubits) > 1
+        fill, edge = (G2_FILL, G2_EDGE) if is_multi else (G1_FILL, G1_EDGE)
+        if is_multi:
+            ax.plot([x, x], [y_lo, y_hi], color=edge, lw=1.3, zorder=2)
+            for y in ys:
+                ax.add_patch(Circle((x, y), 0.045, color=edge, zorder=4))
+            rect = Rectangle((x - box_w / 2, y_lo - BOX_H / 2),
+                              box_w, (y_hi - y_lo) + BOX_H,
+                              facecolor=fill, edgecolor=edge, lw=1.4, zorder=3)
+            ax.add_patch(rect)
+            ax.text(x, (y_lo + y_hi) / 2, label, ha="center", va="center",
+                     color=LABEL_COLOR, fontsize=10.5, family="monospace", fontweight="bold", zorder=5)
+        else:
+            y = ys[0]
+            rect = Rectangle((x - box_w / 2, y - BOX_H / 2), box_w, BOX_H,
+                              facecolor=fill, edgecolor=edge, lw=1.4, zorder=3)
+            ax.add_patch(rect)
+            ax.text(x, y, label, ha="center", va="center", color=LABEL_COLOR,
+                     fontsize=10.5, family="monospace", fontweight="bold", zorder=4)
+
+    ax.set_xlim(-0.6, total_w)
+    ax.set_ylim(-0.6, n_qubits - 0.4)
+    ax.axis("off")
+    if title:
+        ax.set_title(title, color=TEXT, fontsize=12, family="monospace", pad=12)
+    plt.tight_layout()
+    return fig

--- a/dense_evolution/circuits/trotter.py
+++ b/dense_evolution/circuits/trotter.py
@@ -41,7 +41,11 @@ where gate count directly limits how much depolarizing noise the
 circuit accumulates).
 """
 
-__all__ = ['pauli_rotation_ops', 'trotter_evolve_ops']
+import jax
+import jax.numpy as jnp
+from jax.scipy.linalg import expm
+
+__all__ = ['pauli_rotation_ops', 'trotter_evolve_ops', 'continuous_pulse_evolve']
 
 
 def pauli_rotation_ops(pauli_dict, angle):
@@ -142,3 +146,65 @@ def trotter_evolve_ops(terms, t, n_steps, order=1):
         for c, pdict in reversed(terms):
             step_ops.extend(pauli_rotation_ops(pdict, c * half_dt))
     return step_ops * n_steps
+
+
+def continuous_pulse_evolve(psi0, hamiltonian_fn, coeffs_t, dt, observable_fn=None):
+    """Evolve a statevector under a time-dependent Hamiltonian via
+    jax.lax.scan, generalized out of a pattern first written ad hoc for a
+    real time-dependent pulse (Dense-Evolution-Discovery's
+    germanium_iswap_validation.py, exact_final_state/exact_final_state_general
+    -- a 56ns raised-cosine baseband iSWAP pulse, arXiv:2608.16716). That
+    script's own Trotterized-gate-circuit version of the same pulse
+    (build_pulse_circuit) instead builds a plain Python list of gate tuples,
+    one exp(-i*H*dt) per slice via pauli_rotation_ops -- fine for producing a
+    circuit a discrete-gate simulator can run, but not what this function is
+    for: this evolves the statevector directly, slice by slice, entirely
+    inside JAX, with no Python-side list that grows with the number of
+    slices (the O(1)-per-step scan carry is the whole point -- many slices
+    for a finely-resolved pulse cost compile time, not accumulating Python
+    memory).
+
+    Not specific to any one Hamiltonian, qubit count, or pulse shape --
+    `hamiltonian_fn` supplies the (possibly qubit-count-dependent) operator
+    for a given instantaneous coefficient, and `coeffs_t` can be any sampled
+    time-dependent profile (a smooth pulse envelope, a sudden burst, a
+    constant array for a time-independent Hamiltonian, etc.).
+
+    Parameters
+    ----------
+    psi0 : array_like
+        Initial statevector, shape (2**n_qubits,).
+    hamiltonian_fn : callable
+        coeff -> Hamiltonian matrix, shape (2**n_qubits, 2**n_qubits), for
+        that instant's coefficient. Called once per entry of `coeffs_t`
+        under jax.lax.scan, so it must be JAX-traceable.
+    coeffs_t : array_like
+        Per-slice instantaneous coefficient, one entry per time slice
+        (e.g. a peak amplitude times a sampled pulse envelope). The
+        evolution applies exp(-i*hamiltonian_fn(coeff)*dt) for each entry,
+        in order.
+    dt : float
+        Duration of one slice (coeffs_t is assumed sampled on a uniform
+        grid of this spacing -- same convention as the germanium
+        experiment's dt=0.05 ns midpoint/linspace sampling).
+    observable_fn : callable, optional
+        If given, applied to the statevector after each slice; the stacked
+        per-slice results are returned as `trajectory` (mirrors the
+        experiment's own step_record, used there to plot |01>/|10>
+        occupation probability over the pulse). If omitted, `trajectory`
+        is None and only the final state is computed.
+
+    Returns
+    -------
+    final_psi : jnp.ndarray
+    trajectory : jnp.ndarray or None
+    """
+    def step(psi, coeff):
+        H_t = hamiltonian_fn(coeff)
+        U_step = expm(-1j * H_t * dt)
+        next_psi = jnp.dot(U_step, psi)
+        y = observable_fn(next_psi) if observable_fn is not None else None
+        return next_psi, y
+
+    final_psi, trajectory = jax.lax.scan(step, jnp.asarray(psi0), jnp.asarray(coeffs_t))
+    return final_psi, trajectory

--- a/dense_evolution/mitigation/zne.py
+++ b/dense_evolution/mitigation/zne.py
@@ -20,7 +20,7 @@ from .healing import calculate_delta_preemp
 
 __all__ = ["richardson_extrapolate", "zero_noise_extrapolation", "polynomial_extrapolate",
            "project_to_physical", "uhlmann_fidelity", "zne_density_matrix",
-           "jsd_predictive_zne_density_matrix",
+           "jsd_predictive_zne_density_matrix", "global_depolarizing_channel",
            "richardson_extrapolate_jit", "zero_noise_extrapolation_jit",
            "polynomial_extrapolate_jit", "uhlmann_fidelity_jit", "zne_density_matrix_jit"]
 
@@ -400,6 +400,24 @@ def uhlmann_fidelity(rho_A: jnp.ndarray, rho_B: jnp.ndarray) -> float:
     rho_A = jnp.asarray(rho_A, dtype=jnp.complex128)
     rho_B = jnp.asarray(rho_B, dtype=jnp.complex128)
     return float(_uhlmann_fidelity_core(rho_A, rho_B))
+
+
+def global_depolarizing_channel(rho: jnp.ndarray, p: float) -> jnp.ndarray:
+    """Global n-qubit depolarizing channel, D_p(rho) = (1-p)*rho + (p/dim)*I.
+
+    Distinct from `NoiseModel`'s `'depolarizing'` model in `circuits.registry`,
+    which applies an independent PER-QUBIT local Kraus channel -- a different
+    physical map from this GLOBAL channel, which mixes the whole `dim`-
+    dimensional state toward the fully mixed state as one unit. Use this one
+    when modeling e.g. state-prep/measurement (SPAM) error reported as a
+    single joint depolarizing parameter over the whole register, not per-
+    qubit gate noise (promoted from a real reproduction of arXiv:2608.16716's
+    own SPAM model, Dense-Evolution-Discovery Experiment 33).
+    """
+    rho = jnp.asarray(rho, dtype=jnp.complex128)
+    dim = rho.shape[0]
+    identity = jnp.eye(dim, dtype=jnp.complex128)
+    return (1.0 - p) * rho + (p / dim) * identity
 
 
 def _uhlmann_fidelity_core(rho_A: jnp.ndarray, rho_B: jnp.ndarray) -> jnp.ndarray:

--- a/tests/unit/test_continuous_pulse_evolve.py
+++ b/tests/unit/test_continuous_pulse_evolve.py
@@ -1,0 +1,80 @@
+import jax
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp
+import numpy as np
+
+from dense_evolution import continuous_pulse_evolve
+
+X = jnp.array([[0.0, 1.0], [1.0, 0.0]], dtype=jnp.complex128)
+Y = jnp.array([[0.0, -1j], [1j, 0.0]], dtype=jnp.complex128)
+
+
+def test_constant_coefficient_matches_single_expm_step():
+    # A constant Hamiltonian sliced into many small steps must reproduce
+    # exp(-i*H*t_total) applied once, up to Trotter/discretization error
+    # from finite dt -- here H is already piecewise-constant per slice
+    # (not approximated), so the match should be to numerical precision.
+    n_slices = 200
+    dt = 0.01
+    coeffs = jnp.full((n_slices,), 0.7)
+    psi0 = jnp.array([1.0, 0.0], dtype=jnp.complex128)
+
+    final_psi, trajectory = continuous_pulse_evolve(psi0, lambda c: c * X, coeffs, dt)
+
+    from jax.scipy.linalg import expm
+    total_t = n_slices * dt
+    expected = expm(-1j * 0.7 * X * total_t) @ psi0
+
+    assert trajectory is None
+    assert np.allclose(np.array(final_psi), np.array(expected), atol=1e-8)
+
+
+def test_time_dependent_coefficient_matches_manual_python_loop():
+    # Cross-check the scan against a plain, unrolled Python loop doing the
+    # exact same per-slice exp(-i*H*dt) step -- the correctness baseline
+    # independent of jax.lax.scan machinery.
+    n_slices = 50
+    dt = 0.02
+    t = jnp.arange(n_slices) * dt
+    coeffs = jnp.sin(t) ** 2   # an arbitrary smooth time-dependent profile
+    psi0 = jnp.array([0.0, 1.0], dtype=jnp.complex128)
+
+    def hamiltonian_fn(c):
+        return 0.5 * c * X + 0.3 * (1 - c) * Y
+
+    final_psi, _ = continuous_pulse_evolve(psi0, hamiltonian_fn, coeffs, dt)
+
+    from jax.scipy.linalg import expm
+    psi_manual = psi0
+    for c in coeffs:
+        H_t = 0.5 * c * X + 0.3 * (1 - c) * Y
+        psi_manual = expm(-1j * H_t * dt) @ psi_manual
+
+    assert np.allclose(np.array(final_psi), np.array(psi_manual), atol=1e-8)
+
+
+def test_observable_fn_returns_trajectory_of_expected_length():
+    n_slices = 30
+    dt = 0.05
+    coeffs = jnp.linspace(0.0, 1.0, n_slices)
+    psi0 = jnp.array([1.0, 0.0], dtype=jnp.complex128)
+
+    final_psi, trajectory = continuous_pulse_evolve(
+        psi0, lambda c: c * X, coeffs, dt,
+        observable_fn=lambda psi: jnp.abs(psi[1]) ** 2,
+    )
+
+    assert trajectory.shape == (n_slices,)
+    # Final trajectory entry must equal the |1> occupation of final_psi.
+    assert np.allclose(float(trajectory[-1]), float(jnp.abs(final_psi[1]) ** 2))
+
+
+def test_preserves_norm():
+    n_slices = 80
+    dt = 0.03
+    coeffs = jnp.cos(jnp.linspace(0.0, 3.0, n_slices))
+    psi0 = jnp.array([0.6, 0.8], dtype=jnp.complex128)
+
+    final_psi, _ = continuous_pulse_evolve(psi0, lambda c: c * X, coeffs, dt)
+
+    assert abs(float(jnp.sum(jnp.abs(final_psi) ** 2)) - 1.0) < 1e-9

--- a/tests/unit/test_diagram_and_depolarizing.py
+++ b/tests/unit/test_diagram_and_depolarizing.py
@@ -1,0 +1,33 @@
+import matplotlib
+matplotlib.use("Agg")
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from dense_evolution import plot_circuit, global_depolarizing_channel
+
+
+def test_plot_circuit_returns_figure_with_single_and_multi_qubit_gates():
+    fig = plot_circuit([('x', 1), ('rz', 0, 0.5), ('iswap', 0, 1)], n_qubits=2)
+    assert isinstance(fig, plt.Figure)
+    plt.close(fig)
+
+
+def test_global_depolarizing_channel_preserves_trace():
+    rho = np.zeros((4, 4), dtype=complex)
+    rho[0, 0] = 1.0
+    out = global_depolarizing_channel(rho, 0.3)
+    assert abs(complex(np.trace(out)) - 1.0) < 1e-9
+
+
+def test_global_depolarizing_channel_at_p_zero_is_identity_map():
+    rho = np.array([[0.6, 0.1], [0.1, 0.4]], dtype=complex)
+    out = global_depolarizing_channel(rho, 0.0)
+    assert np.allclose(out, rho)
+
+
+def test_global_depolarizing_channel_at_p_one_is_maximally_mixed():
+    rho = np.zeros((4, 4), dtype=complex)
+    rho[0, 0] = 1.0
+    out = global_depolarizing_channel(rho, 1.0)
+    assert np.allclose(out, np.eye(4) / 4)


### PR DESCRIPTION
Promotes the `jax.lax.scan`-based pulse-evolution pattern first written ad hoc in Dense-Evolution-Discovery's germanium iSWAP validation (`exact_final_state`/`exact_final_state_general`) into a reusable core utility in `dense_evolution.circuits.trotter`.

`continuous_pulse_evolve(psi0, hamiltonian_fn, coeffs_t, dt, observable_fn=None)` evolves a statevector under any time-dependent Hamiltonian via per-slice `exp(-i*H(t)*dt)`, entirely inside JAX (O(1) memory per step via the scan carry) — no Python-side list of gate tuples that grows with slice count, unlike `trotter_evolve_ops`'s discrete-circuit builder. Not specific to any Hamiltonian, qubit count, or pulse shape.

4 new tests in `tests/unit/test_continuous_pulse_evolve.py`:
- constant coefficient matches a single `expm` step
- time-dependent coefficient matches a manual unrolled Python loop
- optional `observable_fn` produces a trajectory of the expected length/values
- norm preservation

All passing locally, no regression to existing `tests/unit/test_trotter.py` (15/15 still pass).