### PR TITLE
Add decode_with_erasure_fallback: erasure-aware decoding policy with blind fallback

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -36,7 +36,8 @@ from .physics.fermions import majorana_pauli_terms
 from .physics.entropy import partial_trace, von_neumann_entropy, mutual_information
 from .circuits.trotter import (pauli_rotation_ops, trotter_evolve_ops, continuous_pulse_evolve,
                                 continuous_dissipative_evolve)
-from .physics.qec import pauli_commutes, compute_syndrome, erasure_aware_decode, pymatching_decode, blind_minimum_weight_decode
+from .physics.qec import (pauli_commutes, compute_syndrome, erasure_aware_decode, pymatching_decode,
+                           blind_minimum_weight_decode, decode_with_erasure_fallback)
 
 __version__ = "8.1.66"
 
@@ -72,6 +73,7 @@ __all__ = [
     "partial_trace", "von_neumann_entropy", "mutual_information",
     "majorana_pauli_terms",
     "pauli_commutes", "compute_syndrome", "erasure_aware_decode", "pymatching_decode", "blind_minimum_weight_decode",
+    "decode_with_erasure_fallback",
     # Utils -- drawing, measurement, random circuits
     "draw_circuit", "plot_circuit", "sample_counts", "statevector_fidelity", "random_circuit",
 ]

