### PR TITLE
Add verified runnable examples to all 13 dashboard_core docs pages

### DIFF
--- a/docs/api/dashboard_core_circuit_builder_component.md
+++ b/docs/api/dashboard_core_circuit_builder_component.md
@@ -4,6 +4,29 @@ Graphical (drag-and-drop) circuit builder — the fourth pillar of IBM
 Quantum Composer's layout (graphical editor + code editor + statevector
 view + results) reproduced natively for this project's own dashboard.
 
+This is a real Streamlit component (`st.components.v2.component`) — it only means
+something rendered inside a running Streamlit app (`streamlit run app.py`), unlike
+every other `dashboard_core` module, which is a plain importable function you can
+call from a script or a REPL. There is nothing to execute standalone here; the
+snippet below is the exact call `tools/dashboard/app.py` makes, reproduced as a
+minimal `streamlit run`-able app:
+
+```python
+import streamlit as st
+import dashboard_core as dc
+
+n_qubits = st.number_input("Qubits", min_value=1, max_value=8, value=3, step=1)
+ops = dc.mount_circuit_builder(int(n_qubits), n_columns=12, key=f"circuit_builder_{int(n_qubits)}")
+
+if ops:
+    st.write(ops)  # [{'gate': 'h', 'qubits': [0]}, ...] as gates are dropped onto the grid
+    tuples = dc.ops_to_native_tuples(int(n_qubits), ops)
+    st.code(dc.gate_tuples_to_qasm(tuples, int(n_qubits)))
+```
+
+`key` must change whenever `n_qubits` changes (include it in the key, as above), or
+Streamlit reuses a stale grid sized for a different qubit count.
+
 ::: dashboard_core.circuit_builder_component
 
 ---

--- a/docs/api/dashboard_core_circuit_diagram.md
+++ b/docs/api/dashboard_core_circuit_diagram.md
@@ -5,6 +5,13 @@ Native circuit-diagram renderer — pure matplotlib, never a Qiskit
 exactly the gate set `dense_evolution` actually supports, so Composer
 never depends on Qiskit just to draw a picture.
 
+```python
+from dashboard_core.circuit_diagram import draw_native_circuit_diagram
+
+fig = draw_native_circuit_diagram([("h", 0), ("cx", 0, 1)], n_qubits=2)
+fig.savefig("bell_pair.png")  # a matplotlib.figure.Figure, save/show it like any other
+```
+
 ::: dashboard_core.circuit_diagram
 
 ---

--- a/docs/api/dashboard_core_engine.md
+++ b/docs/api/dashboard_core_engine.md
@@ -5,4 +5,32 @@ The real simulation engine for the dashboard: runs an actual
 result, and is what Composer's UI and the MCP server's simulation tools
 both call underneath.
 
+```python
+from dashboard_core.engine import run_circuit_from_qasm
+
+qasm = """
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+h q[0];
+cx q[0],q[1];
+measure q -> c;
+"""
+
+result = run_circuit_from_qasm(qasm, n_shots=1000, seed=0)
+print(result.probabilities.round(3))  # [0.5 0.  0.  0.5] -- Bell pair
+print(result.counts)                  # e.g. {'00': 473, '11': 527}
+```
+
+For circuits too large for a dense statevector, `run_large_circuit_mps` finds the
+top-*k* most probable basis states via MPS instead:
+
+```python
+from dashboard_core.engine import run_large_circuit_mps
+
+result = run_large_circuit_mps(qasm, k=4, seed=0)
+print(result.top_k_states[:2])  # [('00', 0.5), ('11', 0.5)] -- the rest are ~0
+```
+
 ::: dashboard_core.engine

--- a/docs/api/dashboard_core_graphical_builder.md
+++ b/docs/api/dashboard_core_graphical_builder.md
@@ -5,6 +5,19 @@ builder component into `dense_evolution`'s own `(name, *qubits[, param])`
 gate-tuple format, so a circuit built visually runs through the exact
 same execution path as one written in OpenQASM.
 
+```python
+from dashboard_core.graphical_builder import ops_to_native_tuples
+
+# A Bell pair, as the drag-and-drop grid would emit it:
+ops = [{"gate": "h", "qubits": [0]}, {"gate": "cx", "qubits": [0, 1]}]
+tuples = ops_to_native_tuples(n_qubits=2, ops=ops)
+print(tuples)  # [('h', 0), ('cx', 0, 1)]
+
+# Feed straight into gate_tuples_to_qasm for the QASM the rest of the Composer runs on:
+from dashboard_core.qasm_library import gate_tuples_to_qasm
+print(gate_tuples_to_qasm(tuples, n_qubits=2))
+```
+
 ::: dashboard_core.graphical_builder
 
 ---

--- a/docs/api/dashboard_core_hamiltonians.md
+++ b/docs/api/dashboard_core_hamiltonians.md
@@ -33,6 +33,19 @@ unchanged, this is a separate opt-in path for systems too large to
 densify at all — verified to match the dense path to ~1e-15 on H2/HeH+,
 and to actually succeed on Si2 where the dense path fails.
 
+```python
+from dashboard_core.hamiltonians import build_molecular_hamiltonian, ground_state_energy
+
+H, n_qubits = build_molecular_hamiltonian(["H", "H"], [[0, 0, 0], [0, 0, 0.7414]])
+print(n_qubits)                    # 4
+print(ground_state_energy(H))      # -1.1373 Hartree
+
+# For a catalog molecule too large to densify (e.g. Si2), skip the dense matrix entirely:
+from dashboard_core.hamiltonians import ground_state_energy_sparse
+e = ground_state_energy_sparse(["H", "H"], [[0, 0, 0], [0, 0, 0.7414]])
+print(abs(e - ground_state_energy(H)) < 1e-8)  # True -- matches the dense path exactly
+```
+
 ::: dashboard_core.hamiltonians
 
 ---

--- a/docs/api/dashboard_core_mitigation.md
+++ b/docs/api/dashboard_core_mitigation.md
@@ -6,6 +6,27 @@ the rest of Composer uses — a thin dashboard-facing layer over
 [`dense_evolution.mitigation`](mitigation.md), not a separate
 reimplementation.
 
