### PR TITLE
Fix docs build: add pennylane to the docs extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,18 @@ docs = [
     "mkdocs-material>=9.5.0",
     "mkdocstrings[python]>=0.24.0",
     "mkdocs-include-markdown-plugin>=6.0.0",
-    "ruff>=0.4.0"
+    "ruff>=0.4.0",
+    # mkdocstrings dynamically imports every documented module to introspect
+    # it -- dashboard_core/__init__.py transitively imports qmmm.py, which
+    # does `import pennylane as qml` at module level, so the docs build
+    # itself needs pennylane installed even though nothing in docs/ or
+    # dense_evolution/ imports it directly. A pre-existing gap in this
+    # extra (unrelated to the tools/dashboard/ restructure, PR #105 --
+    # dashboard_core's own content is untouched) that a floating
+    # mkdocstrings/griffe version bump surfaced as a real, reproducible
+    # docs-build failure.
+    "pennylane>=0.35.0",
+    "basis_set_exchange>=0.9"
 ]
 
 [project.urls]


### PR DESCRIPTION
Main's "Docs — Build & Deploy" workflow turned red right after PR #105 merged. Root cause is NOT the `tools/dashboard/` restructure itself (100% content-identical rename per that PR's own description) — it's a pre-existing gap: `mkdocstrings` dynamically imports every documented module, and `dashboard_core/__init__.py` transitively imports `qmmm.py`, which does `import pennylane as qml` at module level. The `docs` extra never included pennylane.

An earlier docs-build run (the one right before #105, for #124's merge) happened to succeed despite this same gap — most likely a floating `mkdocstrings`/`griffe` version bump (both pinned with `>=`, no lockfile) changed introspection behavior between runs. Verified directly: the failing job's log shows `ModuleNotFoundError: No module named 'pennylane'` while building `docs/api/dashboard_core_circuit_builder_component.md`.

Fix: add `pennylane>=0.35.0` and `basis_set_exchange>=0.9` (its own companion dependency, same versions already used by the `pennylane`/`composer`/`full` extras) to the `docs` extra.