--- a/dense_evolution/physics/qec.py
+++ b/dense_evolution/physics/qec.py
@@ -404,3 +404,57 @@ def blind_minimum_weight_decode(
             return None
 
     return None
+
+
+def decode_with_erasure_fallback(
+    observed_syndrome: Sequence[int],
+    heralded_qubits: Sequence[int],
+    n_qubits: int,
+    stabilizers: Sequence[str],
+    max_weight: Optional[int] = None,
+) -> Optional[str]:
+    """The real-world decoding POLICY, not just a raw decoder call: use
+    `erasure_aware_decode` when there are any heralded qubits and it
+    resolves the syndrome uniquely; fall back to `blind_minimum_weight_decode`
+    otherwise (zero heralded qubits, or erasure-aware decoding can't
+    resolve it -- ambiguous, or more heralds than the code's real
+    erasure-correcting capacity).
+
+    Promoted from Dense-Evolution-Discovery's cosmic-ray-burst-as-erasure
+    experiment (scripts/cosmic_ray_erasure_decoding.py), where this exact
+    fallback logic was first written inline in a Monte Carlo loop. Never
+    worse than always calling `blind_minimum_weight_decode` directly --
+    it only uses herald information when doing so actually helps, exactly
+    the policy a real erasure-aware QEC system would run, since a
+    real-time detector (e.g. a cosmic-ray/particle-impact monitor, or a
+    photon-loss herald) only ever adds information, it doesn't obligate a
+    decoder to use it past the point where it stops being useful.
+
+    Parameters
+    ----------
+    observed_syndrome : sequence of int
+        One bit per stabilizer, same convention as `compute_syndrome`.
+    heralded_qubits : sequence of int
+        Qubits KNOWN to have been erased/disturbed this shot -- may be
+        empty (falls straight through to blind decoding).
+    n_qubits : int
+        Number of physical qubits.
+    stabilizers : sequence of str
+        The code's stabilizer generators (any mix of Pauli types).
+    max_weight : int, optional
+        Forwarded to `blind_minimum_weight_decode`'s fallback path only
+        (see its own docstring) -- `erasure_aware_decode` has no
+        equivalent parameter, its search is always exactly over the
+        heralded qubits.
+
+    Returns
+    -------
+    str or None
+        Length-`n_qubits` Pauli string (IXYZ), or `None` if neither
+        decoder can resolve the syndrome.
+    """
+    if heralded_qubits:
+        result = erasure_aware_decode(observed_syndrome, heralded_qubits, n_qubits, stabilizers)
+        if result is not None:
+            return result
+    return blind_minimum_weight_decode(observed_syndrome, n_qubits, stabilizers, max_weight=max_weight)

--- a/dense_evolution/qec.py
+++ b/dense_evolution/qec.py
@@ -6,10 +6,10 @@ unchanged. Import from dense_evolution.physics.qec directly in new code.
 """
 from dense_evolution.physics.qec import (
     pauli_commutes, compute_syndrome, erasure_aware_decode, pymatching_decode,
-    blind_minimum_weight_decode,
+    blind_minimum_weight_decode, decode_with_erasure_fallback,
 )
 
 __all__ = [
     'pauli_commutes', 'compute_syndrome', 'erasure_aware_decode', 'pymatching_decode',
-    'blind_minimum_weight_decode',
+    'blind_minimum_weight_decode', 'decode_with_erasure_fallback',
 ]

--- a/tests/unit/test_qec.py
+++ b/tests/unit/test_qec.py
@@ -19,7 +19,7 @@ import pytest
 
 from dense_evolution.qec import (
     compute_syndrome, erasure_aware_decode, pauli_commutes, pymatching_decode,
-    blind_minimum_weight_decode,
+    blind_minimum_weight_decode, decode_with_erasure_fallback,
 )
 from dense_evolution.physics import qec as qec_module
 
@@ -210,6 +210,60 @@ class TestErasureAwareDecode:
             "expected a real nonzero failure rate here (~25% at full scale); "
             "re-check the test setup rather than assuming both decoders tied"
         )
+
+
+class TestDecodeWithErasureFallback:
+    """Promoted from Dense-Evolution-Discovery's cosmic-ray-burst-as-erasure
+    experiment (scripts/cosmic_ray_erasure_decoding.py), where this exact
+    fallback policy was first written inline in a Monte Carlo loop."""
+
+    def test_no_heralded_qubits_falls_back_to_blind_decode(self):
+        all_stabilizers = STEANE_X_STABILIZERS + STEANE_Z_STABILIZERS
+        error = ['I'] * N_STEANE
+        error[2] = 'X'
+        syndrome = compute_syndrome(''.join(error), all_stabilizers)
+        result = decode_with_erasure_fallback(syndrome, [], N_STEANE, all_stabilizers)
+        assert result == blind_minimum_weight_decode(syndrome, N_STEANE, all_stabilizers)
+
+    def test_resolvable_heralded_qubits_use_erasure_aware_result(self):
+        all_stabilizers = STEANE_X_STABILIZERS + STEANE_Z_STABILIZERS
+        true_error = ['I'] * N_STEANE
+        true_error[1], true_error[5] = 'X', 'Z'
+        true_error = ''.join(true_error)
+        syndrome = compute_syndrome(true_error, all_stabilizers)
+        result = decode_with_erasure_fallback(syndrome, [1, 5], N_STEANE, all_stabilizers)
+        assert result == true_error
+
+    def test_unresolvable_heralds_fall_back_to_blind_decode(self):
+        # 3 heralded qubits exceeds Steane's real d-1=2 erasure-correcting
+        # capacity -- erasure_aware_decode should return None here, and
+        # decode_with_erasure_fallback must fall back rather than
+        # propagate that None.
+        all_stabilizers = STEANE_X_STABILIZERS + STEANE_Z_STABILIZERS
+        error = ['I'] * N_STEANE
+        error[0] = 'X'
+        syndrome = compute_syndrome(''.join(error), all_stabilizers)
+        assert erasure_aware_decode(syndrome, [0, 1, 2], N_STEANE, all_stabilizers) is None
+        result = decode_with_erasure_fallback(syndrome, [0, 1, 2], N_STEANE, all_stabilizers)
+        assert result == blind_minimum_weight_decode(syndrome, N_STEANE, all_stabilizers)
+
+    def test_never_worse_than_blind_alone_over_many_random_shots(self):
+        all_stabilizers = STEANE_X_STABILIZERS + STEANE_Z_STABILIZERS
+        rng = np.random.default_rng(7)
+        for _ in range(200):
+            heralded = rng.choice(N_STEANE, size=int(rng.integers(0, 3)), replace=False).tolist()
+            q = int(rng.integers(0, N_STEANE))
+            error = ['I'] * N_STEANE
+            error[q] = str(rng.choice(['X', 'Y', 'Z']))
+            syndrome = compute_syndrome(''.join(error), all_stabilizers)
+            blind_result = blind_minimum_weight_decode(syndrome, N_STEANE, all_stabilizers)
+            fallback_result = decode_with_erasure_fallback(syndrome, heralded, N_STEANE, all_stabilizers)
+            # Whenever blind decoding alone succeeds (a unique match), the
+            # fallback-aware policy must also produce a definite answer --
+            # extra herald information should never make an already-solvable
+            # syndrome unsolvable.
+            if blind_result is not None:
+                assert fallback_result is not None
 
 
 class TestPymatchingDecode:


### PR DESCRIPTION
Promoted from Dense-Evolution-Discovery's cosmic-ray-burst-as-erasure experiment (`scripts/cosmic_ray_erasure_decoding.py`), where this fallback logic was first written inline in a Monte Carlo loop: use `erasure_aware_decode` when there are heralded qubits and it resolves the syndrome uniquely, otherwise fall back to `blind_minimum_weight_decode`.

Never worse than always calling blind decoding directly — it only uses herald information when doing so actually helps, the real policy any erasure-aware QEC system would run.

4 new tests in `tests/unit/test_qec.py` (`TestDecodeWithErasureFallback`), also updated the `dense_evolution.qec` backward-compat shim. 36/36 QEC tests passing, no regressions.