### PR TITLE
Add cosmic_ray_burst_profile: reusable time-dependent burst-severity generator

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -17,7 +17,7 @@ from .backends.mps import MPSSimulator
 from .mitigation.zne import (richardson_extrapolate, zero_noise_extrapolation, polynomial_extrapolate,
                           project_to_physical, uhlmann_fidelity, zne_density_matrix,
                           jsd_predictive_zne_density_matrix, global_depolarizing_channel,
-                          amplitude_damping_channel,
+                          amplitude_damping_channel, cosmic_ray_burst_profile,
                           richardson_extrapolate_jit, zero_noise_extrapolation_jit,
                           polynomial_extrapolate_jit, uhlmann_fidelity_jit, zne_density_matrix_jit)
 from .circuits.diagram import plot_circuit
@@ -64,6 +64,7 @@ __all__ = [
     "richardson_extrapolate", "zero_noise_extrapolation", "polynomial_extrapolate",
     "project_to_physical", "uhlmann_fidelity", "zne_density_matrix",
     "jsd_predictive_zne_density_matrix", "global_depolarizing_channel", "amplitude_damping_channel",
+    "cosmic_ray_burst_profile",
     "richardson_extrapolate_jit", "zero_noise_extrapolation_jit",
     "polynomial_extrapolate_jit", "uhlmann_fidelity_jit", "zne_density_matrix_jit",
     # Physics -- states, observables, entropy, fermions, QEC

--- a/dense_evolution/mitigation/zne.py
+++ b/dense_evolution/mitigation/zne.py
@@ -21,7 +21,7 @@ from .healing import calculate_delta_preemp
 __all__ = ["richardson_extrapolate", "zero_noise_extrapolation", "polynomial_extrapolate",
            "project_to_physical", "uhlmann_fidelity", "zne_density_matrix",
            "jsd_predictive_zne_density_matrix", "global_depolarizing_channel",
-           "amplitude_damping_channel",
+           "amplitude_damping_channel", "cosmic_ray_burst_profile",
            "richardson_extrapolate_jit", "zero_noise_extrapolation_jit",
            "polynomial_extrapolate_jit", "uhlmann_fidelity_jit", "zne_density_matrix_jit"]
 
@@ -444,6 +444,62 @@ def amplitude_damping_channel(rho: jnp.ndarray, gamma: float) -> jnp.ndarray:
     e0 = jnp.array([[1.0, 0.0], [0.0, jnp.sqrt(1.0 - gamma)]], dtype=jnp.complex128)
     e1 = jnp.array([[0.0, jnp.sqrt(gamma)], [0.0, 0.0]], dtype=jnp.complex128)
     return e0 @ rho @ e0.conj().T + e1 @ rho @ e1.conj().T
+
+
+def cosmic_ray_burst_profile(time_us, baseline_gamma: float, ratio_intermediate: float = 2.5,
+                              ratio_peak: float = 3.75, tau1_us: float = 3.0,
+                              tau2_us: float = 300.0, tau_decay_ms: float = 25.0) -> jnp.ndarray:
+    """Time-dependent decay-probability profile for a cosmic-ray/gamma-ray-
+    induced quasiparticle burst: a two-stage rise (fast to
+    `ratio_intermediate`x baseline, slower to `ratio_peak`x baseline) times
+    a single-exponential recovery, generalized out of a fixed, paper-number
+    validation (Dense-Evolution-Discovery Experiment 34, reproducing
+    arXiv:2104.05219's real measured event on a 26-qubit chip).
+
+    Feed the result to `continuous_dissipative_evolve` alongside
+    `amplitude_damping_channel` (or any other single-time-varying-parameter
+    channel) to inject a realistic burst into any circuit or QEC study,
+    without re-deriving this shape by hand each time.
+
+    The default ratios/timescales are the paper's own real numbers -- see
+    Experiment 34's docstring for exactly which are paper-fitted (the 25ms
+    decay) versus chosen to match the paper's two described rise points
+    (tau1/tau2). All are overridable for a different event severity or
+    device generation; `baseline_gamma` is never derived here -- pass
+    whatever per-slice decay probability corresponds to your own dt/T1
+    convention (see Experiment 34 for one worked example of that
+    conversion).
+
+    Parameters
+    ----------
+    time_us : array_like
+        Time since impact, in microseconds (t=0 is the impact instant).
+    baseline_gamma : float
+        Undisturbed per-slice decay probability; this profile scales it
+        up, it does not derive it.
+    ratio_intermediate, ratio_peak : float
+        Multiplier on `baseline_gamma` at the two described checkpoints
+        (paper defaults 2.5=10/4, 3.75=15/4, from Fig. 3's ~10us/~1ms
+        readings).
+    tau1_us, tau2_us : float
+        Rise timescales for the two saturating-exponential stages (paper
+        defaults 3, 300 -- chosen to match its ~10us/~1ms descriptions,
+        not fitted by the paper itself).
+    tau_decay_ms : float
+        Recovery time constant (paper default 25 -- its own fitted central
+        value, real range 25-30ms across 415 events).
+
+    Returns
+    -------
+    jnp.ndarray
+        Per-slice decay probability at each entry of `time_us`.
+    """
+    time_us = jnp.asarray(time_us)
+    stage1 = (ratio_intermediate - 1.0) * (1.0 - jnp.exp(-time_us / tau1_us))
+    stage2 = (ratio_peak - ratio_intermediate) * (1.0 - jnp.exp(-time_us / tau2_us))
+    decay = jnp.exp(-time_us / (tau_decay_ms * 1000.0))
+    scaling = 1.0 + (stage1 + stage2) * decay
+    return baseline_gamma * scaling
 
 
 def _uhlmann_fidelity_core(rho_A: jnp.ndarray, rho_B: jnp.ndarray) -> jnp.ndarray:

--- a/tests/unit/test_cosmic_ray_burst_profile.py
+++ b/tests/unit/test_cosmic_ray_burst_profile.py
@@ -1,0 +1,44 @@
+import jax
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp
+import numpy as np
+
+from dense_evolution import cosmic_ray_burst_profile
+
+
+def test_at_impact_returns_baseline():
+    out = cosmic_ray_burst_profile(jnp.array([0.0]), baseline_gamma=0.05)
+    assert float(out[0]) == 0.05
+
+
+def test_recovers_to_baseline_after_many_decay_constants():
+    # 6 decay constants (25ms default) -> essentially fully recovered.
+    out = cosmic_ray_burst_profile(jnp.array([150000.0]), baseline_gamma=0.05)
+    assert abs(float(out[0]) - 0.05) / 0.05 < 0.01
+
+
+def test_reaches_near_peak_ratio_before_decaying_away():
+    # At 1ms both default rise stages (tau1=3us, tau2=300us) are long
+    # saturated, while the 25ms decay has barely acted.
+    out = cosmic_ray_burst_profile(jnp.array([1000.0]), baseline_gamma=0.05)
+    assert abs(float(out[0]) - 0.05 * 3.75) < 0.05 * 0.2
+
+
+def test_scales_linearly_with_baseline_gamma():
+    t = jnp.array([0.0, 10.0, 1000.0, 50000.0])
+    out1 = cosmic_ray_burst_profile(t, baseline_gamma=0.05)
+    out2 = cosmic_ray_burst_profile(t, baseline_gamma=0.10)
+    assert np.allclose(np.array(out2), np.array(out1) * 2.0)
+
+
+def test_custom_ratios_and_timescales_are_respected():
+    out_default = cosmic_ray_burst_profile(jnp.array([1000.0]), baseline_gamma=0.05)
+    out_custom = cosmic_ray_burst_profile(jnp.array([1000.0]), baseline_gamma=0.05,
+                                           ratio_peak=10.0, ratio_intermediate=5.0)
+    assert float(out_custom[0]) > float(out_default[0])
+
+
+def test_output_shape_matches_input():
+    t = jnp.linspace(0.0, 1000.0, 37)
+    out = cosmic_ray_burst_profile(t, baseline_gamma=0.05)
+    assert out.shape == t.shape


### PR DESCRIPTION
Generalizes Dense-Evolution-Discovery Experiment 34's fixed, paper-number validation (arXiv:2104.05219) into a parametrized utility: any circuit or QEC study can generate a realistic cosmic-ray-burst decay-probability profile and feed it to `continuous_dissipative_evolve` + `amplitude_damping_channel` directly, without re-deriving the two-stage-rise/exponential-decay shape by hand each time.

The paper's real ratios (2.5x/3.75x) and fitted decay time constant (25ms) are the defaults — all overridable for a different event severity or device generation. Complements #121/#122/#123 as the fourth utility promoted from this line of work.

6 new tests in `tests/unit/test_cosmic_ray_burst_profile.py`. 52/52 passing (including full `test_mitigation.py` and `test_amplitude_damping_channel.py`), no regressions.