### PR TITLE
Add dev/CI Dockerfile and dependency lockfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git/
+.github/
+.claude/
+__pycache__/
+*.pyc
+.pytest_cache/
+.coverage
+coverage.xml
+htmlcov/
+dist/
+build/
+*.egg-info/
+docs/site/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,32 @@
+name: Docker — Build dev/CI image
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'requirements-lock.txt'
+      - '.github/workflows/docker.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'requirements-lock.txt'
+      - '.github/workflows/docker.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build image
+        run: docker build -t dense-evolution-dev .
+
+      - name: Sanity-check the image (import + version)
+        run: docker run --rm dense-evolution-dev python -c "import dense_evolution as de; print(de.__version__)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Development / CI environment for dense-evolution -- reproduces the
+# environment the test suite and docs build are validated against
+# (see requirements-lock.txt). Not an image meant to be published or run
+# as a service: there's no server here, just a container to `docker run
+# --rm -it dense-evolution-dev pytest tests/ -q` (or `bash`) in, so CI
+# failures reported by contributors on other machines/OSes can be
+# reproduced exactly instead of chased through "works on my machine".
+FROM python:3.12-slim
+
+WORKDIR /workspace
+
+# git: setuptools_scm / editable installs sometimes shell out to it;
+# build-essential: a couple of extras (pymatching, stim) ship no prebuilt
+# wheel for every platform and fall back to compiling from source.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements-lock.txt .
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements-lock.txt
+
+COPY . .
+RUN pip install --no-cache-dir -e . --no-deps
+
+CMD ["pytest", "tests/", "-q"]

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,0 +1,73 @@
+# Reproducibility lockfile -- NOT installed by `pip install dense-evolution`.
+#
+# pyproject.toml keeps `>=` lower-bound ranges deliberately: they're what a
+# library is supposed to ship, so it doesn't force version conflicts on
+# whatever else a downstream project has installed. This file pins the
+# exact versions the full test suite (943 passed, 19 skipped, 0 failed) and
+# the docs build were last verified against, for anyone who wants an
+# identical CI/dev environment rather than "whatever >= resolves to today".
+#
+# Usage: pip install -r requirements-lock.txt && pip install -e . --no-deps
+#
+# Covers the same footprint as .github/workflows/ci.yml's pip install steps
+# plus the `docs` extra. Regenerate by re-running the full suite in a fresh
+# venv and re-freezing these exact package names -- don't hand-edit versions.
+
+# Core (dependencies + jax extra)
+numpy==2.5.2
+scipy==1.18.1
+matplotlib==3.11.1
+psutil==7.2.2
+jax==0.11.1
+jaxlib==0.11.1
+
+# dashboard extra
+streamlit==1.59.2
+qiskit==2.5.0
+pylatexenc==2.11
+
+# pennylane extra
+pennylane==0.45.1
+basis_set_exchange==0.12
+
+# stim / pymatching extras
+stim==1.16.0
+pymatching==2.4.0
+
+# composer extra
+fastapi==0.138.0
+uvicorn==0.49.0
+pydantic==2.13.4
+
+# mcp extra
+mcp==2.0.0
+httpx==0.28.1
+
+# CI-only, not in pyproject.toml but installed in ci.yml for specific tests
+pandas==3.0.3
+ipython==9.15.0
+seaborn==0.13.2
+plotly==6.9.0
+ipywidgets==8.1.8
+qiskit-ibm-runtime==0.49.0
+httpx2==2.9.1
+
+# dev extra
+pytest==9.1.0
+pytest-cov==7.1.0
+
+# docs extra
+mkdocs==1.6.1
+mkdocs-material==9.7.7
+mkdocstrings==1.0.6
+mkdocstrings-python==2.0.5
+mkdocs-include-markdown-plugin==7.3.0
+ruff==0.16.1
+
+# build backend
+setuptools==81.0.0
+wheel==0.47.0
+
+# Not pinned here: the `gpu` extra (cupy-cuda12x / jax[cuda12]) -- CUDA
+# availability is host-specific, pinning it in a CPU-reproducibility
+# lockfile would be misleading rather than helpful.


### PR DESCRIPTION
## Summary
- `requirements-lock.txt`: pins exact versions of everything the full test suite and docs build were last verified against (943 passed, 19 skipped, 0 failed), covering the same footprint as `.github/workflows/ci.yml`'s pip install steps plus the `docs` extra. `pyproject.toml` keeps its `>=` ranges unchanged -- a library shouldn't force exact-version conflicts on downstream projects, so this is a separate, opt-in file for anyone who wants a byte-identical dev/CI environment.
- `Dockerfile` (+ `.dockerignore`): a dev/CI-only image (not published, not a service) that installs from the lockfile and installs the package editable -- lets a contributor reproduce a CI failure in an identical container instead of chasing host-specific differences.

## Test plan
- [x] `requirements-lock.txt` versions taken directly from the environment that just ran the full suite (943 passed, 19 skipped, 0 failed) -- see PR #130
- [ ] Docker not available in this environment to build-test the image directly -- flagging so a maintainer with Docker can do a sanity `docker build .` before relying on it