### PR TITLE
Add counts_in_intervals_dimension: burst-vs-Poisson noise diagnostic for QEC

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ dense_evolution/
 │   ├── observables.py      Pauli-string expectation values, O(2ⁿ) direct from a statevector · pauli_sum_matvec (matrix-free H·v)
 │   ├── states.py           common state-preparation circuits (Bell, GHZ, W, ...) as gate tuples
 │   ├── fermions.py         majorana_pauli_terms — Majorana-fermion → qubit (Jordan-Wigner) mapping
-│   └── qec.py              pauli_commutes · compute_syndrome · erasure_aware_decode · pymatching_decode (MWPM) · blind_minimum_weight_decode (code-agnostic stabilizer QEC)
+│   └── qec.py              pauli_commutes · compute_syndrome · erasure_aware_decode · pymatching_decode (MWPM) · blind_minimum_weight_decode · counts_in_intervals_dimension (code-agnostic stabilizer QEC + burst-vs-Poisson noise diagnostic)
 ├── mitigation/           [subpackage] error mitigation and density-matrix diagnostics
 │   ├── zne.py               richardson_extrapolate · zero_noise_extrapolation · zne_density_matrix · jsd_predictive_zne_density_matrix · uhlmann_fidelity (+ jit variants)
 │   ├── healing.py            predictive state engine · Phi_AB · vettore dinamico · MemoryReflectionEngine
