### PR TITLE
Add native (PennyLane-free) UCCSD excitation circuits

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -8,6 +8,16 @@ from .circuits.compiler import QuantumTranspiler
 from .circuits.registry import NoiseModel, NoiseSpec, QuantumHardwareRegistry
 from .circuits.gates import GATES, PARAMETRIC_GATES, GATE_IDS
 from .backends.chunk import Chunk
+# Also bind dense_evolution.chunk as an attribute of this package (the
+# shim at dense_evolution/chunk.py is otherwise only reachable via an
+# explicit `import dense_evolution.chunk` / `from dense_evolution.chunk
+# import ...` -- Python only auto-binds a submodule as a package
+# attribute when something actually imports that exact module path, and
+# `from .backends.chunk import Chunk` above binds backends.chunk, not
+# chunk). Real external code (dashboard_core.hamiltonians) does
+# `de.chunk.SafeMemoryGuard()` -- attribute access, not an import -- so
+# this import's only job is that side effect.
+from . import chunk as chunk
 from .config import set_precision
 from .interop import (
     from_qiskit, from_pennylane, run_qiskit_circuit, run_pennylane_circuit,
@@ -37,6 +47,7 @@ from .physics.fermions import majorana_pauli_terms
 from .physics.entropy import partial_trace, von_neumann_entropy, mutual_information
 from .circuits.trotter import (pauli_rotation_ops, trotter_evolve_ops, continuous_pulse_evolve,
                                 continuous_dissipative_evolve)
+from .circuits.uccsd import find_excitations, single_excitation_ops, double_excitation_ops
 from .physics.qec import (pauli_commutes, compute_syndrome, erasure_aware_decode, pymatching_decode,
                            blind_minimum_weight_decode, decode_with_erasure_fallback)
 
@@ -55,6 +66,7 @@ __all__ = [
     "entangling_layer", "qft",
     "pauli_rotation_ops", "trotter_evolve_ops", "continuous_pulse_evolve",
     "continuous_dissipative_evolve",
+    "find_excitations", "single_excitation_ops", "double_excitation_ops",
     # Chunking / anti-OOM
     "Chunk",
     # Interop -- Qiskit / PennyLane / STIM bridges

--- a/dense_evolution/circuits/uccsd.py
+++ b/dense_evolution/circuits/uccsd.py
@@ -1,0 +1,275 @@
+"""
+Native (PennyLane-free) UCCSD excitation circuits.
+
+UCCSD's single/double fermionic excitation generators
+(a_p^dagger a_q - h.c., a_p^dagger a_q^dagger a_r a_s - h.c.) were
+previously only reachable through PennyLane's own FermionicSingleExcitation/
+FermionicDoubleExcitation decomposition (see dashboard/core/vqe.py's
+_uccsd_tape_to_qasm) -- not because a native circuit is theoretically
+impossible, but because deriving the exact (non-Trotterized) circuit
+identity requires real derivation, not just wiring PennyLane through.
+
+This module IS that derivation, done directly against
+dense_evolution.physics.fermions.majorana_pauli_terms (already-verified
+Jordan-Wigner mapping) rather than against PennyLane's internals, and
+every circuit identity below was verified against scipy.linalg.expm of
+the exact generator matrix (independently reconstructed from raw
+Jordan-Wigner ladder operators, not from PennyLane) before being written
+here -- see tests/unit/test_uccsd.py.
+
+Single excitation (any orbital distance): exact closed form, always.
+G_pq = a_p^dagger a_q - a_q^dagger a_p decomposes (via
+a_p^dagger=(chi_X(p)-i*chi_Y(p))/2) into exactly 2 Pauli strings that
+share the Jordan-Wigner Z-string between p and q and differ only by an
+X<->Y swap at p and q. This is the standard "Givens rotation" generator
+(G^2 = 2I): exact circuit is CNOT(p,q), fold each Z-string qubit's
+parity onto p via CNOT(k,p), CRY(2*theta, control=q, target=p), then
+undo. Verified for adjacent and long-Z-string pairs alike (any p<q).
+
+Double excitation: exact closed form when the occupied pair (p,q) is
+adjacent (q=p+1) AND the virtual pair (r,s) is adjacent (s=r+1) -- the
+gap between q and r (HOMO-LUMO gap) can be any length, no restriction.
+This is the case dashboard/core/vqe.py's UCCSD ansatz always produces
+for a 2-occupied/2-virtual active space (e.g. H2 in a minimal basis),
+and generally whenever qml.qchem.excitations pairs consecutive occupied
+orbitals with consecutive virtual orbitals. G_pqrs (8 Pauli terms)
+reduces to a clean 2-level coupling between |p=0,q=1,r=1,s=1,...> and
+its bit-flip, realized via a CNOT fan (mirroring the p,q,r,s pattern
+onto q) plus a triple-controlled RY (Toffoli-mediated, 2 ancilla
+qubits, always returned to |0>).
+
+For a double excitation where the occupied pair or the virtual pair is
+itself non-adjacent (occurs for active spaces with 3+ occupied or 3+
+virtual orbitals, e.g. LiH/BeH2), the same closed-form Z-string folding
+used for single excitations does NOT carry over cleanly (verified
+directly: the naive fold leaves genuine leakage, not just an
+unsimplified-but-correct circuit) -- deriving a comparably compact
+closed form for that case is unresolved, so double_excitation_ops falls
+back to per-term exponentiation of the 8 Pauli terms via
+dense_evolution.circuits.trotter.pauli_rotation_ops for that specific
+case, applied sequentially in a fixed term order.
+
+That fallback turned out to be exact too, not a Trotter approximation:
+verified exhaustively (every computational basis state, several p<q<r<s
+choices including non-adjacent pairs, theta up to pi) against
+scipy.linalg.expm of the exact generator matrix, to floating-point
+precision (~1e-15) at every theta tested, not just small theta the way
+a genuine first-order Trotter error would show. The 8 terms don't
+commute as operators on the full Hilbert space, but the generator only
+ever couples two basis states for any fixed setting of the qubits it
+doesn't act on (same structure as the closed-form case), and within
+that 2-dimensional invariant subspace the per-term exponentials
+apparently compose without error -- not derived from first principles
+here, just confirmed by the exhaustive check above. Only the GATE COUNT
+differs from the closed form, not correctness.
+"""
+from typing import List, Tuple
+
+from .trotter import pauli_rotation_ops
+
+__all__ = ['find_excitations', 'single_excitation_ops', 'double_excitation_ops']
+
+
+def find_excitations(electrons: int, n_qubits: int):
+    """
+    Enumerate spin-conserving single/double excitation index tuples for
+    a Hartree-Fock reference with the given electron count -- pure
+    classical combinatorics (occupied = orbitals [0, electrons), virtual
+    = the rest, even index = spin-up, odd = spin-down under the standard
+    Jordan-Wigner interleaved spin-orbital ordering), no quantum
+    computation involved. Verified to reproduce
+    qml.qchem.excitations(electrons, n_qubits) exactly across several
+    (electrons, n_qubits) pairs -- see tests/unit/test_uccsd.py -- kept
+    here so finding *which* excitations exist doesn't need PennyLane
+    installed any more than building their circuits does.
+
+    Returns (singles, doubles): singles is a list of [p, q] (p occupied,
+    q virtual, same spin); doubles is a list of [p, q, r, s] with
+    p<q both occupied, r<s both virtual, total spin conserved.
+    """
+    occupied = list(range(electrons))
+    virtual = list(range(electrons, n_qubits))
+    singles = [[p, q] for p in occupied for q in virtual if p % 2 == q % 2]
+    doubles = []
+    for i, p in enumerate(occupied):
+        for q in occupied[i + 1:]:
+            for j, r in enumerate(virtual):
+                for s in virtual[j + 1:]:
+                    if (p % 2 + q % 2) == (r % 2 + s % 2):
+                        doubles.append([p, q, r, s])
+    return singles, doubles
+
+
+# ── Pauli-string algebra (needed only for the per-term fallback path's
+# generator decomposition -- the closed-form circuits below are pure
+# combinatorial gate templates and never call this at all) ──────────────
+
+_MUL = {
+    ('I', 'I'): ('I', 1), ('I', 'X'): ('X', 1), ('I', 'Y'): ('Y', 1), ('I', 'Z'): ('Z', 1),
+    ('X', 'I'): ('X', 1), ('Y', 'I'): ('Y', 1), ('Z', 'I'): ('Z', 1),
+    ('X', 'X'): ('I', 1), ('Y', 'Y'): ('I', 1), ('Z', 'Z'): ('I', 1),
+    ('X', 'Y'): ('Z', 1j), ('Y', 'X'): ('Z', -1j),
+    ('Y', 'Z'): ('X', 1j), ('Z', 'Y'): ('X', -1j),
+    ('Z', 'X'): ('Y', 1j), ('X', 'Z'): ('Y', -1j),
+}
+
+
+def _pauli_mul_term(term_a, term_b):
+    ca, da = term_a
+    cb, db = term_b
+    phase = ca * cb
+    out = {}
+    for q in set(da) | set(db):
+        la, lb = da.get(q, 'I'), db.get(q, 'I')
+        letter, ph = _MUL[(la, lb)]
+        phase *= ph
+        if letter != 'I':
+            out[q] = letter
+    return (phase, out)
+
+
+def _psum_mul(terms_a, terms_b):
+    return [_pauli_mul_term(ta, tb) for ta in terms_a for tb in terms_b]
+
+
+def _psum_scale(terms, s):
+    return [(c * s, d) for c, d in terms]
+
+
+def _psum_combine(terms):
+    acc = {}
+    for c, d in terms:
+        key = tuple(sorted(d.items()))
+        acc[key] = acc.get(key, 0) + c
+    return [(c, dict(key)) for key, c in acc.items() if abs(c) > 1e-12]
+
+
+def _chi(mode_index, n_qubits):
+    from ..physics.fermions import majorana_pauli_terms
+    return majorana_pauli_terms(mode_index, n_qubits)[1]
+
+
+def _a_dagger(p, n_qubits):
+    return [(0.5, _chi(2 * p + 1, n_qubits)), (-0.5j, _chi(2 * p + 2, n_qubits))]
+
+
+def _a(p, n_qubits):
+    return [(0.5, _chi(2 * p + 1, n_qubits)), (0.5j, _chi(2 * p + 2, n_qubits))]
+
+
+def _double_excitation_generator(p, q, r, s, n_qubits):
+    """8 Pauli terms of a_p^dagger a_q^dagger a_r a_s - h.c. (JW-mapped).
+    Used only by the per-term fallback path -- verified against direct
+    fermionic ladder operators in tests/unit/test_uccsd.py."""
+    term1 = _psum_mul(_psum_mul(_a_dagger(p, n_qubits), _a_dagger(q, n_qubits)),
+                       _psum_mul(_a(r, n_qubits), _a(s, n_qubits)))
+    term2 = _psum_mul(_psum_mul(_a_dagger(s, n_qubits), _a_dagger(r, n_qubits)),
+                       _psum_mul(_a(q, n_qubits), _a(p, n_qubits)))
+    return _psum_combine(term1 + _psum_scale(term2, -1))
+
+
+# ── Single excitation: exact closed form, any p<q ───────────────────────
+
+def single_excitation_ops(p: int, q: int, theta: float) -> List[Tuple]:
+    """
+    Exact circuit for exp(theta * (a_p^dagger a_q - a_q^dagger a_p)),
+    the UCCS single-excitation unitary, for ANY p < q (any Jordan-Wigner
+    Z-string length in between) -- no Trotter error, ever.
+
+    Gate count: 2*(1 + (q-p-1)) CX + 1 CRY (itself 2 CX + 2 RY), so
+    2*(q-p) + 2 CX total.
+    """
+    if not p < q:
+        raise ValueError(f"single_excitation_ops requires p < q, got p={p}, q={q}")
+    inter = list(range(p + 1, q))
+    ops: List[Tuple] = []
+    ops.append(('cx', p, q))
+    for k in inter:
+        ops.append(('cx', k, p))
+    ops.extend(_cry_ops(2 * theta, control=q, target=p))
+    for k in reversed(inter):
+        ops.append(('cx', k, p))
+    ops.append(('cx', p, q))
+    return ops
+
+
+def _cry_ops(theta, control, target):
+    """CRY(theta) from native RY+CX: RY(theta/2)_t ; CX(c,t) ; RY(-theta/2)_t ; CX(c,t)."""
+    return [
+        ('ry', target, theta / 2),
+        ('cx', control, target),
+        ('ry', target, -theta / 2),
+        ('cx', control, target),
+    ]
+
+
+# ── Double excitation ────────────────────────────────────────────────────
+
+def double_excitation_ops(p: int, q: int, r: int, s: int, theta: float,
+                           ancilla1: int = None, ancilla2: int = None) -> List[Tuple]:
+    """
+    Circuit for exp(theta * (a_p^dagger a_q^dagger a_r a_s - h.c.)), the
+    UCCD double-excitation unitary, for p < q < r < s.
+
+    Exact closed form (no Trotter error) when ancilla1/ancilla2 are both
+    given AND the occupied pair is adjacent (q == p+1) AND the virtual
+    pair is adjacent (s == r+1) -- the gap between q and r can be any
+    length. This is what qml.qchem.excitations always produces for a
+    2-occupied/2-virtual active space, and sometimes for larger ones.
+
+    Falls back to per-term exponentiation of the 8-term Pauli
+    decomposition whenever no ancillas are given, or the pairs aren't
+    adjacent -- verified exact (not an approximation), just more gates
+    than the closed form; see the module docstring for why the closed
+    form doesn't generalize to a non-adjacent occupied or virtual pair
+    yet.
+
+    ancilla1, ancilla2 : two qubits that MUST be |0> on entry and are
+    guaranteed returned to |0> on exit -- only touched by the
+    closed-form path (never referenced by the per-term fallback), so
+    the same two ancillas can be reused across every double excitation
+    in an ansatz. Omit both (leave as None) to force the ancilla-free
+    per-term path unconditionally -- e.g. when the caller's qubit
+    register has no spare qubits to offer.
+    """
+    if not p < q < r < s:
+        raise ValueError(f"double_excitation_ops requires p<q<r<s, got {p},{q},{r},{s}")
+
+    have_ancillas = ancilla1 is not None and ancilla2 is not None
+    if have_ancillas and q == p + 1 and s == r + 1:
+        return _double_excitation_ops_closed_form(p, q, r, s, theta, ancilla1, ancilla2)
+    return _double_excitation_ops_per_term(p, q, r, s, theta)
+
+
+def _double_excitation_ops_closed_form(p, q, r, s, theta, a1, a2) -> List[Tuple]:
+    ops: List[Tuple] = []
+    ops.append(('cx', q, s))
+    ops.append(('cx', q, r))
+    ops.append(('cx', q, p))
+    ops.append(('x', p))
+    ops.extend(_toffoli_ops(p, r, a1))
+    ops.extend(_toffoli_ops(a1, s, a2))
+    ops.extend(_cry_ops(-2 * theta, control=a2, target=q))
+    ops.extend(_toffoli_ops(a1, s, a2))
+    ops.extend(_toffoli_ops(p, r, a1))
+    ops.append(('x', p))
+    ops.append(('cx', q, p))
+    ops.append(('cx', q, r))
+    ops.append(('cx', q, s))
+    return ops
+
+
+def _toffoli_ops(c1, c2, t):
+    from .compiler import QuantumTranspiler
+    return QuantumTranspiler.decompose_toffoli(c1, c2, t)
+
+
+def _double_excitation_ops_per_term(p, q, r, s, theta) -> List[Tuple]:
+    n_qubits = s + 1
+    terms = _double_excitation_generator(p, q, r, s, n_qubits)
+    ops: List[Tuple] = []
+    for coeff, pauli_dict in terms:
+        real_part = (coeff / 1j).real
+        angle = -theta * real_part
+        ops.extend(pauli_rotation_ops(pauli_dict, angle))
+    return ops

--- a/tests/unit/test_uccsd.py
+++ b/tests/unit/test_uccsd.py
@@ -1,0 +1,176 @@
+"""
+Unit tests for dense_evolution/circuits/uccsd.py -- native (PennyLane-free)
+UCCSD single/double excitation circuits.
+
+Ground truth throughout is built independently: raw Jordan-Wigner ladder
+operators (a_p, a_p^dagger) constructed directly with numpy Kronecker
+products, NOT via majorana_pauli_terms and NOT via PennyLane -- so a bug
+shared between the module under test and its own internal generator
+derivation would still be caught here.
+"""
+import numpy as np
+import pytest
+from scipy.linalg import expm
+
+from dense_evolution import DenseSVSimulator
+from dense_evolution.circuits.uccsd import find_excitations, single_excitation_ops, double_excitation_ops
+
+X = np.array([[0, 1], [1, 0]], dtype=complex)
+Y = np.array([[0, -1j], [1j, 0]], dtype=complex)
+Z = np.array([[1, 0], [0, -1]], dtype=complex)
+
+
+def _kron_all(mats):
+    out = mats[0]
+    for m in mats[1:]:
+        out = np.kron(out, m)
+    return out
+
+
+def _a_dagger(p, n):
+    zstring = _kron_all([Z] * p) if p > 0 else np.array([[1]], dtype=complex)
+    op = np.kron(zstring, (X - 1j * Y) / 2)
+    if n - p - 1 > 0:
+        op = np.kron(op, np.eye(2 ** (n - p - 1), dtype=complex))
+    return op
+
+
+def _a(p, n):
+    zstring = _kron_all([Z] * p) if p > 0 else np.array([[1]], dtype=complex)
+    op = np.kron(zstring, (X + 1j * Y) / 2)
+    if n - p - 1 > 0:
+        op = np.kron(op, np.eye(2 ** (n - p - 1), dtype=complex))
+    return op
+
+
+def _single_generator_matrix(p, q, n):
+    return _a_dagger(p, n) @ _a(q, n) - _a_dagger(q, n) @ _a(p, n)
+
+
+def _double_generator_matrix(p, q, r, s, n):
+    return (_a_dagger(p, n) @ _a_dagger(q, n) @ _a(r, n) @ _a(s, n)
+            - _a_dagger(s, n) @ _a_dagger(r, n) @ _a(q, n) @ _a(p, n))
+
+
+def _run_ops(ops, n, basis_index):
+    sim = DenseSVSimulator(n_qubits=n)
+    sim.sv = np.zeros(2 ** n, dtype=complex)
+    sim.sv[basis_index] = 1.0
+    sim.run_circuit(ops)
+    return sim.sv
+
+
+class TestFindExcitations:
+
+    @pytest.mark.parametrize("electrons,n_qubits", [
+        (2, 4), (2, 6), (4, 8), (2, 8), (4, 6),
+    ])
+    def test_matches_pennylane(self, electrons, n_qubits):
+        pennylane = pytest.importorskip("pennylane")
+        expected_singles, expected_doubles = pennylane.qchem.excitations(electrons, n_qubits)
+        singles, doubles = find_excitations(electrons, n_qubits)
+        assert singles == expected_singles
+        assert doubles == expected_doubles
+
+
+class TestSingleExcitation:
+
+    @pytest.mark.parametrize("p,q,n", [
+        (0, 1, 3), (0, 2, 3), (1, 4, 6), (0, 5, 6), (2, 3, 4),
+    ])
+    def test_exact_against_direct_ladder_operators(self, p, q, n):
+        """Every basis state, several (p, q, n) including adjacent and
+        long Jordan-Wigner Z-strings -- must match to floating-point
+        precision, not just approximately."""
+        theta = 0.4173
+        G = _single_generator_matrix(p, q, n)
+        target = expm(theta * G)
+        ops = single_excitation_ops(p, q, theta)
+        for basis in range(2 ** n):
+            out = _run_ops(ops, n, basis)
+            expected = target[:, basis]
+            assert np.max(np.abs(out - expected)) < 1e-10
+
+    def test_rejects_p_not_less_than_q(self):
+        with pytest.raises(ValueError, match="p < q"):
+            single_excitation_ops(2, 1, 0.5)
+
+    def test_zero_theta_is_identity(self):
+        ops = single_excitation_ops(0, 2, 0.0)
+        out = _run_ops(ops, 3, 0)
+        expected = np.zeros(8, dtype=complex); expected[0] = 1.0
+        assert np.max(np.abs(out - expected)) < 1e-12
+
+
+class TestDoubleExcitationClosedForm:
+
+    @pytest.mark.parametrize("p,q,r,s,n_logical", [
+        (0, 1, 2, 3, 4),   # fully adjacent (e.g. H2 minimal basis)
+        (0, 1, 4, 5, 6),   # adjacent pairs, large HOMO-LUMO gap
+        (2, 3, 4, 5, 6),
+    ])
+    def test_exact_against_direct_ladder_operators(self, p, q, r, s, n_logical):
+        theta = 0.317
+        a1, a2 = n_logical, n_logical + 1
+        n = n_logical + 2
+        G = _double_generator_matrix(p, q, r, s, n)
+        target = expm(theta * G)
+        ops = double_excitation_ops(p, q, r, s, theta, a1, a2)
+        for basis in range(0, 2 ** n, 4):  # ancillas start at |00> only
+            out = _run_ops(ops, n, basis)
+            expected = target[:, basis]
+            assert np.max(np.abs(out - expected)) < 1e-9
+
+    def test_ancillas_return_to_zero(self):
+        """Ancilla qubits must come back to |0> regardless of the
+        logical register's state, so callers can reuse them."""
+        n_logical, theta = 4, 0.6
+        a1, a2 = 4, 5
+        n = 6
+        ops = double_excitation_ops(0, 1, 2, 3, theta, a1, a2)
+        for basis in range(0, 2 ** n, 4):
+            out = _run_ops(ops, n, basis)
+            prob_ancilla_nonzero = np.sum(np.abs(out) ** 2) - sum(
+                np.abs(out[i]) ** 2 for i in range(0, 2 ** n, 4)
+            )
+            assert prob_ancilla_nonzero < 1e-10
+
+
+class TestDoubleExcitationPerTermFallback:
+
+    @pytest.mark.parametrize("p,q,r,s,n", [
+        (0, 2, 4, 6, 7),   # non-adjacent occupied pair
+        (0, 1, 3, 5, 6),   # non-adjacent virtual pair
+        (1, 3, 5, 7, 8),   # both pairs non-adjacent
+        (0, 2, 3, 5, 6),
+    ])
+    def test_exact_against_direct_ladder_operators(self, p, q, r, s, n):
+        """The fallback path (used whenever the occupied or virtual pair
+        isn't adjacent) is verified exact here too, not just 'close' --
+        see the module docstring for why this held up empirically."""
+        theta = 0.9137
+        G = _double_generator_matrix(p, q, r, s, n)
+        target = expm(theta * G)
+        ops = double_excitation_ops(p, q, r, s, theta, ancilla1=97, ancilla2=98)
+        for basis in range(2 ** n):
+            out = _run_ops(ops, n, basis)
+            expected = target[:, basis]
+            assert np.max(np.abs(out - expected)) < 1e-9
+
+    def test_rejects_unordered_indices(self):
+        with pytest.raises(ValueError, match=r"p<q<r<s"):
+            double_excitation_ops(0, 2, 1, 3, 0.5, 10, 11)
+
+    def test_no_ancillas_forces_per_term_path_even_when_adjacent(self):
+        """Omitting ancilla1/ancilla2 must give the ancilla-free path
+        unconditionally, even for an adjacent pair that would otherwise
+        qualify for the closed form -- e.g. a caller with no spare
+        qubits to offer."""
+        p, q, r, s, n, theta = 0, 1, 2, 3, 4, 0.6
+        G = _double_generator_matrix(p, q, r, s, n)
+        target = expm(theta * G)
+        ops = double_excitation_ops(p, q, r, s, theta)  # ancillas omitted
+        assert all(name != 'ccx' for (name, *_) in ops)  # sanity: no Toffoli in this path
+        for basis in range(2 ** n):
+            out = _run_ops(ops, n, basis)
+            assert np.max(np.abs(out - target[:, basis])) < 1e-9

--- a/tools/dashboard/core/vqe.py
+++ b/tools/dashboard/core/vqe.py
@@ -28,28 +28,34 @@ Two real ansatz families:
   order of residual error against the exact energy, same physics).
 - **UCCSD** (Unitary Coupled-Cluster Singles and Doubles): the standard
   chemically-motivated VQE ansatz. Built from the molecule's *real*
-  single/double fermionic excitation operators (qml.qchem.excitations),
-  applied to the Hartree-Fock reference via qml.UCCSD (which internally
-  exponentiates each excitation as a FermionicSingleExcitation /
-  FermionicDoubleExcitation -- Givens-rotation-equivalent operators, not
-  a generic template). Fewer parameters than hardware-efficient for the
-  same molecule (H2: 3 vs 32), and converges to the exact energy faster
+  single/double fermionic excitation operators
+  (dense_evolution.find_excitations -- pure combinatorics, verified to
+  reproduce qml.qchem.excitations exactly), applied to the Hartree-Fock
+  reference via dense_evolution.single_excitation_ops/
+  double_excitation_ops -- exact closed-form circuits derived directly
+  against dense_evolution's own Jordan-Wigner mapping
+  (physics.fermions.majorana_pauli_terms), not PennyLane's decomposition;
+  see dense_evolution/circuits/uccsd.py for the derivation and the exact
+  scope of the closed form vs. its (also verified exact) per-term
+  fallback. Fewer parameters than hardware-efficient for the same
+  molecule (H2: 3 vs 32), and converges to the exact energy faster
   because the ansatz form actually matches the physics. Also optimized
   entirely on dense_evolution's own engine, same as hardware-efficient --
-  the obstacle was that PennyLane's own decomposition of qml.UCCSD reuses
-  each of the few real weights across several RX/RZ gates per excitation
-  (Trotter exponentiation of that excitation's several Pauli-string
-  terms), whereas circuit_to_energy_fn treats every parametric gate
+  the obstacle was that these excitation circuits reuse the same weight
+  across several RY/RZ gates per excitation (single_excitation_ops' CRY
+  is 2 RY gates; double_excitation_ops' per-term path is up to 8 RZ
+  gates), whereas circuit_to_energy_fn treats every parametric gate
   occurrence as an independent free parameter. Solved with an affine
-  parameter expansion (_uccsd_native_expansion): probing PennyLane's own
-  decomposition at weights=0 and at each basis vector gives a fixed
+  parameter expansion (_uccsd_native_expansion): probing
+  _uccsd_native_ops at weights=0 and at each basis vector gives a fixed
   (baseline, expansion_matrix) pair such that
   full_gate_values = baseline + expansion_matrix @ real_weights exactly
-  reproduces PennyLane's own per-gate values for any weights (verified by
+  reproduces the real per-gate values for any weights (verified by
   direct probing, not derived from theory) -- composed with
   circuit_to_energy_fn this is still JAX-differentiable in the small real
   weight vector by ordinary chain rule, so the same hand-rolled Adam loop
-  optimizes it with no PennyLane device/QNode/optimizer involved.
+  optimizes it with no PennyLane device/QNode/optimizer, or PennyLane
+  import of any kind, involved.
 
 The Hartree-Fock initial state (computed via qml.qchem.hf_state) only
 has a simple X-gate encoding under the Jordan-Wigner mapping, so VQE
@@ -57,12 +63,12 @@ generation here is JW-only. Bravyi-Kitaev stays available for exact
 ground-state-energy queries in hamiltonians.py, where the eigenvalue
 spectrum is mapping-invariant.
 
-UCCSD's FermionicSingleExcitation/FermionicDoubleExcitation don't have a
-one-line OpenQASM equivalent, so the converged circuit is decomposed via
-PennyLane's own tape.expand() into RX/RY/RZ/CNOT (verified: executing
-the resulting QASM on dense_evolution.DenseSVSimulator and recomputing
-<psi|H|psi> matches PennyLane's own reported energy to 1e-14, i.e. pure
-floating-point noise, not an approximation) and translated gate-by-gate.
+PennyLane's only remaining role anywhere in this module is the real
+Hartree-Fock + Jordan-Wigner Hamiltonian construction itself
+(dashboard_core.hamiltonians), which isn't something worth
+reimplementing (see research/quantum_chemistry_vqe_pipeline.md) -- the
+ansatz circuits themselves (hardware-efficient and UCCSD alike) never
+touch PennyLane at all.
 """
 
 import numpy as np
@@ -72,13 +78,6 @@ import dense_evolution as de
 from .hamiltonians import _get_pennylane_hamiltonian, build_molecular_hamiltonian
 
 __all__ = ['run_vqe']
-
-_PENNYLANE_TO_QASM_GATE = {
-    'RX': 'rx', 'RY': 'ry', 'RZ': 'rz',
-    'CNOT': 'cx', 'Hadamard': 'h',
-    'PauliX': 'x', 'PauliY': 'y', 'PauliZ': 'z',
-    'S': 's', 'T': 't',
-}
 
 
 def _hardware_efficient_ansatz(params, n_qubits, n_layers, hf_occupation):
@@ -112,60 +111,93 @@ def _hardware_efficient_qasm(params, n_qubits, n_layers, hf_occupation):
 
 
 def _uccsd_excitations(electrons, n_qubits):
-    import pennylane as qml
-    singles, doubles = qml.qchem.excitations(electrons, n_qubits)
-    s_wires, d_wires = qml.qchem.excitations_to_wires(singles, doubles)
-    return s_wires, d_wires
+    """Which single/double excitations exist for this electron count --
+    pure combinatorics (occupied/virtual orbital pairing respecting spin
+    conservation), no quantum circuit involved. de.find_excitations is
+    dense_evolution's own reimplementation, verified to reproduce
+    qml.qchem.excitations exactly (see tests/unit/test_uccsd.py) --
+    kept native rather than calling PennyLane here for the same reason
+    the circuits themselves are native: this is chemistry index-finding,
+    not the deliberately-kept PennyLane dependency (Hartree-Fock +
+    Jordan-Wigner Hamiltonian construction, see module docstring)."""
+    return de.find_excitations(electrons, n_qubits)
 
 
-def _uccsd_tape_to_qasm(weights, n_qubits, s_wires, d_wires, hf_occupation):
-    """Builds the real UCCSD circuit for the given (converged) weights,
-    decomposes it into basic gates via PennyLane's own tape expansion,
-    and translates that exact gate sequence into OpenQASM 2.0 -- not a
-    hand-derived approximation of what UCCSD does, the literal expansion
-    PennyLane itself uses to run the circuit."""
-    import pennylane as qml
+def _uccsd_native_ops(weights, n_qubits, singles, doubles, hf_occupation):
+    """Real UCCSD circuit for the given weights, built entirely from
+    dense_evolution.single_excitation_ops/double_excitation_ops (exact
+    closed-form / exact per-term circuits, see
+    dense_evolution/circuits/uccsd.py) -- no PennyLane device, QNode, or
+    gate decomposition involved anywhere in this function. Doubles
+    always use the ancilla-free path (omitting ancilla1/ancilla2) so the
+    circuit's qubit count stays exactly n_qubits, matching H_dense's own
+    dimension with no padding needed."""
+    ops = []
+    for wire, occ in enumerate(hf_occupation):
+        if occ:
+            ops.append(('x', wire))
+    idx = 0
+    for (p, q) in singles:
+        ops.extend(de.single_excitation_ops(p, q, weights[idx]))
+        idx += 1
+    for (p, q, r, s) in doubles:
+        ops.extend(de.double_excitation_ops(p, q, r, s, weights[idx]))
+        idx += 1
+    return ops
 
-    with qml.queuing.AnnotatedQueue() as q:
-        qml.UCCSD(weights, wires=range(n_qubits), s_wires=s_wires, d_wires=d_wires, init_state=hf_occupation)
-    tape = qml.tape.QuantumScript.from_queue(q)
-    expanded = tape.expand(depth=10)
 
+def _ops_to_qasm(ops, n_qubits):
+    """Gate-tuple list -> OpenQASM 2.0 text. Handles every gate name
+    dense_evolution.single_excitation_ops/double_excitation_ops can
+    produce: 2-qubit no-param (cx), 1-qubit no-param (x, h, s, sdg, ...),
+    1-qubit with param (ry, rz, ...)."""
     lines = ['OPENQASM 2.0;', 'include "qelib1.inc";', f'qreg q[{n_qubits}];', f'creg c[{n_qubits}];']
-    for op in expanded.operations:
-        gate = _PENNYLANE_TO_QASM_GATE.get(op.name)
-        if gate is None:
-            raise ValueError(f"UCCSD decomposition produced an unmapped gate: {op.name!r}")
-        wires = ','.join(f'q[{w}]' for w in op.wires.tolist())
-        if op.parameters:
-            lines.append(f'{gate}({float(op.parameters[0]):.12f}) {wires};')
+    for op in ops:
+        name, rest = op[0], op[1:]
+        if name == 'cx':
+            q0, q1 = rest
+            lines.append(f'cx q[{q0}],q[{q1}];')
+        elif len(rest) == 2:
+            q0, param = rest
+            lines.append(f'{name}({float(param):.12f}) q[{q0}];')
         else:
-            lines.append(f'{gate} {wires};')
+            (q0,) = rest
+            lines.append(f'{name} q[{q0}];')
     lines.append('measure q -> c;')
     return '\n'.join(lines)
 
 
-def _uccsd_native_expansion(n_qubits, s_wires, d_wires, hf_occupation, n_params):
+def _uccsd_tape_to_qasm(weights, n_qubits, singles, doubles, hf_occupation):
+    """Builds the real UCCSD circuit for the given (converged) weights
+    and translates it to OpenQASM 2.0 -- the literal native circuit
+    dense_evolution runs, not an approximation of it."""
+    return _ops_to_qasm(_uccsd_native_ops(weights, n_qubits, singles, doubles, hf_occupation), n_qubits)
+
+
+def _uccsd_native_expansion(n_qubits, singles, doubles, hf_occupation, n_params):
     """Makes UCCSD optimizable through dense_evolution's own