+```python
+from dashboard_core.mitigation import run_zne_mitigation, run_density_matrix_zne
+
+qasm = """
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[1];
+creg c[1];
+x q[0];
+measure q -> c;
+"""
+
+result = run_zne_mitigation(qasm, pauli_string="Z", noise_model="bitflip", noise_p=0.05, seed=0)
+print(result.ideal_expectation)     # -1.0
+print(result.noisy_expectations)    # [-0.880, -0.790, -0.810] -- decays with noise scale
+print(result.zne_extrapolated)      # -1.080 -- closer to -1.0 than any single noisy measurement
+
+dm_result = run_density_matrix_zne(qasm, noise_model="bitflip", noise_p=0.05, seed=0)
+print(dm_result.fidelity_raw, dm_result.fidelity_corrected)  # 0.940 -> 1.000
+```
+
 ::: dashboard_core.mitigation
 
 ---

--- a/docs/api/dashboard_core_qasm_library.md
+++ b/docs/api/dashboard_core_qasm_library.md
@@ -4,6 +4,18 @@ Real, standard OpenQASM 2.0 circuits offered as Composer presets —
 textbook examples (Bell pair, GHZ, W-state) and `dense_evolution`'s own
 gate library exercised end to end, not synthetic placeholder text.
 
+```python
+import dense_evolution as de
+from dashboard_core.qasm_library import gate_tuples_to_qasm
+
+# Any hand-written gate-tuple circuit:
+print(gate_tuples_to_qasm([('h', 0), ('cx', 0, 1)], n_qubits=2))
+
+# Or any of dense_evolution's own circuit generators, unmodified:
+qft_ops = de.qft(3)
+print(gate_tuples_to_qasm(qft_ops, n_qubits=3))
+```
+
 ::: dashboard_core.qasm_library
 
 ---

--- a/docs/api/dashboard_core_qmmm.md
+++ b/docs/api/dashboard_core_qmmm.md
@@ -5,6 +5,21 @@ for this project's molecule catalog — no fabricated geometry, no
 placeholder forces. Backs Composer's QM/MM force and MD-trajectory
 panels.
 
+```python
+from dashboard_core.qmmm import compute_hellmann_feynman_forces, run_md_trajectory
+from dashboard_core.hamiltonians import MOLECULE_CATALOG
+
+# MOLECULE_CATALOG keys are descriptive strings, not bare element symbols:
+h2 = [k for k in MOLECULE_CATALOG if k.startswith("H2 ")][0]
+
+forces = compute_hellmann_feynman_forces(h2)
+print(forces["energy_hartree"])  # -1.1373 (Hartree-Fock ground state)
+print(forces["force_norm"])      # ~0.0154 Hartree/Angstrom -- small residual at equilibrium
+
+trajectory = run_md_trajectory(h2, n_steps=3, dt_fs=0.5)
+print(trajectory["force_norm"])  # decreasing as the bond relaxes toward equilibrium
+```
+
 ::: dashboard_core.qmmm
 
 ---

--- a/docs/api/dashboard_core_state_visuals.md
+++ b/docs/api/dashboard_core_state_visuals.md
@@ -3,6 +3,19 @@
 Native statevector visualizations — histogram, Q-sphere, per-qubit Bloch
 spheres — pure matplotlib/numpy, no Qiskit anywhere.
 
+```python
+import numpy as np
+from dashboard_core.state_visuals import (
+    native_histogram_figure, native_bloch_multivector_figure, native_qsphere_figure,
+)
+
+bell = np.array([1, 0, 0, 1]) / np.sqrt(2)  # (|00> + |11>)/sqrt(2)
+
+native_histogram_figure({"00": 512, "11": 488}).savefig("histogram.png")
+native_bloch_multivector_figure(bell).savefig("bloch.png")   # both spheres point to the origin -- maximally mixed
+native_qsphere_figure(bell).savefig("qsphere.png")            # two equal-size dots at the poles
+```
+
 ::: dashboard_core.state_visuals
 
 ---

--- a/docs/api/dashboard_core_system_limits.md
+++ b/docs/api/dashboard_core_system_limits.md
@@ -5,4 +5,15 @@ a number picked to fit whatever machine this was developed on, so
 Composer refuses an allocation that would actually exhaust memory rather
 than crashing partway through.
 
+```python
+from dashboard_core.system_limits import max_safe_dense_qubits
+
+limits = max_safe_dense_qubits()
+print(limits)
+# {'total_mb': 8066.7, 'available_mb': 3039.0, 'threshold_pct': 0.15, 'max_qubits_dense': 27}
+# (total_mb/available_mb/max_qubits_dense are real, machine-dependent values --
+#  this is one real run's output, not a fixed constant; max_qubits_dense is
+#  always between 16 and 27)
+```
+
 ::: dashboard_core.system_limits

--- a/docs/api/dashboard_core_vector_healing.md
+++ b/docs/api/dashboard_core_vector_healing.md
@@ -8,6 +8,26 @@ lazily imported so a missing/stripped `ia_utils` install fails with a
 clear error at call time rather than breaking `dashboard_core` import
 for everyone.
 
+```python
+import numpy as np
+from dashboard_core.vector_healing import run_vector_healing
+
+rng = np.random.default_rng(0)
+vectors = rng.normal(0, 1, size=(30, 3))
+vectors[10, 1] += 8.0    # a noise spike -- healed by the per-step Phi-Trigger
+vectors[15, 0] = np.nan  # genuine NaN corruption -- this is what fallback_triggered reports
+
+result = run_vector_healing(vectors)
+print(result.fallback_triggered)  # True -- because of the NaN, NOT the spike (see note below)
+print(result.healed_vectors[10])  # [0.115, -0.338, -0.044] -- spike replaced by the local median
+print(vectors[10].tolist())       # [-1.010, 7.791, -0.159] -- the raw, unhealed value for comparison
+```
+
+`fallback_triggered` is narrower than it sounds: it's `True` only when genuine NaN/Inf
+corruption was present and corrected, not whenever the Phi-Trigger replaces an outlier
+spike with the local median — a spike-only run above (no NaN/Inf) heals `vectors[10]`
+exactly the same way but reports `fallback_triggered=False`.
+
 ::: dashboard_core.vector_healing
 
 ---

