### PR TITLE
Release prep: bump to v8.1.67

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -39,7 +39,7 @@ from .circuits.trotter import (pauli_rotation_ops, trotter_evolve_ops, continuou
 from .physics.qec import (pauli_commutes, compute_syndrome, erasure_aware_decode, pymatching_decode,
                            blind_minimum_weight_decode, decode_with_erasure_fallback)
 
-__version__ = "8.1.66"
+__version__ = "8.1.67"
 
 __all__ = [
     "__version__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dense-evolution"
-version = "8.1.66"
+version = "8.1.67"
 description = "Micro-optimized High-Performance NISQ Statevector Quantum Circuit Simulator (Hardware-Adaptive Integration of Native NumPy and CPU/GPU/TPU JAX JIT/XLA Compilation, with Linear Kernel Fusion)"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Version bump only, no code changes. New in this release: `continuous_pulse_evolve`, `continuous_dissipative_evolve`, `amplitude_damping_channel`, `cosmic_ray_burst_profile`, `decode_with_erasure_fallback` (promoted from Dense-Evolution-Discovery Experiments 33/34 and the cosmic-ray-as-erasure decoding follow-up), `plot_circuit`, `global_depolarizing_channel`; the `tools/dashboard/` restructure; and a docs-build fix (pennylane added to the `docs` extra).