@@ -245,6 +245,7 @@ research/                           (not installed as a module -- reference/expe
 | **STIM Bridge** | `to_stim` — Clifford-only op-list → `stim.Circuit`, for cross-validation against STIM's stabilizer simulator/decoder tooling |
 | **Native Hartree-Fock** | `dense_evolution.native_hf` — from-scratch JAX/Obara-Saika ab-initio HF engine for elements outside PennyLane's own STO-3G table (H–Ne), auto-used by the Hamiltonian Library for e.g. Si2 |
 | **QEC Decoding** | `dense_evolution.qec` — code-agnostic Pauli commutation/syndrome primitives, an erasure-aware decoder (corrects up to *d*-1 known-location errors on a distance-*d* code, Grassl/Beth/Pellizzari 1997), a real MWPM decoder (`pymatching_decode`, via `pymatching`) for graph-like/topological codes, and a blind minimum-weight brute-force decoder (`blind_minimum_weight_decode`) for the small codes MWPM structurally can't handle (e.g. Steane) |
+| **Burst-vs-Poisson Noise Diagnostic** | `dense_evolution.qec` — `counts_in_intervals_dimension`: generalizes the "counts-in-spheres" fractal-dimension estimator used to measure large-scale cosmic homogeneity (Scrimgeour et al. 2012, MNRAS 425, 116, arXiv:1205.6812) from 3-D space to 1-D time, to tell whether a stream of error/erasure timestamps is temporally clustered (D<1, e.g. cosmic-ray-correlated bursts) or Poissonian (D≈1) — returns the log-log fit's R² alongside D so a poorly-supported fit is never silently trusted |
 | **Backend Agnostic** | NumPy CPU · JAX XLA CPU/GPU/TPU — GPU dispatch is automatic whenever a CUDA-enabled `jax[cuda12]` is installed and a GPU is present, zero code changes |
 | **Live Dashboard** | `tools/dashboard/app.py` — Streamlit Quantum-Composer clone, 5 tabs (Graphical Builder/Circuit/Statevector/Probabilities/Q-sphere) per simulation run |
 
@@ -586,6 +587,20 @@ syndrome = compute_syndrome('IIIZIII', stabilizers)                             
 # Uses the known error location when it resolves the syndrome, falls back to
 # blind minimum-weight decoding otherwise -- one entry point either way:
 corrected = decode_with_erasure_fallback(syndrome, heralded_qubits=[3], n_qubits=7, stabilizers=stabilizers)
+```
+
+Is a stream of error timestamps actually bursty, or just Poissonian noise? `counts_in_intervals_dimension`
+answers that directly from data instead of assuming either model, and reports the fit quality alongside
+the answer:
+
+```python
+from dense_evolution import counts_in_intervals_dimension
+import numpy as np
+
+error_timestamps = ...  # e.g. heralded-erasure or syndrome-detection times from a run
+radii = np.logspace(0, 2, 10)  # span at least 2 orders of magnitude -- a narrow range gives a meaningless fit
+D, r_squared, _ = counts_in_intervals_dimension(error_timestamps, radii)
+# D ~ 1, high r_squared -> Poissonian; D < 1 -> temporally clustered/bursty
 ```
 
 ---

--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -49,7 +49,8 @@ from .circuits.trotter import (pauli_rotation_ops, trotter_evolve_ops, continuou
                                 continuous_dissipative_evolve)
 from .circuits.uccsd import find_excitations, single_excitation_ops, double_excitation_ops
 from .physics.qec import (pauli_commutes, compute_syndrome, erasure_aware_decode, pymatching_decode,
-                           blind_minimum_weight_decode, decode_with_erasure_fallback)
+                           blind_minimum_weight_decode, decode_with_erasure_fallback,
+                           counts_in_intervals_dimension)
 
 __version__ = "8.1.67"
 
@@ -89,7 +90,7 @@ __all__ = [
     "partial_trace", "von_neumann_entropy", "mutual_information",
     "majorana_pauli_terms",
     "pauli_commutes", "compute_syndrome", "erasure_aware_decode", "pymatching_decode", "blind_minimum_weight_decode",
-    "decode_with_erasure_fallback",
+    "decode_with_erasure_fallback", "counts_in_intervals_dimension",
     # Utils -- drawing, measurement, random circuits
     "draw_circuit", "plot_circuit", "sample_counts", "statevector_fidelity", "random_circuit",
 ]

--- a/dense_evolution/physics/qec.py
+++ b/dense_evolution/physics/qec.py
@@ -56,6 +56,20 @@ lowest-weight match, not require a totally unique one across every
 possible weight) is what makes blind decoding well-posed at all -- the
 same principle `pymatching_decode`'s MWPM implements via a matching
 graph instead of brute force.
+
+`counts_in_intervals_dimension` answers a question upstream of all of
+the above: IS a given stream of error/erasure timestamps actually
+bursty, or Poissonian? It generalizes the "counts-in-spheres" fractal
+dimension estimator used to measure large-scale cosmic homogeneity
+(Scrimgeour et al. 2012, MNRAS 425, 116, arXiv:1205.6812) from 3-D
+space to 1-D time: D~=1 means homogeneous arrivals, D<1 means temporal
+clustering (e.g. cosmic-ray-correlated bursts, arXiv:2104.05219 --
+the same physical noise source `cosmic_ray_burst_profile` in
+`dense_evolution.mitigation.zne` models). Returns the fit's R^2
+alongside D deliberately, never just the number -- a box-counting fit
+through too few points spanning too narrow a range of scales can
+report a fractal dimension as absurd as 142 in 3 dimensions purely
+from fit noise, not from any real structure in the data.
 """
 import itertools
 from typing import Optional, Sequence
@@ -404,6 +418,147 @@ def blind_minimum_weight_decode(
             return None
 
     return None
+
+
+def counts_in_intervals_dimension(
+    event_times: Sequence[float],
+    window_sizes: Sequence[float],
+    min_reference_points: int = 5,
+) -> tuple:
+    """Correlation-dimension estimator for a 1-D point process (event
+    times), generalizing the "counts-in-spheres" statistic used to
+    measure the fractal dimension of galaxy distributions -- Scrimgeour
+    et al., "The WiggleZ Dark Energy Survey: the transition to
+    large-scale cosmic homogeneity," MNRAS 425, 116 (2012),
+    arXiv:1205.6812 -- from 3-D space down to 1-D time.
+
+    For a homogeneous (Poisson) point process, the expected number of
+    OTHER events within radius r of a given event scales as N(<=r) ~ r^1
+    exactly. Real burst-like noise (e.g. cosmic-ray-correlated error
+    events, arXiv:2104.05219, already modelled by `cosmic_ray_burst_profile`
+    in `dense_evolution.mitigation.zne`) clusters in time: events arrive
+    in tight groups separated by long, comparatively empty gaps, which
+    depresses this exponent below 1. This function measures that exponent
+    directly from a sequence of observed/simulated event times (e.g.
+    heralded-erasure timestamps, or detected-syndrome timestamps), instead
+    of assuming Poissonian noise or a particular burst model up front --
+    the measured dimension is then evidence for whether `decode_with_erasure_fallback`
+    style single-shot decoding or a burst-aware strategy is the right model
+    for a given noise source.
+
+    For each candidate radius r in `window_sizes`, every event at least r
+    away from both ends of the observed time range is used as a reference
+    point (events too close to either edge are skipped for that r, so a
+    partially-empty window near the boundary never silently deflates the
+    count -- the same edge correction real counts-in-spheres analyses
+    use). The mean count of other events within r of each valid reference
+    point is computed, and the dimension D is the slope of log(mean
+    count) vs log(r) over a linear least-squares fit -- with the fit's
+    R^2 returned alongside it, not hidden, because a narrow or
+    poorly-covered range of `window_sizes` can make the fitted slope
+    meaningless (see the warning below).
+
+    D ~= 1 : homogeneous/Poissonian arrivals, no clustering.
+    D < 1 : temporally clustered/bursty (e.g. cosmic-ray-correlated
+            error bursts) -- the smaller D, the tighter the clustering.
+    D > 1 : more regularly spaced than random (suppressed fluctuations,
+            "hyperuniform" arrivals) -- unusual for physical error
+            processes but not excluded by the statistic itself.
+
+    A LOW R^2 (rule of thumb: below ~0.98) means `window_sizes` does not
+    span enough dynamic range or lacks enough valid reference points for
+    the fit to be trustworthy -- widen the range (ideally 2-3 orders of
+    magnitude) and/or supply more events rather than trusting the
+    reported D. This mirrors a real, previously-made mistake: a spatial
+    box-counting fit through only 4 points spanning a narrow range of
+    scales produced a fractal dimension of 142 (physically impossible in
+    3 dimensions) from noise alone, not from any real structure in the
+    data -- always inspect R^2 before quoting D.
+
+    Cost is O(len(window_sizes) * n_events^2) in the worst case (every
+    event checked against every other at every radius) -- fine for the
+    thousands-of-events regime a per-run error/erasure log produces, not
+    intended for streaming/online use on millions of events.
+
+    Parameters
+    ----------
+    event_times : sequence of float
+        Timestamps of observed/simulated events (need not be sorted).
+    window_sizes : sequence of float
+        Radii r to evaluate counts at, ideally spanning several orders of
+        magnitude and containing at least ~5-8 values.
+    min_reference_points : int, optional
+        Minimum number of edge-safe reference events required at a given
+        r for that r to be included in the fit. Radii with fewer valid
+        reference points (or a zero mean count) are silently dropped, not
+        zero-padded, so the returned `mean_counts` may be shorter than
+        `window_sizes`. Defaults to 5.
+
+    Returns
+    -------
+    dimension : float
+        Estimated scaling exponent D (the slope of the log-log fit).
+    r_squared : float
+        Coefficient of determination of the log-log linear fit --
+        inspect this before trusting `dimension` (see above).
+    mean_counts : dict[float, float]
+        Mean count of other events within each usable radius r, keyed by
+        the r values from `window_sizes` that had enough valid reference
+        points and a nonzero count.
+
+    Raises
+    ------
+    ValueError
+        If `event_times` has fewer than 2 events, if any `window_sizes`
+        entry is not positive, or if fewer than 2 radii end up with
+        enough valid reference points and a nonzero count to fit a slope
+        at all.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> poisson_events = np.sort(rng.uniform(0, 1000, 2000))
+    >>> radii = np.logspace(0, 2, 10)  # 1 to 100
+    >>> D, r2, _ = counts_in_intervals_dimension(poisson_events, radii)
+    >>> 0.9 < D < 1.1 and r2 > 0.99
+    True
+    """
+    event_times = np.asarray(event_times, dtype=float)
+    if event_times.size < 2:
+        raise ValueError(f"need at least 2 events, got {event_times.size}")
+    event_times = np.sort(event_times)
+    t_min, t_max = event_times[0], event_times[-1]
+
+    mean_counts = {}
+    for r in window_sizes:
+        if r <= 0:
+            raise ValueError(f"window_sizes must be positive, got {r}")
+        valid_refs = event_times[(event_times - r >= t_min) & (event_times + r <= t_max)]
+        if valid_refs.size < min_reference_points:
+            continue
+        counts = np.array([np.sum(np.abs(event_times - t) <= r) - 1 for t in valid_refs])
+        mean_counts[float(r)] = float(np.mean(counts))
+
+    valid_items = sorted((r, c) for r, c in mean_counts.items() if c > 0)
+    if len(valid_items) < 2:
+        raise ValueError(
+            f"only {len(valid_items)} of {len(window_sizes)} window_sizes had at least "
+            f"{min_reference_points} edge-safe reference points with a nonzero count -- "
+            f"widen window_sizes, supply more events, or lower min_reference_points"
+        )
+
+    r_vals = np.array([r for r, _ in valid_items])
+    n_vals = np.array([c for _, c in valid_items])
+    log_r, log_n = np.log(r_vals), np.log(n_vals)
+    design = np.vstack([log_r, np.ones_like(log_r)]).T
+    slope, intercept = np.linalg.lstsq(design, log_n, rcond=None)[0]
+    predicted = slope * log_r + intercept
+    ss_res = np.sum((log_n - predicted) ** 2)
+    ss_tot = np.sum((log_n - np.mean(log_n)) ** 2)
+    r_squared = 1.0 - ss_res / ss_tot if ss_tot > 0 else 1.0
+
+    return float(slope), float(r_squared), dict(valid_items)
 
 
 def decode_with_erasure_fallback(

--- a/dense_evolution/qec.py
+++ b/dense_evolution/qec.py
@@ -7,9 +7,11 @@ unchanged. Import from dense_evolution.physics.qec directly in new code.
 from dense_evolution.physics.qec import (
     pauli_commutes, compute_syndrome, erasure_aware_decode, pymatching_decode,
     blind_minimum_weight_decode, decode_with_erasure_fallback,
+    counts_in_intervals_dimension,
 )
 
 __all__ = [
     'pauli_commutes', 'compute_syndrome', 'erasure_aware_decode', 'pymatching_decode',
     'blind_minimum_weight_decode', 'decode_with_erasure_fallback',
+    'counts_in_intervals_dimension',
 ]

--- a/docs/api/qec.md
+++ b/docs/api/qec.md
@@ -48,6 +48,29 @@ assignments, so the function returns `None` — never a guess). The same
 "return `None`, never guess" discipline applies to `pymatching_decode`
 and `blind_minimum_weight_decode` whenever a syndrome is ambiguous.
 
+`counts_in_intervals_dimension` answers a question upstream of decoding
+strategy altogether: is a given stream of error/erasure timestamps
+actually temporally clustered (bursty), or Poissonian? It generalizes
+the "counts-in-spheres" fractal-dimension estimator used to measure the
+transition to large-scale cosmic homogeneity —
+[Scrimgeour et al., "The WiggleZ Dark Energy Survey: the transition to
+large-scale cosmic homogeneity," MNRAS 425, 116 (2012), arXiv:1205.6812](https://arxiv.org/abs/1205.6812) —
+from 3-D space down to 1-D time: for a homogeneous (Poisson) process the
+mean count of other events within radius *r* of a reference event scales
+as *r*¹ exactly; real burst-like noise (e.g. cosmic-ray-correlated error
+bursts, arXiv:2104.05219 — the same physical source `cosmic_ray_burst_profile`
+in `dense_evolution.mitigation.zne` models) depresses that exponent below 1.
+
+The function always returns the log-log fit's R² alongside the estimated
+dimension, never the number alone — a narrow or poorly-covered range of
+window sizes can make a fitted slope meaningless. This is not a
+hypothetical caveat: an unrelated spatial box-counting fit through only
+4 points spanning a narrow range of scales once produced a fractal
+dimension of **142** — physically impossible in 3 dimensions — purely
+from fit noise, not from any real structure in the underlying data.
+Always inspect R² (rule of thumb: below ~0.98 means don't trust the
+dimension) before acting on the result.
+
 ::: dense_evolution.physics.qec
 
 ---

--- a/tests/unit/test_qec.py
+++ b/tests/unit/test_qec.py
@@ -20,6 +20,7 @@ import pytest
 from dense_evolution.qec import (
     compute_syndrome, erasure_aware_decode, pauli_commutes, pymatching_decode,
     blind_minimum_weight_decode, decode_with_erasure_fallback,
+    counts_in_intervals_dimension,
 )
 from dense_evolution.physics import qec as qec_module
 
@@ -469,3 +470,64 @@ class TestBlindMinimumWeightDecode:
     def test_stabilizer_length_mismatch_raises(self):
         with pytest.raises(ValueError, match="n_qubits"):
             blind_minimum_weight_decode((0, 0), n_qubits=3, stabilizers=['ZZ', 'IZZ'])
+
+
+class TestCountsInIntervalsDimension:
+    """Calibrated against synthetic point processes with a KNOWN answer,
+    same discipline as any box-counting fractal-dimension estimator
+    should follow before being trusted on real data (see the module
+    docstring's D=142 cautionary note)."""
+
+    def test_poisson_process_gives_dimension_near_one(self):
+        rng = np.random.default_rng(0)
+        events = np.sort(rng.uniform(0, 1000, 2000))
+        radii = np.logspace(0, 2, 10)
+        D, r2, mean_counts = counts_in_intervals_dimension(events, radii)
+        assert 0.9 < D < 1.1
+        assert r2 > 0.99
+        assert len(mean_counts) >= 8
+
+    def test_clustered_bursty_process_gives_dimension_below_one(self):
+        rng = np.random.default_rng(1)
+        cluster_centers = rng.uniform(0, 1000, 40)
+        events = np.concatenate([
+            c + rng.normal(0, 0.5, rng.integers(20, 60)) for c in cluster_centers
+        ])
+        events = events[(events >= 0) & (events <= 1000)]
+        radii = np.logspace(-1, 2, 12)
+        D, r2, _ = counts_in_intervals_dimension(events, radii)
+        assert D < 0.8, f"expected a clustered process to show D<0.8, got D={D}"
+        assert r2 > 0.9
+
+    def test_regular_lattice_gives_dimension_above_one(self):
+        """A perfectly evenly-spaced ('hyperuniform') process suppresses
+        fluctuations relative to Poisson and should read D > 1."""
+        events = np.arange(0, 1000, 1.0)
+        radii = np.logspace(0, 2, 10)
+        D, r2, _ = counts_in_intervals_dimension(events, radii)
+        assert D > 1.0
+        assert r2 > 0.9
+
+    def test_too_few_events_raises(self):
+        with pytest.raises(ValueError, match="at least 2 events"):
+            counts_in_intervals_dimension([1.0], [1.0, 2.0])
+
+    def test_nonpositive_window_size_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            counts_in_intervals_dimension([1.0, 2.0, 3.0], [1.0, 0.0])
+
+    def test_too_narrow_window_range_raises(self):
+        rng = np.random.default_rng(2)
+        events = np.sort(rng.uniform(0, 1000, 20))
+        with pytest.raises(ValueError, match="window_sizes"):
+            counts_in_intervals_dimension(events, [500.0])
+
+    def test_min_reference_points_drops_undersupported_radii(self):
+        rng = np.random.default_rng(3)
+        events = np.sort(rng.uniform(0, 100, 50))
+        # A radius comparable to the full observed range leaves almost no
+        # edge-safe reference points -- should be dropped, not crash.
+        D, r2, mean_counts = counts_in_intervals_dimension(
+            events, [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 99.0], min_reference_points=5
+        )
+        assert 99.0 not in mean_counts


### PR DESCRIPTION
## Summary
- New `dense_evolution.physics.qec.counts_in_intervals_dimension`: generalizes the "counts-in-spheres" fractal-dimension estimator used to measure large-scale cosmic homogeneity (Scrimgeour et al. 2012, MNRAS 425, 116, arXiv:1205.6812) from 3-D space to 1-D time, to tell whether a stream of error/erasure timestamps is temporally clustered (D<1, e.g. cosmic-ray-correlated bursts) or Poissonian (D≈1).
- Always returns the log-log fit's R² alongside D, never the number alone — a narrow/poorly-covered window-size range can make the fitted slope meaningless.
- Exported from `dense_evolution` and the `dense_evolution.qec` compatibility shim; docs page and README updated with a runnable example.

## Test plan
- [x] New `TestCountsInIntervalsDimension` suite (7 tests) calibrated against synthetic point processes with a known answer: Poisson (D≈1.00, R²≈1.00), clustered/bursty (D<0.8), regular lattice (D>1, "hyperuniform"), plus edge-case validation (too few events, non-positive window size, too-narrow window range, radii dropped for insufficient reference points).
- [x] Full `tests/unit/test_qec.py` suite passes (43/43).
- [x] Docstring `Examples` doctest passes (`pytest --doctest-modules`).
- [x] Full `tests/unit/` suite passes with no regressions.
