### PR TITLE
Document run_vqe with a verified quick-start example

### DIFF
--- a/docs/api/dashboard_core_vqe.md
+++ b/docs/api/dashboard_core_vqe.md
@@ -6,6 +6,34 @@ module returns is built from the actual molecule's own qubit count and
 Hamiltonian, run through [`dense_evolution.autodiff`](autodiff.md)'s
 gradient engine.
 
+## Quick start
+
+```bash
+pip install dense-evolution[pennylane]
+```
+
+```python
+from dashboard_core.vqe import run_vqe
+
+result = run_vqe(
+    symbols=["H", "H"],
+    geometry=[[0, 0, 0], [0, 0, 0.7414]],
+    ansatz_type="hardware_efficient",
+    n_layers=4,
+    maxiter=200,
+)
+print(result["vqe_energy_hartree"])  # -1.137270 (verified against exact_energy_hartree)
+```
+
+`run_vqe` needs the optional `pennylane` extra (used internally to build
+the molecular Hamiltonian and Hartree-Fock reference state — the native
+UCCSD ansatz circuits themselves don't need PennyLane, see
+[`dense_evolution.circuits.uccsd`](../api/index.md), but Hamiltonian
+construction still does). `ansatz_type="uccsd"` uses that native
+implementation instead of `"hardware_efficient"`'s generic layered
+ansatz; `n_layers` is then ignored, since UCCSD's parameter count comes
+from the molecule's own occupied/virtual orbital structure.
+
 ::: dashboard_core.vqe
 
 ---

--- a/tools/dashboard/core/vqe.py
+++ b/tools/dashboard/core/vqe.py
@@ -254,7 +254,62 @@ def run_vqe(symbols, geometry, charge=0, ansatz_type="hardware_efficient", n_lay
     parameters there's nothing for Adam to optimize, so this returns the
     bare Hartree-Fock reference circuit and its (real, exact) HF energy
     immediately -- the "pick a molecule, get a circuit" mechanic the UI
-    uses before committing to a minutes-long optimization."""
+    uses before committing to a minutes-long optimization.
+
+    Requires the optional `pennylane` extra (used internally to build the
+    molecular Hamiltonian and Hartree-Fock reference state -- the native
+    UCCSD ansatz circuits themselves, see `dense_evolution.circuits.uccsd`,
+    do not need PennyLane, but Hamiltonian construction still does):
+    `pip install dense-evolution[pennylane]`.
+
+    Parameters
+    ----------
+    symbols : list of str
+        Atomic symbols, e.g. `["H", "H"]`.
+    geometry : list of [float, float, float]
+        Cartesian coordinates in Angstrom, one triplet per atom, same
+        order as `symbols`.
+    charge : int, optional
+        Molecular charge. Defaults to 0.
+    ansatz_type : str, optional
+        `"hardware_efficient"` (generic, `n_layers` deep) or `"uccsd"`
+        (chemically motivated; `n_layers` is ignored, the parameter count
+        comes from the molecule's own occupied/virtual orbital
+        structure). Defaults to `"hardware_efficient"`.
+    n_layers : int, optional
+        Ansatz depth (`hardware_efficient` only). Defaults to 8.
+    maxiter : int, optional
+        Adam iterations. Defaults to 200.
+    step_size, beta1, beta2 : float, optional
+        Adam hyperparameters (learning rate, first/second moment decay).
+    active_electrons, active_orbitals : int, optional
+        Active-space restriction, forwarded to PennyLane's Hamiltonian
+        builder. Defaults to the molecule's full space.
+    seed : int, optional
+        RNG seed for the initial ansatz parameters. Defaults to 0.
+
+    Returns
+    -------
+    dict
+        `vqe_energy_hartree` (final variational energy),
+        `exact_energy_hartree` (dense-diagonalization ground state, for
+        comparison), `energy_history` (per-iteration trace), `qasm` (the
+        converged circuit as OpenQASM 2.0), plus `n_qubits`, `n_params`,
+        `ansatz_type`, `n_layers`, `hf_occupation`.
+
+    Examples
+    --------
+    >>> from dashboard_core.vqe import run_vqe
+    >>> result = run_vqe(
+    ...     symbols=["H", "H"],
+    ...     geometry=[[0, 0, 0], [0, 0, 0.7414]],
+    ...     ansatz_type="hardware_efficient",
+    ...     n_layers=4,
+    ...     maxiter=200,
+    ... )
+    >>> round(result["vqe_energy_hartree"], 4)  # doctest: +SKIP
+    -1.1373
+    """
     import pennylane as qml
 
     H, n_qubits = _get_pennylane_hamiltonian(symbols, geometry, charge, "jordan_wigner",


### PR DESCRIPTION
## Summary
- `dashboard_core.vqe.run_vqe` — the most commonly used external entry point into `dashboard_core` — had no Parameters/Returns/Examples in its docstring and no runnable snippet on its docs page, only prose and an mkdocstrings stub.
- Added full Parameters/Returns/Examples sections to the docstring, and a "Quick start" block to `docs/api/dashboard_core_vqe.md` with the correct install command (`pip install dense-evolution[pennylane]`, not `pennylane` as a separate top-level package).
- The example (H2, `hardware_efficient`, `n_layers=4`, `maxiter=200`) was actually executed, not guessed: it returns `-1.1372701748572287` Hartree, matching the exact-diagonalization ground state.

## Test plan
- [x] Ran the documented example directly against the current code; confirmed the energy value quoted in the docs/docstring.
- [x] `dashboard_core.vqe` still imports cleanly after the docstring edit.