-    circuit_to_energy_fn (not PennyLane's optimizer) despite
+    circuit_to_energy_fn (not a black-box optimizer) despite
     circuit_to_energy_fn treating every parametric gate occurrence as an
-    independent free value: PennyLane's UCCSD decomposition reuses the
-    *same* weight across several RX/RZ gates per excitation (the Trotter
-    exponentiation of that excitation's several Pauli-string terms), so
-    the true relationship between the small real weight vector (length
+    independent free value: _uccsd_native_ops's own excitation circuits
+    reuse the *same* weight across several RY/RZ gates per excitation
+    (single_excitation_ops' CRY is 2 RY gates; double_excitation_ops'
+    per-term path is up to 8 RZ gates, one per Pauli-string term), so the
+    true relationship between the small real weight vector (length
     n_params, one per excitation) and the full per-gate value vector
     (length n_params_full, one per parametric gate occurrence -- most of
     them *not* free parameters at all, but fixed pi/2 basis-change
     rotations) is affine: full = baseline + expansion_matrix @ weights.
 
     Verified exact (not approximate) by direct probing rather than
-    derived from theory: evaluating PennyLane's own decomposition at
-    weights=0 (-> baseline) and at each basis vector e_i (-> baseline's
-    i-th deviation, i.e. expansion_matrix's i-th column) reproduces
-    PennyLane's own reported energy for arbitrary weight vectors to
-    2.5e-14 (pure floating-point noise) when fed through this affine map
-    into circuit_to_energy_fn -- not just the per-gate values, the real
-    downstream energy, checked directly against qml.expval(H).
+    derived from theory -- same technique this function always used,
+    just probing dense_evolution's own native circuit builder now
+    instead of PennyLane's UCCSD decomposition: evaluating
+    _uccsd_native_ops at weights=0 (-> baseline) and at each basis
+    vector e_i (-> baseline's i-th deviation, i.e. expansion_matrix's
+    i-th column) reproduces the real downstream energy for arbitrary
+    weight vectors to floating-point precision when fed through this
+    affine map into circuit_to_energy_fn (see
+    tests/integration/test_dashboard_vqe.py).
 
     Since expansion_matrix/baseline are fixed (non-trainable) arrays, the
     composition `energy_fn_full(baseline + expansion_matrix @ real_theta,
@@ -174,18 +206,15 @@ def _uccsd_native_expansion(n_qubits, s_wires, d_wires, hf_occupation, n_params)
 
     Returns (qasm_structure, baseline, expansion_matrix). qasm_structure
     uses the weights=0 reference circuit -- gate order/wires depend only
-    on s_wires/d_wires/hf_occupation, never on the numeric weight values,
-    so any reference weight vector would produce the same structure."""
-    import pennylane as qml
-
-    def tape_ops(weights):
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.UCCSD(weights, wires=range(n_qubits), s_wires=s_wires, d_wires=d_wires, init_state=hf_occupation)
-        tape = qml.tape.QuantumScript.from_queue(q)
-        return tape.expand(depth=10).operations
-
+    on singles/doubles/hf_occupation, never on the numeric weight
+    values, so any reference weight vector would produce the same
+    structure."""
     def param_values(weights):
-        return np.array([float(op.parameters[0]) for op in tape_ops(weights) if op.parameters])
+        ops = _uccsd_native_ops(weights, n_qubits, singles, doubles, hf_occupation)
+        # 'cx' is also a 3-tuple (name, control, target) -- must be
+        # excluded explicitly, not just by tuple length, or its target
+        # qubit index gets misread as a rotation angle.
+        return np.array([float(op[-1]) for op in ops if op[0] in ('ry', 'rz', 'rx')])
 
     zero_weights = np.zeros(n_params)
     baseline = param_values(zero_weights)
@@ -196,7 +225,7 @@ def _uccsd_native_expansion(n_qubits, s_wires, d_wires, hf_occupation, n_params)
         columns.append(param_values(e_i) - baseline)
     expansion_matrix = np.array(columns).T if n_params else np.zeros((len(baseline), 0))
 
-    qasm_structure = _uccsd_tape_to_qasm(zero_weights, n_qubits, s_wires, d_wires, hf_occupation)
+    qasm_structure = _uccsd_tape_to_qasm(zero_weights, n_qubits, singles, doubles, hf_occupation)
     return qasm_structure, baseline, expansion_matrix
 
 
@@ -241,10 +270,10 @@ def run_vqe(symbols, geometry, charge=0, ansatz_type="hardware_efficient", n_lay
         electrons = molecule.n_electrons
     hf_occupation = qml.qchem.hf_state(electrons, n_qubits)
 
-    s_wires = d_wires = None
+    singles = doubles = None
     if ansatz_type == "uccsd":
-        s_wires, d_wires = _uccsd_excitations(electrons, n_qubits)
-        n_params = len(s_wires) + len(d_wires)
+        singles, doubles = _uccsd_excitations(electrons, n_qubits)
+        n_params = len(singles) + len(doubles)
     else:
         n_params = n_qubits * n_layers
 
@@ -270,7 +299,7 @@ def run_vqe(symbols, geometry, charge=0, ansatz_type="hardware_efficient", n_lay
         H_dense, _ = build_molecular_hamiltonian(symbols, geometry, charge, "jordan_wigner",
                                                    active_electrons, active_orbitals)
         qasm_structure, baseline, expansion_matrix = _uccsd_native_expansion(
-            n_qubits, s_wires, d_wires, hf_occupation, n_params,
+            n_qubits, singles, doubles, hf_occupation, n_params,
         )
         parsed = de.QASMParser().parse(qasm_structure)
         energy_fn_full, n_params_full = de.circuit_to_energy_fn(parsed, n_qubits)
@@ -360,7 +389,7 @@ def run_vqe(symbols, geometry, charge=0, ansatz_type="hardware_efficient", n_lay
     if n_params == 0:
         qasm = _hardware_efficient_qasm(params, n_qubits, 0, hf_occupation)
     elif ansatz_type == "uccsd":
-        qasm = _uccsd_tape_to_qasm(params, n_qubits, s_wires, d_wires, hf_occupation)
+        qasm = _uccsd_tape_to_qasm(params, n_qubits, singles, doubles, hf_occupation)
     else:
         qasm = _hardware_efficient_qasm(params, n_qubits, n_layers, hf_occupation)
 


### PR DESCRIPTION
## Summary
UCCSD's single/double fermionic excitation generators were only reachable through PennyLane's own `FermionicSingleExcitation`/`FermionicDoubleExcitation` decomposition -- not because a native circuit is theoretically impossible, but because deriving the exact circuit identity requires real derivation, not just wiring PennyLane through. `dense_evolution/circuits/uccsd.py` is that derivation, done directly against this package's own Jordan-Wigner mapping (`physics.fermions.majorana_pauli_terms`):

- **`single_excitation_ops`**: exact closed form for any `p<q` (any Jordan-Wigner Z-string length), verified against direct fermionic ladder operators independently reconstructed with numpy (not via PennyLane, not via the module's own internals).
- **`double_excitation_ops`**: exact closed form when the occupied pair and virtual pair are each adjacent (covers H2 and many larger active spaces) -- a CNOT fan + Toffoli-mediated triple-controlled rotation, 2 ancilla qubits always returned to `|0>`. Falls back to per-term exponentiation of the 8-term Pauli decomposition otherwise -- verified exact too (not a Trotter approximation, checked exhaustively at theta up to pi), just more gates than the closed form.
- **`find_excitations`**: native reimplementation of `qml.qchem.excitations`'s spin-conserving excitation enumeration (pure combinatorics, no quantum computation), verified to reproduce it exactly across 5 (electrons, n_qubits) configurations.

`tools/dashboard/core/vqe.py`'s UCCSD ansatz now builds its circuit entirely from these -- no PennyLane device, QNode, decomposition, or import of any kind anywhere in the circuit-construction path. PennyLane's only remaining role in the module is Hartree-Fock + Hamiltonian construction (`dashboard_core.hamiltonians`), an already-accepted, separate dependency (see module docstring).

Also includes the same `dense_evolution.chunk` attribute-access fix as #133 (this branch forked from `main` after #130 merged, so it needed the same fix to test cleanly) -- will be a no-op once #133 merges first.

## Test plan
- [x] `tests/unit/test_uccsd.py` (22 new tests) -- exhaustive per-basis-state verification against independent ground-truth fermionic operators, both circuit paths (closed form + per-term fallback)
- [x] `tests/integration/test_dashboard_vqe.py` (10 tests, unchanged) -- all passing, including real convergence to H2's exact ground-state energy (3 params, energy within 1e-3) and a QASM round-trip check
- [ ] Full suite (`pytest tests/ -q`) kept getting killed early in this local environment for reasons unrelated to these changes (no test failures/errors in the captured output, just clean truncation at the same point across 3 attempts) -- deferring to CI's clean environment for that final signal