--- a/docs/api/dashboard_core_visuals.md
+++ b/docs/api/dashboard_core_visuals.md
@@ -6,4 +6,21 @@ anywhere in this module. Aggregates
 [`state_visuals`](dashboard_core_state_visuals.md) into the set Composer
 actually renders.
 
+```python
+import numpy as np
+from dashboard_core.visuals import draw_circuit_figure, histogram_figure, qsphere_figure, bloch_multivector_figure
+
+bell = np.array([1, 0, 0, 1]) / np.sqrt(2)
+draw_circuit_figure([("h", 0), ("cx", 0, 1)], n_qubits=2).savefig("circuit.png")
+histogram_figure({"00": 512, "11": 488}).savefig("histogram.png")
+qsphere_figure(bell).savefig("qsphere.png")
+bloch_multivector_figure(bell).savefig("bloch.png")
+```
+
+Same functions and signatures as
+[`circuit_diagram`](dashboard_core_circuit_diagram.md)/[`state_visuals`](dashboard_core_state_visuals.md)
+directly — this module just pins matplotlib's light style regardless of
+any other module's global style changes (e.g. `dense_evolution.registry`
+sets a dark background for its own diagnostic plots at import time).
+
 ::: dashboard_core.visuals

--- a/docs/api/dashboard_core_wormhole.md
+++ b/docs/api/dashboard_core_wormhole.md
@@ -8,6 +8,25 @@ panel and the MCP server's wormhole tools. Built on
 [`dense_evolution.entropy`](entropy.md) (`mutual_information`), the
 protocol's actual readout quantity.
 
+```python
+import math
+from dashboard_core.wormhole import select_good_instance, run_wormhole_protocol, run_wormhole_protocol_trotter
+
+# The paper's own instance-selection criterion: screen candidate seeds
+# for the one whose commuting/anticommuting term-pair count best matches
+# the reference K=10 instance (34 commuting / 11 anticommuting of 45 pairs).
+seed = select_good_instance(n_majorana=8, k_terms=10, J=math.sqrt(2), n_candidates=200, target_commuting=34)
+print(seed)  # 61
+
+kwargs = dict(n_majorana=8, k_terms=10, J=math.sqrt(2), t0=0.3, t1=0.60, seed=seed, with_message=True)
+print(run_wormhole_protocol(mu=12, **kwargs))    # 0.0133 -- weaker signal
+print(run_wormhole_protocol(mu=-12, **kwargs))   # 0.0179 -- the "traversable" sign shows more
+
+# The same protocol via a real Trotterized gate circuit (~6300 two-qubit gates)
+# instead of exact matrix exponentiation, for comparison against real hardware:
+print(run_wormhole_protocol_trotter(mu=-12, **kwargs))  # 0.0182 -- closely matches the exact backend
+```
+
 ::: dashboard_core.wormhole
 
 ---

--- a/tools/dashboard/core/circuit_diagram.py
+++ b/tools/dashboard/core/circuit_diagram.py
@@ -122,7 +122,20 @@ def draw_native_circuit_diagram(ops, n_qubits: int, add_measure: bool = True):
     tuples -- no Qiskit QuantumCircuit ever constructed. Qubit 0 is drawn
     at the top, increasing downward, matching Qiskit's own drawer
     convention so this is a drop-in replacement for
-    dashboard_core.visuals.draw_circuit_figure's panel."""
+    dashboard_core.visuals.draw_circuit_figure's panel.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+
+    Examples
+    --------
+    >>> from dashboard_core.circuit_diagram import draw_native_circuit_diagram
+    >>> fig = draw_native_circuit_diagram([('h', 0), ('cx', 0, 1)], n_qubits=2)
+    >>> type(fig).__name__
+    'Figure'
+    >>> fig.savefig('bell_pair.png')  # doctest: +SKIP
+    """
     scheduled, n_columns = _schedule_columns(ops)
     n_display_columns = n_columns + (1 if add_measure else 0)
 

--- a/tools/dashboard/core/engine.py
+++ b/tools/dashboard/core/engine.py
@@ -120,6 +120,24 @@ def run_circuit_from_qasm(
     circuit). Verified to match 'dense' exactly (atol=1e-6) on every
     preset in QASM_LIBRARY, and to run a 12-qubit GHZ state in ~2.5s
     (max_bond=2) where 'dense' would need 2**12 complex amplitudes.
+
+    Examples
+    --------
+    >>> from dashboard_core.engine import run_circuit_from_qasm
+    >>> qasm = '''
+    ... OPENQASM 2.0;
+    ... include "qelib1.inc";
+    ... qreg q[2];
+    ... creg c[2];
+    ... h q[0];
+    ... cx q[0],q[1];
+    ... measure q -> c;
+    ... '''
+    >>> result = run_circuit_from_qasm(qasm, n_shots=1000, seed=0)
+    >>> result.probabilities.round(3).tolist()  # Bell pair: only |00> and |11> populated
+    [0.5, 0.0, 0.0, 0.5]
+    >>> set(result.counts.keys()) <= {'00', '11'}  # shot counts only land on those two states
+    True
     """
     n_qubits, ops = _qasm_to_tuples(qasm_text)
     if n_qubits < 1:
@@ -225,6 +243,28 @@ def run_large_circuit_mps(qasm_text: str, k: int = 32, seed: Optional[int] = Non
     measured directly, sampling 2000 shots takes 130s/257s/582s at
     30/50/100 qubits (grows with n -- roughly O(n_samples * n_qubits)),
     while get_top_k_probable_states stays under 2s even at 100 qubits.
+
+    Examples
+    --------
+    >>> from dashboard_core.engine import run_large_circuit_mps
+    >>> qasm = '''
+    ... OPENQASM 2.0;
+    ... include "qelib1.inc";
+    ... qreg q[5];
+    ... creg c[5];
+    ... h q[0];
+    ... cx q[0],q[1];
+    ... cx q[1],q[2];
+    ... cx q[2],q[3];
+    ... cx q[3],q[4];
+    ... measure q -> c;
+    ... '''
+    >>> result = run_large_circuit_mps(qasm, k=4, seed=0)  # a 5-qubit GHZ state
+    >>> top2 = sorted(result.top_k_states, key=lambda t: -t[1])[:2]
+    >>> [bits for bits, _ in top2]
+    ['00000', '11111']
+    >>> all(abs(p - 0.5) < 1e-9 for _, p in top2)
+    True
     """
     n_qubits, raw_ops = _qasm_to_tuples(qasm_text)
     if n_qubits < 1:

--- a/tools/dashboard/core/graphical_builder.py
+++ b/tools/dashboard/core/graphical_builder.py
@@ -68,6 +68,13 @@ def ops_to_native_tuples(n_qubits: int, ops: list) -> list:
         Pass to qasm_library.gate_tuples_to_qasm(tuples, n_qubits) for the
         QASM text the rest of the Composer already runs on (measure_all
         equivalent included there by default).
+
+    Examples
+    --------
+    >>> from dashboard_core.graphical_builder import ops_to_native_tuples
+    >>> ops = [{'gate': 'h', 'qubits': [0]}, {'gate': 'cx', 'qubits': [0, 1]}]
+    >>> ops_to_native_tuples(2, ops)
+    [('h', 0), ('cx', 0, 1)]
     """
     if n_qubits < 1:
         raise ValueError("circuit must have at least 1 qubit")

--- a/tools/dashboard/core/hamiltonians.py
+++ b/tools/dashboard/core/hamiltonians.py
@@ -36,7 +36,15 @@ __all__ = [
 def linear_chain_geometry(n_atoms: int, bond_length_angstrom: float):
     """N atoms on a line, each bond_length_angstrom apart -- the real,
     general shape behind every diatomic entry in the catalog (H2, HeH+,
-    LiH), extended to any atom count."""
+    LiH), extended to any atom count.
+
+    Examples
+    --------
+    >>> from dashboard_core.hamiltonians import linear_chain_geometry
+    >>> linear_chain_geometry(2, 0.7414)
+    array([[0.    , 0.    , 0.    ],
+           [0.    , 0.    , 0.7414]])
+    """
     if n_atoms < 1:
         raise ValueError("linear_chain_geometry needs at least 1 atom")
     return np.array([[0.0, 0.0, i * bond_length_angstrom] for i in range(n_atoms)])
@@ -49,7 +57,16 @@ def ring_geometry(n_atoms: int, bond_length_angstrom: float):
     triangle -- the same real D3h geometry H3+'s catalog entry uses, just
     generalized to any ring size (still only meaningful up to whatever
     qubit count this simulator's exact diagonalization / VQE range can
-    handle -- this function itself has no such limit, the caller does)."""
+    handle -- this function itself has no such limit, the caller does).
+
+    Examples
+    --------
+    >>> from dashboard_core.hamiltonians import ring_geometry
+    >>> ring_geometry(3, 0.8738).round(4)
+    array([[ 0.5045,  0.    ,  0.    ],
+           [-0.2522,  0.4369,  0.    ],
+           [-0.2522, -0.4369,  0.    ]])
+    """
     if n_atoms < 3:
         raise ValueError("ring_geometry needs at least 3 atoms")
     R = bond_length_angstrom / (2 * np.sin(np.pi / n_atoms))
@@ -335,7 +352,17 @@ def build_molecular_hamiltonian(symbols, geometry, charge: int = 0, mapping: str
     dense_evolution.pauli_hamiltonian_to_matrix from PennyLane's real
     Pauli decomposition, not qml.matrix() -- verified to match qml.matrix
     exactly (same ground-state energy, same matrix, atol=1e-8) for every
-    catalog molecule."""
+    catalog molecule.
+
+    Examples
+    --------
+    >>> from dashboard_core.hamiltonians import build_molecular_hamiltonian, ground_state_energy
+    >>> H, n_qubits = build_molecular_hamiltonian(['H', 'H'], [[0, 0, 0], [0, 0, 0.7414]])
+    >>> n_qubits
+    4
+    >>> round(ground_state_energy(H), 4)
+    -1.1373
+    """
     H, n_qubits = _get_hamiltonian(symbols, geometry, charge, mapping, active_electrons, active_orbitals)
 
     dense_key = (tuple(symbols), tuple(map(tuple, np.asarray(geometry).round(10))), charge, mapping,
@@ -378,7 +405,15 @@ def get_all_molecules(catalog=None, mapping="jordan_wigner"):
     """Every catalog molecule, each annotated with its real qubit count
     under the given mapping -- unfiltered, so the UI can always show the
     whole catalog and let the molecule choice drive the circuit's qubit
-    count (not the other way around)."""
+    count (not the other way around).
+
+    Examples
+    --------
+    >>> from dashboard_core.hamiltonians import get_all_molecules
+    >>> molecules = get_all_molecules()
+    >>> molecules['H2 (Idrogeno) - R = 0.7414 A [equilibrio reale]']['n_qubits']
+    4
+    """
     catalog = catalog if catalog is not None else MOLECULE_CATALOG
     out = {}
     for name, spec in catalog.items():
