### PR TITLE
Add amplitude_damping_channel: single-qubit T1-style Kraus channel

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -17,6 +17,7 @@ from .backends.mps import MPSSimulator
 from .mitigation.zne import (richardson_extrapolate, zero_noise_extrapolation, polynomial_extrapolate,
                           project_to_physical, uhlmann_fidelity, zne_density_matrix,
                           jsd_predictive_zne_density_matrix, global_depolarizing_channel,
+                          amplitude_damping_channel,
                           richardson_extrapolate_jit, zero_noise_extrapolation_jit,
                           polynomial_extrapolate_jit, uhlmann_fidelity_jit, zne_density_matrix_jit)
 from .circuits.diagram import plot_circuit
@@ -62,7 +63,7 @@ __all__ = [
     # Mitigation -- Zero-Noise Extrapolation
     "richardson_extrapolate", "zero_noise_extrapolation", "polynomial_extrapolate",
     "project_to_physical", "uhlmann_fidelity", "zne_density_matrix",
-    "jsd_predictive_zne_density_matrix", "global_depolarizing_channel",
+    "jsd_predictive_zne_density_matrix", "global_depolarizing_channel", "amplitude_damping_channel",
     "richardson_extrapolate_jit", "zero_noise_extrapolation_jit",
     "polynomial_extrapolate_jit", "uhlmann_fidelity_jit", "zne_density_matrix_jit",
     # Physics -- states, observables, entropy, fermions, QEC

--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -33,7 +33,8 @@ from .solvers.vhd_tb import (MATERIALS as VHD_MATERIALS, sp3s_star_hamiltonian,
                               direct_gap_at_gamma, band_extrema_along_path)
 from .physics.fermions import majorana_pauli_terms
 from .physics.entropy import partial_trace, von_neumann_entropy, mutual_information
-from .circuits.trotter import pauli_rotation_ops, trotter_evolve_ops, continuous_pulse_evolve
+from .circuits.trotter import (pauli_rotation_ops, trotter_evolve_ops, continuous_pulse_evolve,
+                                continuous_dissipative_evolve)
 from .physics.qec import pauli_commutes, compute_syndrome, erasure_aware_decode, pymatching_decode, blind_minimum_weight_decode
 
 __version__ = "8.1.66"
@@ -48,6 +49,7 @@ __all__ = [
     "GATES", "PARAMETRIC_GATES", "GATE_IDS",
     "entangling_layer", "qft",
     "pauli_rotation_ops", "trotter_evolve_ops", "continuous_pulse_evolve",
+    "continuous_dissipative_evolve",
     # Chunking / anti-OOM
     "Chunk",
     # Interop -- Qiskit / PennyLane / STIM bridges

--- a/dense_evolution/circuits/trotter.py
+++ b/dense_evolution/circuits/trotter.py
@@ -45,7 +45,8 @@ import jax
 import jax.numpy as jnp
 from jax.scipy.linalg import expm
 
-__all__ = ['pauli_rotation_ops', 'trotter_evolve_ops', 'continuous_pulse_evolve']
+__all__ = ['pauli_rotation_ops', 'trotter_evolve_ops', 'continuous_pulse_evolve',
+           'continuous_dissipative_evolve']
 
 
 def pauli_rotation_ops(pauli_dict, angle):
@@ -208,3 +209,57 @@ def continuous_pulse_evolve(psi0, hamiltonian_fn, coeffs_t, dt, observable_fn=No
 
     final_psi, trajectory = jax.lax.scan(step, jnp.asarray(psi0), jnp.asarray(coeffs_t))
     return final_psi, trajectory
+
+
+def continuous_dissipative_evolve(rho0, channel_fn, params_t, observable_fn=None):
+    """Evolve a density matrix through a time-dependent open-system (CPTP)
+    channel via jax.lax.scan -- the dissipative counterpart of
+    `continuous_pulse_evolve`, which only ever does unitary exp(-i*H*dt)
+    steps on a pure state.
+
+    Needed because not every real time-dependent physical event is coherent.
+    E.g. a cosmic-ray/gamma impact on a superconducting qubit chip (real
+    data: McEwen et al., arXiv:2104.05219) produces a burst of quasiparticles
+    that transiently collapses the chip's effective T1 -- a rise (~10us to a
+    first plateau, ~1ms to near-saturation) followed by a ~25-30ms
+    exponential decay back to baseline, measured directly, not modeled as a
+    static before/after depolarizing parameter. That is dissipation with a
+    time-varying rate, which cannot be expressed as a coefficient inside a
+    Hermitian Hamiltonian and passed to `continuous_pulse_evolve` -- it has
+    to act on rho through an actual CPTP map at each instant.
+
+    `channel_fn` supplies that per-slice CPTP map (e.g.
+    `dense_evolution.global_depolarizing_channel`, or any other Kraus
+    channel taking a time-varying parameter), so this function is not
+    specific to any one noise mechanism, exactly like `continuous_pulse_evolve`
+    is not specific to any one Hamiltonian.
+
+    Parameters
+    ----------
+    rho0 : array_like
+        Initial density matrix, shape (dim, dim).
+    channel_fn : callable
+        (rho, param) -> rho_next, a single-slice CPTP map. Called once per
+        entry of `params_t` under jax.lax.scan, so it must be
+        JAX-traceable.
+    params_t : array_like
+        Per-slice instantaneous channel parameter (e.g. a depolarizing/
+        decay probability sampled on a time grid reproducing a measured
+        event's rise-and-decay profile).
+    observable_fn : callable, optional
+        If given, applied to rho after each slice; the stacked per-slice
+        results are returned as `trajectory`. If omitted, `trajectory` is
+        None and only the final density matrix is computed.
+
+    Returns
+    -------
+    final_rho : jnp.ndarray
+    trajectory : jnp.ndarray or None
+    """
+    def step(rho, param):
+        rho_next = channel_fn(rho, param)
+        y = observable_fn(rho_next) if observable_fn is not None else None
+        return rho_next, y
+
+    final_rho, trajectory = jax.lax.scan(step, jnp.asarray(rho0), jnp.asarray(params_t))
+    return final_rho, trajectory

--- a/dense_evolution/mitigation/zne.py
+++ b/dense_evolution/mitigation/zne.py
@@ -21,6 +21,7 @@ from .healing import calculate_delta_preemp
 __all__ = ["richardson_extrapolate", "zero_noise_extrapolation", "polynomial_extrapolate",
            "project_to_physical", "uhlmann_fidelity", "zne_density_matrix",
            "jsd_predictive_zne_density_matrix", "global_depolarizing_channel",
+           "amplitude_damping_channel",
            "richardson_extrapolate_jit", "zero_noise_extrapolation_jit",
            "polynomial_extrapolate_jit", "uhlmann_fidelity_jit", "zne_density_matrix_jit"]
 
@@ -418,6 +419,31 @@ def global_depolarizing_channel(rho: jnp.ndarray, p: float) -> jnp.ndarray:
     dim = rho.shape[0]
     identity = jnp.eye(dim, dtype=jnp.complex128)
     return (1.0 - p) * rho + (p / dim) * identity
+
+
+def amplitude_damping_channel(rho: jnp.ndarray, gamma: float) -> jnp.ndarray:
+    """Single-qubit amplitude-damping channel: E0 @ rho @ E0.conj().T +
+    E1 @ rho @ E1.conj().T, with E0=diag(1, sqrt(1-gamma)) and
+    E1=[[0,sqrt(gamma)],[0,0]] -- population only ever moves |1>->|0>,
+    never the reverse.
+
+    Distinct from `global_depolarizing_channel` (symmetric, mixes toward
+    the fully-mixed state regardless of which state is |1> or |0>) -- this
+    one is asymmetric by construction, the real signature of energy-relaxation
+    (T1) processes and of quasiparticle poisoning (promoted from a real
+    reproduction of arXiv:2104.05219's measured cosmic-ray-induced error
+    bursts, Dense-Evolution-Discovery Experiment 34, where this asymmetry is
+    exactly the mechanism's own reported signature: decay errors only, no
+    excess excitation errors).
+
+    Single-qubit only (rho must be 2x2) -- unlike `global_depolarizing_channel`,
+    this is not dimension-generic, since amplitude damping is inherently a
+    per-qubit process, not a joint-register one.
+    """
+    rho = jnp.asarray(rho, dtype=jnp.complex128)
+    e0 = jnp.array([[1.0, 0.0], [0.0, jnp.sqrt(1.0 - gamma)]], dtype=jnp.complex128)
+    e1 = jnp.array([[0.0, jnp.sqrt(gamma)], [0.0, 0.0]], dtype=jnp.complex128)
+    return e0 @ rho @ e0.conj().T + e1 @ rho @ e1.conj().T
 
 
 def _uhlmann_fidelity_core(rho_A: jnp.ndarray, rho_B: jnp.ndarray) -> jnp.ndarray:

--- a/tests/unit/test_amplitude_damping_channel.py
+++ b/tests/unit/test_amplitude_damping_channel.py
@@ -1,0 +1,46 @@
+import jax
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from dense_evolution import amplitude_damping_channel
+
+
+def _rho1():
+    return jnp.array([[0.0, 0.0], [0.0, 1.0]], dtype=jnp.complex128)   # |1><1|
+
+
+def _rho0():
+    return jnp.array([[1.0, 0.0], [0.0, 0.0]], dtype=jnp.complex128)   # |0><0|
+
+
+def test_ground_state_is_untouched():
+    # The real asymmetry the channel exists to model: |0><0| passes through
+    # unchanged regardless of gamma -- no excess excitation.
+    out = amplitude_damping_channel(_rho0(), 0.7)
+    assert np.allclose(np.array(out), np.array(_rho0()))
+
+
+def test_gamma_zero_is_identity_map():
+    rho = jnp.array([[0.6, 0.2 - 0.1j], [0.2 + 0.1j, 0.4]], dtype=jnp.complex128)
+    out = amplitude_damping_channel(rho, 0.0)
+    assert np.allclose(np.array(out), np.array(rho))
+
+
+def test_gamma_one_fully_decays_excited_state():
+    out = amplitude_damping_channel(_rho1(), 1.0)
+    assert np.allclose(np.array(out), np.array(_rho0()), atol=1e-9)
+
+
+def test_preserves_trace():
+    rho = jnp.array([[0.3, 0.1j], [-0.1j, 0.7]], dtype=jnp.complex128)
+    for gamma in (0.0, 0.25, 0.5, 0.9, 1.0):
+        out = amplitude_damping_channel(rho, gamma)
+        assert abs(complex(jnp.trace(out)) - 1.0) < 1e-9
+
+
+def test_population_only_moves_excited_to_ground():
+    out = amplitude_damping_channel(_rho1(), 0.4)
+    assert float(jnp.real(out[1, 1])) == pytest.approx(0.6, abs=1e-9)
+    assert float(jnp.real(out[0, 0])) == pytest.approx(0.4, abs=1e-9)

--- a/tests/unit/test_continuous_dissipative_evolve.py
+++ b/tests/unit/test_continuous_dissipative_evolve.py
@@ -1,0 +1,65 @@
+import jax
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp
+import numpy as np
+
+from dense_evolution import continuous_dissipative_evolve, global_depolarizing_channel
+
+
+def _pure_state_rho(dim, index=0):
+    rho = jnp.zeros((dim, dim), dtype=jnp.complex128)
+    return rho.at[index, index].set(1.0)
+
+
+def test_zero_parameter_profile_leaves_rho_unchanged():
+    rho0 = _pure_state_rho(4)
+    params = jnp.zeros((20,))
+
+    final_rho, trajectory = continuous_dissipative_evolve(rho0, global_depolarizing_channel, params)
+
+    assert trajectory is None
+    assert np.allclose(np.array(final_rho), np.array(rho0))
+
+
+def test_matches_manual_sequential_composition():
+    # Cross-check the scan against a plain Python loop applying the same
+    # channel step by step -- the correctness baseline independent of
+    # jax.lax.scan machinery.
+    rho0 = _pure_state_rho(4)
+    n_slices = 15
+    params = jnp.linspace(0.01, 0.05, n_slices)
+
+    final_rho, _ = continuous_dissipative_evolve(rho0, global_depolarizing_channel, params)
+
+    rho_manual = rho0
+    for p in params:
+        rho_manual = global_depolarizing_channel(rho_manual, p)
+
+    assert np.allclose(np.array(final_rho), np.array(rho_manual), atol=1e-10)
+
+
+def test_rise_and_decay_profile_preserves_trace_and_pushes_toward_mixed_state():
+    # A synthetic event profile shaped like the real cosmic-ray-induced
+    # error burst (McEwen et al., arXiv:2104.05219): a fast rise to a peak
+    # followed by an exponential decay back to baseline -- here in
+    # dimensionless slice units, not literal microseconds/milliseconds.
+    n_slices = 100
+    slice_idx = jnp.arange(n_slices)
+    peak_idx = 10
+    rise = jnp.clip(slice_idx / peak_idx, 0.0, 1.0)
+    decay = jnp.exp(-jnp.clip(slice_idx - peak_idx, 0, None) / 25.0)
+    params = 0.3 * rise * decay   # peaks at p=0.3, decays back toward 0
+
+    rho0 = _pure_state_rho(4)
+    final_rho, trajectory = continuous_dissipative_evolve(
+        rho0, global_depolarizing_channel, params,
+        observable_fn=lambda rho: jnp.real(jnp.trace(rho)),
+    )
+
+    assert trajectory.shape == (n_slices,)
+    assert np.allclose(np.array(trajectory), 1.0, atol=1e-9)   # trace preserved throughout
+    assert abs(float(jnp.real(jnp.trace(final_rho))) - 1.0) < 1e-9
+    # Some population must have been pushed off the diagonal peak toward
+    # the maximally mixed state during the burst, then only partially
+    # recover (channel is not perfectly invertible/undone by design).
+    assert float(jnp.real(final_rho[0, 0])) < 1.0


### PR DESCRIPTION
Promoted from Dense-Evolution-Discovery Experiment 34 (cosmic-ray burst validation, arXiv:2104.05219). Asymmetric by construction — population only ever moves `|1>` → `|0>` — unlike `global_depolarizing_channel`'s symmetric mixing toward the fully-mixed state. Pairs with `continuous_dissipative_evolve` (#122) as a second built-in channel option.

5 new tests in `tests/unit/test_amplitude_damping_channel.py`. 46/46 passing (including full `test_mitigation.py`), no regressions.