### PR TITLE
Document the 7 functions promoted from Experiments 33/34/cosmic-ray-erasure

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ research/                           (not installed as a module -- reference/expe
 | **Density-Matrix Diagnostics** | `mitigation.py` — `sandwiched_renyi_divergence` (non-commuting-aware, order-α), `magic_entropy` (single-qubit non-stabilizerness, zero for all six stabilizer states) |
 | **Shadow-Based Estimation** | `mitigation.py` — `sample_classical_shadow`/`magic_entropy_from_shadows` (median-of-means classical-shadows estimator for `magic_entropy`, from randomized measurement snapshots instead of the exact state), `approx_shadow_std`/`fit_shadow_sample_complexity` (empirically-derived error guidance) |
 | **Classical Distribution Divergence** | `mitigation.py` — `kl_divergence`/`kl_divergence_jit` (Kullback-Leibler divergence over probability distributions, e.g. measurement-outcome distributions — distinct from `sandwiched_renyi_divergence`'s density-matrix form) |
+| **Continuous-Time Evolution** | `circuits/trotter.py` — `continuous_pulse_evolve`/`continuous_dissipative_evolve`, `jax.lax.scan`-based coherent/dissipative evolution under any time-dependent Hamiltonian or CPTP channel, no growing Python-side gate list |
+| **Time-Dependent Noise Channels** | `mitigation.py` — `global_depolarizing_channel` (symmetric, whole-register SPAM), `amplitude_damping_channel` (asymmetric, single-qubit T1-style decay), `cosmic_ray_burst_profile` (parametrized cosmic-ray-burst decay-probability profile, arXiv:2104.05219) |
+| **Quirk-Style Circuit Diagrams** | `plot_circuit` — matplotlib box-diagram renderer for Dense-Evolution's native gate-tuple format, auto-sized boxes, no gate table to keep in sync by hand |
 | **VQE + ADAM** | Hellmann-Feynman gradient · positional parameter injection into any OpenQASM 2.0 circuit |
 | **Sparse Ground-State Solver** | `ground_state_energy_sparse` — `scipy.sparse.linalg.eigsh` against a matrix-free `pauli_sum_matvec` `LinearOperator`, no dense `(2**n_qubits)²` Hamiltonian ever built; unblocks molecules too large for exact dense diagonalization (e.g. Si₂) |
 | **Auto-JIT Dispatch** | `run_circuit()` auto-delegates to the compiled `run_circuit_jit()` path whenever every gate is supported there (26/26 gate parity) — 6x+ faster, zero API change, no need to know `run_circuit_jit` exists |
@@ -538,22 +541,51 @@ healed = de.zero_noise_extrapolation([e1, e2, e3], [1.0, 2.0, 3.0],
 
 `richardson_extrapolate`/`zero_noise_extrapolation` accept array-valued `expectation_values` too (e.g. a full probability distribution per noise scale, extrapolated elementwise), not just scalars — this is what the Streamlit dashboard's **Mitigation (ZNE)** tab uses under the hood (`dashboard_core.mitigation_runner.run_mitigation_sweep`): run the active circuit at 1x/2x/3x the configured noise probability, extrapolate the whole probability vector (and fidelity) to zero noise, reusing these two functions exactly as-is.
 
+### Noise Channels for Density-Matrix Simulation
+
+Three standalone CPTP channels, usable directly on a density matrix (not tied to `NoiseModel`'s per-qubit gate-noise pipeline): `global_depolarizing_channel` (symmetric, whole-register — SPAM error reported as one joint parameter), `amplitude_damping_channel` (asymmetric, single-qubit — population only ever moves `|1>`→`|0>`, the real signature of T1 decay/quasiparticle poisoning), and `cosmic_ray_burst_profile` (not a channel itself, but a parametrized time-dependent decay-probability generator — real ratios/timescales from arXiv:2104.05219's measured cosmic-ray error bursts, feed its output to `amplitude_damping_channel`). Full derivation, citations, and the real experiment these were promoted from: [docs/api/mitigation.md](https://tatopenn-cell.github.io/Dense-Evolution/api/mitigation/).
+
+```python
+import jax.numpy as jnp
+from dense_evolution import cosmic_ray_burst_profile, amplitude_damping_channel, continuous_dissipative_evolve
+
+time_us = jnp.linspace(0.0, 150_000.0, 15_000)                  # 150ms, 10us slices
+gamma_t = cosmic_ray_burst_profile(time_us, baseline_gamma=0.01)  # real paper ratios/decay by default
+rho0 = jnp.array([[0.0, 0.0], [0.0, 1.0]], dtype=jnp.complex128)  # |1><1|
+final_rho, _ = continuous_dissipative_evolve(rho0, amplitude_damping_channel, gamma_t)
+```
+
+---
+
+## ▍ Continuous-Time Evolution — `dense_evolution.circuits.trotter`
+
+Real-time Hamiltonian evolution as an actual gate circuit (`pauli_rotation_ops`/`trotter_evolve_ops`), plus two `jax.lax.scan`-based solvers for genuinely time-dependent processes: `continuous_pulse_evolve` (coherent — any time-dependent Hamiltonian, e.g. a real analog control pulse) and `continuous_dissipative_evolve` (dissipative — any time-dependent CPTP channel, e.g. a transient noise event). Neither builds a growing Python-side list as the slice count increases, unlike a hand-rolled per-slice gate-tuple loop. Full math and the real experiments these were promoted from: [docs/api/trotter.md](https://tatopenn-cell.github.io/Dense-Evolution/api/trotter/).
+
+```python
+import jax.numpy as jnp
+from dense_evolution import continuous_pulse_evolve
+
+X = jnp.array([[0.0, 1.0], [1.0, 0.0]], dtype=jnp.complex128)
+psi0 = jnp.array([1.0, 0.0], dtype=jnp.complex128)
+coeffs_t = jnp.linspace(0.0, 1.0, 200)  # any sampled time-dependent pulse envelope
+final_psi, _ = continuous_pulse_evolve(psi0, lambda c: c * X, coeffs_t, dt=0.01)
+```
+
 ---
 
 ## ▍ QEC Decoding — `dense_evolution.qec`
 
-Code-agnostic stabilizer-code primitives plus three decoders: erasure-aware (known error locations), MWPM (`pymatching_decode`, blind, graph-like/topological codes only), and a blind minimum-weight brute-force decoder (`blind_minimum_weight_decode`) for small codes MWPM can't handle. Full math, citations, and validation details: [docs/api/qec.md](https://tatopenn-cell.github.io/Dense-Evolution/api/qec/).
+Code-agnostic stabilizer-code primitives plus three decoders: erasure-aware (known error locations), MWPM (`pymatching_decode`, blind, graph-like/topological codes only), and a blind minimum-weight brute-force decoder (`blind_minimum_weight_decode`) for small codes MWPM can't handle. `decode_with_erasure_fallback` composes the two into the real-world POLICY (use herald info when it resolves the syndrome, fall back to blind decoding otherwise) — never worse than blind decoding alone. Full math, citations, and validation details: [docs/api/qec.md](https://tatopenn-cell.github.io/Dense-Evolution/api/qec/).
 
 ```python
-from dense_evolution import compute_syndrome, erasure_aware_decode, blind_minimum_weight_decode
+from dense_evolution import compute_syndrome, decode_with_erasure_fallback
 
 stabilizers = ['IIIXXXX', 'IXXIIXX', 'XIXIXIX', 'IIIZZZZ', 'IZZIIZZ', 'ZIZIZIZ']  # Steane [[7,1,3]]
 syndrome = compute_syndrome('IIIZIII', stabilizers)                              # Z error on qubit 3
 
-# Known error location:
-corrected = erasure_aware_decode(syndrome, heralded_qubits=[3], n_qubits=7, stabilizers=stabilizers)
-# Blind (no known location) -- pymatching_decode can't be used for Steane at all (see docs):
-corrected = blind_minimum_weight_decode(syndrome, n_qubits=7, stabilizers=stabilizers)
+# Uses the known error location when it resolves the syndrome, falls back to
+# blind minimum-weight decoding otherwise -- one entry point either way:
+corrected = decode_with_erasure_fallback(syndrome, heralded_qubits=[3], n_qubits=7, stabilizers=stabilizers)
 ```
 
 ---

--- a/docs/api/diagram.md
+++ b/docs/api/diagram.md
@@ -1,0 +1,15 @@
+# Diagram (Quirk-style box diagrams)
+
+A Quirk-style matplotlib box-diagram circuit renderer -- reads Dense-Evolution's own
+gate-tuple format directly (integers after the gate name are qubit indices, floats are
+parameters), so there is no separate gate table to keep in sync by hand. Auto-sized boxes,
+red labels for contrast against the cyan/green single-/multi-qubit borders. Deliberately a
+different name from [`draw_circuit`](drawing.md) (the plain-ASCII text renderer) rather than
+an overload, since the two produce genuinely different output (a saved PNG figure vs. a
+printable string) for different purposes.
+
+Promoted from a real reproduction of arXiv:2608.16716's baseband iSWAP pulse
+([Dense-Evolution-Discovery Experiment 33](https://tatopenn-cell.github.io/Dense-Evolution-Discovery/germanium_iswap_validation/)),
+where it was first used to draw the reference circuit and a single Trotterized pulse slice.
+
+::: dense_evolution.circuits.diagram

--- a/docs/api/mitigation.md
+++ b/docs/api/mitigation.md
@@ -9,6 +9,26 @@ of every entry point.
 
 ---
 
+## Standalone density-matrix noise channels
+
+Three CPTP channels usable directly on a density matrix, independent of `NoiseModel`'s
+per-qubit gate-noise pipeline (`circuits.registry`). `global_depolarizing_channel` is
+symmetric -- it mixes the whole register toward the fully-mixed state as one unit -- promoted
+from a real reproduction of arXiv:2608.16716's SPAM model
+([Experiment 33](https://tatopenn-cell.github.io/Dense-Evolution-Discovery/germanium_iswap_validation/)).
+`amplitude_damping_channel` is the opposite kind of asymmetric: population only ever moves
+`|1>`&rarr;`|0>`, never the reverse -- the real signature of T1 decay and of quasiparticle
+poisoning, promoted from
+[Experiment 34](https://tatopenn-cell.github.io/Dense-Evolution-Discovery/cosmic_ray_burst_validation/)'s
+reproduction of a real cosmic-ray-induced error burst (arXiv:2104.05219). `cosmic_ray_burst_profile`
+is not a channel itself but the time-dependent decay-probability GENERATOR that experiment's
+real numbers were extracted into a reusable, parametrized form from -- feed its output straight
+to `amplitude_damping_channel` via [`continuous_dissipative_evolve`](trotter.md). Both are
+already covered by the `dense_evolution.mitigation.zne` API reference above -- this section
+is context, not a duplicate listing.
+
+---
+
 ## Density-matrix diagnostics
 
 Two further density-matrix diagnostics, both originated as Colab proposals with real bugs,

--- a/docs/api/qec.md
+++ b/docs/api/qec.md
@@ -27,6 +27,16 @@ different real-world settings:
   always violated. Minimum-weight selection is what makes blind decoding
   well-posed at all.
 
+`decode_with_erasure_fallback` composes the two-decoder split above into the real-world
+decoding POLICY, not just another raw decoder: use `erasure_aware_decode` when there are
+heralded qubits and it resolves the syndrome uniquely, otherwise fall back to
+`blind_minimum_weight_decode`. Never worse than always calling blind decoding directly --
+promoted from Dense-Evolution-Discovery's
+[cosmic-ray-burst-as-erasure experiment](https://tatopenn-cell.github.io/Dense-Evolution-Discovery/cosmic_ray_burst_validation/),
+where this exact fallback logic was first written inline in a Monte Carlo loop testing
+whether knowing WHICH qubits a real cosmic-ray burst hit (arXiv:2104.05219) lets a Steane
+[[7,1,3]] code recover better than blind decoding alone.
+
 Erasure-aware decoding rests on a real, foundational result: Grassl, Beth
 & Pellizzari, "Codes for the quantum erasure channel," Phys. Rev. A 56, 33
 (1997) — a distance-*d* stabilizer code can correct up to *d*-1 erasures

--- a/docs/api/trotter.md
+++ b/docs/api/trotter.md
@@ -17,6 +17,19 @@ per doubling of steps against a real, non-trivial multi-qubit
 Hamiltonian, consistent with the expected quadratic convergence of
 first-order Trotter error in state overlap.
 
+`continuous_pulse_evolve` and `continuous_dissipative_evolve` cover a different case
+entirely: a genuinely time-dependent process (a real analog control pulse, or a transient
+noise event) that shouldn't be discretized into a growing Python-side list of gate tuples.
+Both scan a fixed-size `jax.lax.scan` loop over a sampled coefficient array instead --
+`continuous_pulse_evolve` applies `exp(-i*H(t)*dt)` to a pure state (coherent), while
+`continuous_dissipative_evolve` applies an arbitrary CPTP channel to a density matrix
+(dissipative) -- so slice count costs compile time, not accumulating memory. Promoted from
+[Dense-Evolution-Discovery Experiment 34](https://tatopenn-cell.github.io/Dense-Evolution-Discovery/cosmic_ray_burst_validation/)'s
+real reproduction of a cosmic-ray-induced error burst (arXiv:2104.05219), generalized out of
+that experiment's own ad hoc pulse/channel-evolution code (itself first written for
+[Experiment 33](https://tatopenn-cell.github.io/Dense-Evolution-Discovery/germanium_iswap_validation/)'s
+germanium iSWAP pulse).
+
 ::: dense_evolution.circuits.trotter
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
       - QFT: api/qft.md
       - Random Circuit: api/random_circuit.md
       - Drawing (text diagrams): api/drawing.md
+      - Diagram (Quirk-style box diagrams): api/diagram.md
       - Harrison Tight-Binding (universal): api/harrison_tb.md
       - VHD Tight-Binding (material-specific): api/vhd_tb.md
       - Fermions (Majorana Jordan-Wigner): api/fermions.md


### PR DESCRIPTION
Closes the documentation gap for everything promoted today: `plot_circuit`, `global_depolarizing_channel` (#120), `continuous_pulse_evolve` (#121), `continuous_dissipative_evolve` (#122), `amplitude_damping_channel` (#123), `cosmic_ray_burst_profile` (#124), `decode_with_erasure_fallback` (#125) — none of them had README or docs-site coverage yet.

**README**: 3 new Core Features table rows, a new "Continuous-Time Evolution" section, a new "Noise Channels for Density-Matrix Simulation" subsection under Mitigation, and `decode_with_erasure_fallback` folded into the existing QEC Decoding section — every snippet verified to actually run.

**Docs site**: new `docs/api/diagram.md` for `plot_circuit` (added to `mkdocs.yml` nav), intro paragraphs added to `trotter.md`/`mitigation.md`/`qec.md` for the new functions (the `mkdocstrings` API reference itself already auto-updates from the docstrings — no duplicate directives added).

`mkdocs build --strict` verified clean.