@@ -456,6 +491,15 @@ def ground_state_energy_sparse(symbols, geometry, charge: int = 0, mapping: str 
     exact, non-iterative answer -- this is the new, separate opt-in path
     for systems too large to densify at all, not a behavior change to
     the existing one.
+
+    Examples
+    --------
+    >>> from dashboard_core.hamiltonians import ground_state_energy_sparse, build_molecular_hamiltonian, ground_state_energy
+    >>> e_sparse = ground_state_energy_sparse(['H', 'H'], [[0, 0, 0], [0, 0, 0.7414]])
+    >>> H, _ = build_molecular_hamiltonian(['H', 'H'], [[0, 0, 0], [0, 0, 0.7414]])
+    >>> e_dense = ground_state_energy(H)
+    >>> abs(e_sparse - e_dense) < 1e-8  # matches the dense path without ever building H_dense
+    True
     """
     import scipy.sparse.linalg as sla
 
@@ -501,7 +545,17 @@ def mix_hamiltonians(H_a, H_b, weight_a: float = 0.5, weight_b: float = 0.5):
     share an electron space" behavior). A real-weighted sum of two
     Hermitian matrices is itself Hermitian, so H_mix is a real, valid
     Hamiltonian with a real spectrum -- not a fabricated hybrid, just
-    linear algebra applied to two already-real operators."""
+    linear algebra applied to two already-real operators.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from dashboard_core.hamiltonians import build_molecular_hamiltonian, mix_hamiltonians
+    >>> H, _ = build_molecular_hamiltonian(['H', 'H'], [[0, 0, 0], [0, 0, 0.7414]])
+    >>> H_mix = mix_hamiltonians(H, H, weight_a=0.5, weight_b=0.5)
+    >>> bool(np.allclose(H_mix, H))  # mixing H with itself in equal parts reproduces H
+    True
+    """
     if H_a.shape != H_b.shape:
         dim_a, dim_b = H_a.shape[0], H_b.shape[0]
         raise ValueError(

--- a/tools/dashboard/core/mitigation.py
+++ b/tools/dashboard/core/mitigation.py
@@ -72,6 +72,24 @@ def run_zne_mitigation(
     convention (same as pauli_expectation), independent of Qiskit's
     little-endian display convention used elsewhere on this page --
     this function never touches a Qiskit-ordered array.
+
+    Examples
+    --------
+    >>> from dashboard_core.mitigation import run_zne_mitigation
+    >>> qasm = '''
+    ... OPENQASM 2.0;
+    ... include "qelib1.inc";
+    ... qreg q[1];
+    ... creg c[1];
+    ... x q[0];
+    ... measure q -> c;
+    ... '''
+    >>> result = run_zne_mitigation(qasm, pauli_string='Z', noise_model='bitflip',
+    ...                              noise_p=0.05, seed=0, n_trials=200)
+    >>> result.ideal_expectation
+    -1.0
+    >>> abs(result.zne_extrapolated - result.ideal_expectation) < abs(result.noisy_expectations[0] - result.ideal_expectation)
+    True
     """
     if extrapolation_method not in ("richardson", "polynomial"):
         raise ValueError(
@@ -163,6 +181,21 @@ def run_density_matrix_zne(
     correction actually helped -- matches the pattern in
     zne_density_matrix's own docstring (experiments/matrix_healing_zne.py:
     raw ~0.865, corrected ~0.947 on a 2-qubit Bell state).
+
+    Examples
+    --------
+    >>> from dashboard_core.mitigation import run_density_matrix_zne
+    >>> qasm = '''
+    ... OPENQASM 2.0;
+    ... include "qelib1.inc";
+    ... qreg q[1];
+    ... creg c[1];
+    ... x q[0];
+    ... measure q -> c;
+    ... '''
+    >>> result = run_density_matrix_zne(qasm, noise_model='bitflip', noise_p=0.05, seed=0, n_trials=200)
+    >>> result.fidelity_corrected > result.fidelity_raw
+    True
     """
     # Same QASMParser-only parsing as run_zne_mitigation above -- see its
     # comment for why a Qiskit circuit object is never built here.

--- a/tools/dashboard/core/qasm_library.py
+++ b/tools/dashboard/core/qasm_library.py
@@ -23,7 +23,29 @@ def gate_tuples_to_qasm(ops, n_qubits: int, measure: bool = True) -> str:
     """Converts a dense_evolution gate-tuple circuit (the format
     de.qft/de.ghz_state/de.random_circuit/... all return) into real
     OpenQASM 2.0 text, so any of dense_evolution's own circuit generators
-    can be offered as a Composer preset without hand-transcribing gates."""
+    can be offered as a Composer preset without hand-transcribing gates.
+
+    Examples
+    --------
+    >>> import dense_evolution as de
+    >>> from dashboard_core.qasm_library import gate_tuples_to_qasm
+    >>> gate_tuples_to_qasm([('h', 0), ('cx', 0, 1)], n_qubits=2)
+    'OPENQASM 2.0;\\ninclude "qelib1.inc";\\nqreg q[2];\\ncreg c[2];\\nh q[0];\\ncx q[0],q[1];\\nmeasure q -> c;\\n'
+    >>> qft_ops = de.qft(3)
+    >>> print(gate_tuples_to_qasm(qft_ops, n_qubits=3))  # doctest: +NORMALIZE_WHITESPACE
+    OPENQASM 2.0;
+    include "qelib1.inc";
+    qreg q[3];
+    creg c[3];
+    h q[0];
+    cp(1.5707963267948966) q[1],q[0];
+    cp(0.7853981633974483) q[2],q[0];
+    h q[1];
+    cp(1.5707963267948966) q[2],q[1];
+    h q[2];
+    swap q[0],q[2];
+    measure q -> c;
+    """
     lines = ['OPENQASM 2.0;', 'include "qelib1.inc";', f'qreg q[{n_qubits}];']
     if measure:
         lines.append(f'creg c[{n_qubits}];')

--- a/tools/dashboard/core/qmmm.py
+++ b/tools/dashboard/core/qmmm.py
@@ -135,6 +135,31 @@ def compute_hellmann_feynman_forces(name: str, statevector=None, mapping: str = 
     same fixed catalog geometry again (the actual bug this parameter was
     added to fix: run_md_trajectory originally never passed its own
     updated positions back in here).
+
+    Parameters
+    ----------
+    name : str
+        A key from `MOLECULE_CATALOG` (e.g. one of `list(MOLECULE_CATALOG)`
+        -- these are descriptive strings like `"H2 (Idrogeno) - R = 0.7414
+        A [equilibrio reale]"`, not bare element symbols like `"H2"`).
+    statevector, mapping, geometry, fd_step_angstrom : see description above.
+
+    Returns
+    -------
+    dict
+        `name`, `symbols`, `energy_hartree`, `positions_angstrom`,
+        `forces_hartree_per_angstrom`, `force_norm`.
+
+    Examples
+    --------
+    >>> from dashboard_core.qmmm import compute_hellmann_feynman_forces
+    >>> from dashboard_core.hamiltonians import MOLECULE_CATALOG
+    >>> h2 = [k for k in MOLECULE_CATALOG if k.startswith("H2 ")][0]
+    >>> result = compute_hellmann_feynman_forces(h2)
+    >>> round(result['energy_hartree'], 4)
+    -1.1373
+    >>> 0.01 < result['force_norm'] < 0.02  # small residual at equilibrium, not exactly zero
+    True
     """
     if name not in MOLECULE_CATALOG:
         raise ValueError(f"unknown molecule {name!r}; available: {sorted(MOLECULE_CATALOG)}")
@@ -185,7 +210,19 @@ def md_step(positions_angstrom, velocities_angstrom_per_fs, forces_hartree_per_a
     r(t+dt) = r(t) + v(t+dt/2)*dt) using the real Hellmann-Feynman forces
     above and each atom's real atomic mass -- ordinary classical Newtonian
     mechanics (F=ma), nothing invented. Positions in Angstrom, velocities
-    in Angstrom/fs, forces in Hartree/Angstrom, dt in femtoseconds."""
+    in Angstrom/fs, forces in Hartree/Angstrom, dt in femtoseconds.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from dashboard_core.qmmm import md_step
+    >>> positions = np.array([[0, 0, 0.0], [0, 0, 0.7414]])   # H2 at equilibrium
+    >>> velocities = np.zeros_like(positions)
+    >>> forces = np.array([[0, 0, 0.0109], [0, 0, -0.0109]])  # restoring force, pulling atoms together
+    >>> new_pos, new_vel, accel = md_step(positions, velocities, forces, ['H', 'H'], dt_fs=0.5)
+    >>> bool(new_pos[1, 2] < 0.7414)  # the second atom moved toward the first
+    True
+    """
     positions = np.asarray(positions_angstrom, dtype=np.float64)
     velocities = np.asarray(velocities_angstrom_per_fs, dtype=np.float64)
     forces = np.asarray(forces_hartree_per_angstrom, dtype=np.float64)
@@ -218,7 +255,19 @@ def run_md_trajectory(name: str, n_steps: int, dt_fs: float = 0.5, mapping: str 
     (a real, explicitly-stated approximation, not a fabricated one).
     True ab-initio MD (re-solving Hartree-Fock at every step's new
     geometry) is available by setting this True, at real, substantial
-    extra cost per step."""
+    extra cost per step.
+
+    Examples
+    --------
+    >>> from dashboard_core.qmmm import run_md_trajectory
+    >>> from dashboard_core.hamiltonians import MOLECULE_CATALOG
+    >>> h2 = [k for k in MOLECULE_CATALOG if k.startswith("H2 ")][0]
+    >>> traj = run_md_trajectory(h2, n_steps=3, dt_fs=0.5)
+    >>> traj['step']
+    [0, 1, 2]
+    >>> len(traj['force_norm'])
+    3
+    """
     if name not in MOLECULE_CATALOG:
         raise ValueError(f"unknown molecule {name!r}; available: {sorted(MOLECULE_CATALOG)}")
     spec = MOLECULE_CATALOG[name]

--- a/tools/dashboard/core/state_visuals.py
+++ b/tools/dashboard/core/state_visuals.py
@@ -29,7 +29,15 @@ _QSPHERE_LINE_COLOR = "#8d8d8d"
 def native_histogram_figure(counts: dict):
     """Bar chart of shot counts, bitstrings sorted ascending -- the same
     information qiskit.visualization.plot_histogram showed, built from
-    nothing but the counts dict itself."""
+    nothing but the counts dict itself.
+
+    Examples
+    --------
+    >>> from dashboard_core.state_visuals import native_histogram_figure
+    >>> fig = native_histogram_figure({'00': 512, '11': 488})
+    >>> type(fig).__name__
+    'Figure'
+    """
     states = sorted(counts.keys())
     values = [counts[s] for s in states]
     total = sum(values)
@@ -98,7 +106,17 @@ def native_bloch_multivector_figure(statevector: np.ndarray):
     """One Bloch sphere per qubit, each from that qubit's own reduced
     density matrix (partial trace over every other qubit) -- the same
     per-qubit view qiskit.visualization.plot_bloch_multivector showed,
-    computed directly from the real statevector, no Qiskit involved."""
+    computed directly from the real statevector, no Qiskit involved.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from dashboard_core.state_visuals import native_bloch_multivector_figure
+    >>> bell = np.array([1, 0, 0, 1]) / np.sqrt(2)
+    >>> fig = native_bloch_multivector_figure(bell)
+    >>> type(fig).__name__
+    'Figure'
+    """
     n_qubits = int(np.log2(len(statevector)))
     fig = plt.figure(figsize=(3 * n_qubits, 3.2))
     for q in range(n_qubits):
@@ -117,7 +135,17 @@ def native_qsphere_figure(statevector: np.ndarray, prob_threshold: float = 1e-3)
     marker size by probability, marker color by phase (cyclic colormap,
     matching Qiskit's own convention) -- the same encoding
     qiskit.visualization.plot_state_qsphere used, built directly from the
-    statevector's own amplitudes."""
+    statevector's own amplitudes.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from dashboard_core.state_visuals import native_qsphere_figure
+    >>> bell = np.array([1, 0, 0, 1]) / np.sqrt(2)
+    >>> fig = native_qsphere_figure(bell)
+    >>> type(fig).__name__
+    'Figure'
+    """
     n_qubits = int(np.log2(len(statevector)))
     probs = np.abs(statevector) ** 2
     phases = np.angle(statevector)

--- a/tools/dashboard/core/system_limits.py
+++ b/tools/dashboard/core/system_limits.py
@@ -28,7 +28,25 @@ def max_safe_dense_qubits() -> dict:
     for a single dense block). MPS's contract_to_statevector has a
     separate, RAM-independent hard ceiling of 24 qubits; picking 25-27
     with the MPS backend surfaces that function's own real error rather
-    than being silently blocked here."""
+    than being silently blocked here.
+
+    Returns
+    -------
+    dict
+        `total_mb`/`available_mb` (this machine's real RAM, from
+        `SafeMemoryGuard.status()`), `threshold_pct` (the guard's safety
+        margin), `max_qubits_dense` (the suggested cap -- machine-dependent,
+        not a constant).
+
+    Examples
+    --------
+    >>> from dashboard_core.system_limits import max_safe_dense_qubits
+    >>> limits = max_safe_dense_qubits()
+    >>> sorted(limits.keys())
+    ['available_mb', 'max_qubits_dense', 'threshold_pct', 'total_mb']
+    >>> 16 <= limits['max_qubits_dense'] <= 27
+    True
+    """
     guard = de.chunk.SafeMemoryGuard()
     status = guard.status()
     max_qubits = de.chunk.get_dynamic_chunk(de.chunk.jnp.complex128 if de.chunk.HAS_JAX else de.chunk.np.complex128)

--- a/tools/dashboard/core/vector_healing.py
+++ b/tools/dashboard/core/vector_healing.py
@@ -64,6 +64,20 @@ def run_vector_healing(vectors: np.ndarray, radius_baseline: Optional[int] = Non
 
     Returns:
         VectorHealingResult
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from dashboard_core.vector_healing import run_vector_healing
+    >>> rng = np.random.default_rng(0)
+    >>> vectors = rng.normal(0, 1, size=(30, 3))
+    >>> vectors[10, 1] += 8.0    # a noise spike -- the Phi-Trigger heals this
+    >>> vectors[15, 0] = np.nan  # genuine NaN corruption -- this is what fallback_triggered reports
+    >>> result = run_vector_healing(vectors)
+    >>> result.fallback_triggered  # True only because of the NaN, not the spike
+    True
+    >>> abs(result.healed_vectors[10][1]) < 1.0  # spike replaced by the local median regardless
+    True
     """
     if enhanced_dense_healing_hybrid is None:
         raise ImportError(

--- a/tools/dashboard/core/visuals.py
+++ b/tools/dashboard/core/visuals.py
@@ -27,7 +27,15 @@ _LIGHT_STYLE = 'default'
 
 
 def draw_circuit_figure(ops, n_qubits: int):
-    """Native matplotlib circuit diagram (dashboard_core.circuit_diagram)."""
+    """Native matplotlib circuit diagram (dashboard_core.circuit_diagram).
+
+    Examples
+    --------
+    >>> from dashboard_core.visuals import draw_circuit_figure
+    >>> fig = draw_circuit_figure([('h', 0), ('cx', 0, 1)], n_qubits=2)
+    >>> type(fig).__name__
+    'Figure'
+    """
     with plt.style.context(_LIGHT_STYLE):
         return draw_native_circuit_diagram(ops, n_qubits)
 

--- a/tools/dashboard/core/wormhole.py
+++ b/tools/dashboard/core/wormhole.py
@@ -112,6 +112,16 @@ def build_sparse_syk_terms(n_majorana, k_terms, J, seed):
     takes C(4,2)=6 transpositions, (-1)^6=+1 -- no extra i factor needed).
     Returns (n_qubits, terms) where terms is ready for
     dense_evolution.pauli_hamiltonian_to_matrix.
+
+    Examples
+    --------
+    >>> import math
+    >>> from dashboard_core.wormhole import build_sparse_syk_terms
+    >>> n_qubits, terms = build_sparse_syk_terms(n_majorana=8, k_terms=10, J=math.sqrt(2), seed=61)
+    >>> n_qubits
+    4
+    >>> len(terms)
+    10
     """
     n_qubits = n_majorana // 2
     all_quads = list(itertools.combinations(range(1, n_majorana + 1), 4))
@@ -173,6 +183,14 @@ def commuting_pair_count(terms, n_qubits):
     is unused here (kept in the signature for API compatibility -- every
     other caller passes it) since the dict-based check needs only the
     terms' own qubit indices, not the full Hilbert space dimension.
+
+    Examples
+    --------
+    >>> import math
+    >>> from dashboard_core.wormhole import build_sparse_syk_terms, commuting_pair_count
+    >>> n_qubits, terms = build_sparse_syk_terms(n_majorana=8, k_terms=10, J=math.sqrt(2), seed=61)
+    >>> commuting_pair_count(terms, n_qubits)  # the paper's own K=10 instance: 34/11 of 45 pairs
+    (34, 11)
     """
     dicts = [t[1] for t in terms]
     commuting = anticommuting = 0
@@ -191,7 +209,15 @@ def select_good_instance(n_majorana, k_terms, J, n_candidates=200, target_commut
     count (cheap: only needs the k_terms operators' own small matrices,
     not the full protocol simulation) and return the seed whose count is
     closest to target_commuting -- the paper's selection criterion,
-    applied here rather than trusting an arbitrary single seed."""
+    applied here rather than trusting an arbitrary single seed.
+
+    Examples
+    --------
+    >>> import math
+    >>> from dashboard_core.wormhole import select_good_instance
+    >>> select_good_instance(n_majorana=8, k_terms=10, J=math.sqrt(2), n_candidates=200, target_commuting=34)
+    61
+    """
     n_qubits = n_majorana // 2
     best_seed, best_diff = None, None
     for seed in range(n_candidates):
@@ -291,6 +317,18 @@ def run_wormhole_protocol(n_majorana, k_terms, J, mu, t0, t1, seed, with_message
     same (n_majorana, k_terms, J, seed) via _cached_finite_beta_layout --
     real cost for a caller scanning many mu/t0/t1 values at a fixed
     instance, previously redone identically on every single call.
+
+    Examples
+    --------
+    >>> import math
+    >>> from dashboard_core.wormhole import run_wormhole_protocol
+    >>> kwargs = dict(n_majorana=8, k_terms=10, J=math.sqrt(2), t0=0.3, t1=0.60, seed=61, with_message=True)
+    >>> i_plus = run_wormhole_protocol(mu=12, **kwargs)
+    >>> i_minus = run_wormhole_protocol(mu=-12, **kwargs)
+    >>> round(i_plus, 4), round(i_minus, 4)  # the paper's sign-dependent enhancement
+    (0.0133, 0.0179)
+    >>> i_minus > i_plus  # mu=-12 ("traversable") shows the stronger signal for this instance
+    True
     """
     n_side, n_full, L, R, P, Q, eigvals, eigvecs, v_eigvals, v_eigvecs = \
         _cached_finite_beta_layout(n_majorana, k_terms, J, seed)
@@ -316,7 +354,18 @@ def run_wormhole_protocol_trotter(n_majorana, k_terms, J, mu, t0, t1, seed, with
     reproduces the exact backend's result closely: I(mu=+12)=0.01301 vs
     exact 0.01326, I(mu=-12)=0.01821 vs exact 0.01793 -- the
     sign-dependent asymmetry survives with a real gate circuit, it isn't
-    an artifact of the exact-evolution shortcut."""
+    an artifact of the exact-evolution shortcut.
+
+    Examples
+    --------
+    >>> import math
+    >>> from dashboard_core.wormhole import run_wormhole_protocol_trotter
+    >>> kwargs = dict(n_majorana=8, k_terms=10, J=math.sqrt(2), t0=0.3, t1=0.60, seed=61, with_message=True)
+    >>> round(run_wormhole_protocol_trotter(mu=12, **kwargs), 4)
+    0.013
+    >>> round(run_wormhole_protocol_trotter(mu=-12, **kwargs), 4)
+    0.0182
+    """
     n_side, n_full, L, R, P, Q, terms_full, v_terms = _protocol_layout(n_majorana, k_terms, J, seed)
 
     ops = _initial_state_ops(n_side, L, R, P, Q, with_message)
@@ -457,7 +506,16 @@ def run_wormhole_protocol_finite_beta(n_majorana, k_terms, J, mu, t0, t1, beta, 
     (different beta/mu) reuses it instead of redoing it from scratch.
     For an explicit (beta, mu) sweep at a fixed seed, _finite_beta_layout_precomputed
     + _run_finite_beta_precomputed remain available directly if a caller
-    wants to hold the layout itself rather than rely on the cache."""
+    wants to hold the layout itself rather than rely on the cache.
+
+    Examples
+    --------
+    >>> import math
+    >>> from dashboard_core.wormhole import run_wormhole_protocol_finite_beta
+    >>> round(run_wormhole_protocol_finite_beta(n_majorana=8, k_terms=10, J=math.sqrt(2), mu=-12,
+    ...       t0=0.3, t1=0.60, beta=3, seed=61, with_message=True), 4)
+    0.0442
+    """
     n_side, n_full, L, R, P, Q, eigvals, eigvecs, v_eigvals, v_eigvecs = \
         _cached_finite_beta_layout(n_majorana, k_terms, J, seed)
     return _run_finite_beta_precomputed(n_side, n_full, L, R, P, Q, eigvals, eigvecs, v_eigvals, v_eigvecs,
@@ -492,6 +550,15 @@ def find_delta_beta_bands(n_majorana, k_terms, J, mu, t0, t1, seed, with_message
     Crossing points (the beta_lo/beta_hi shared between adjacent bands)
     are linearly interpolated between the nearest two grid points, not
     just snapped to the grid resolution.
+
+    Examples
+    --------
+    >>> import math
+    >>> from dashboard_core.wormhole import find_delta_beta_bands
+    >>> bands = find_delta_beta_bands(n_majorana=8, k_terms=10, J=math.sqrt(2), mu=12, t0=0.3, t1=0.60,
+    ...                                seed=61, with_message=True, beta_max=1.0, beta_step=0.25)
+    >>> [b['sign'] for b in bands]  # the sign flips once within this range, for this seed
+    ['positive', 'negative']
     """
     n_side, n_full, L, R, P, Q, eigvals, eigvecs, v_eigvals, v_eigvecs = \
         _cached_finite_beta_layout(n_majorana, k_terms, J, seed)


### PR DESCRIPTION
## Summary

Systematic audit triggered by a real support case: a user asked how to
use `run_vqe` and had to be given a hand-written example in a DM (see
#145) because neither its docstring nor its docs page had one — unlike
every `dense_evolution` core module, which already follows a
Parameters/Returns/Examples convention throughout.

This closes the same gap for the remaining 12 `dashboard_core` modules
(`system_limits`, `vector_healing`, `graphical_builder`, `qasm_library`,
`circuit_diagram`, `state_visuals`, `visuals`, `mitigation`, `engine`,
`qmmm`, `hamiltonians`, `wormhole`, plus `circuit_builder_component`,
documented as a live-Streamlit-only component with no standalone
example to fake).

**Every example was actually executed against the current code before
being written down — none were guessed.** This caught one real
inaccuracy in a draft: `run_vector_healing`'s `fallback_triggered` flag
was initially assumed to report outlier-spike healing, but it actually
only reports genuine NaN/Inf correction — fixed by adding a NaN to the
example rather than by softening the claim. Several `wormhole.py`
examples independently reproduce that module's own already-documented
reference numbers (seed 61, the paper's 34/11 commuting-pair ratio,
I(mu=±12) matching both its exact and Trotter backends to stated
precision), confirming those claims are still accurate today.

## Test plan
- [x] Every new docstring `Examples` block passes under
      `pytest --doctest-modules` (verified module by module while writing
      them; `hamiltonians.py`'s full doctest run takes ~3.5 min because
      `get_all_molecules()` touches Si2's native_hf path — real JAX
      compilation, not mocked. No CI currently runs `--doctest-modules`,
      so this doesn't block anything today.)
- [x] Full existing integration suite for these modules re-run after all
      changes: `test_dashboard_engine`, `test_dashboard_hamiltonians`,
      `test_dashboard_mitigation`, `test_dashboard_qmmm`,
      `test_dashboard_system_limits`, `test_dashboard_vector_healing`,
      `test_dashboard_visuals`, `test_dashboard_vqe` (111 passed),
      `test_graphical_builder`, `test_wormhole` (27 passed) — 138/138,
      no regressions (only docstrings/docs changed, no logic touched).
