### PR TITLE
Hotfix: restore dense_evolution.chunk attribute access broken by #130

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -8,6 +8,16 @@ from .circuits.compiler import QuantumTranspiler
 from .circuits.registry import NoiseModel, NoiseSpec, QuantumHardwareRegistry
 from .circuits.gates import GATES, PARAMETRIC_GATES, GATE_IDS
 from .backends.chunk import Chunk
+# Also bind dense_evolution.chunk as an attribute of this package (the
+# shim at dense_evolution/chunk.py is otherwise only reachable via an
+# explicit `import dense_evolution.chunk` / `from dense_evolution.chunk
+# import ...` -- Python only auto-binds a submodule as a package
+# attribute when something actually imports that exact module path, and
+# `from .backends.chunk import Chunk` above binds backends.chunk, not
+# chunk). Real external code (dashboard_core.hamiltonians) does
+# `de.chunk.SafeMemoryGuard()` -- attribute access, not an import -- so
+# this import's only job is that side effect.
+from . import chunk as chunk
 from .config import set_precision
 from .interop import (
     from_qiskit, from_pennylane, run_qiskit_circuit, run_pennylane_circuit,


### PR DESCRIPTION
## Summary
PR #130 moved `chunk.py`'s real implementation to `backends/chunk.py` and changed `__init__.py` to `from .backends.chunk import Chunk`. That binds `backends.chunk` as a package attribute, not `chunk` -- Python only auto-binds a submodule as its parent package's attribute when something actually imports that exact module path. Real code (`dashboard_core.hamiltonians.build_molecular_hamiltonian`) does `de.chunk.SafeMemoryGuard()` -- attribute access, not an explicit import -- which has been broken for every caller on `main` since #130 merged.

Fix: `from . import chunk` in `__init__.py` restores the attribute binding. The shim itself (`dense_evolution/chunk.py` aliasing `dense_evolution.backends.chunk` in `sys.modules`) is unchanged and was never the problem.

## Test plan
- [x] `python -c "import dense_evolution as de; de.chunk.SafeMemoryGuard()"` now works (was `AttributeError`)
- [x] `tests/integration/test_dashboard_vqe.py` (which exercises `build_molecular_hamiltonian`, the real caller that broke) -- 10/10 passing
