### PR TITLE
Fix real jax_enable_x64 import-time regression + a GATES precision bug it was masking

### DIFF
--- a/dense_evolution/circuits/gates.py
+++ b/dense_evolution/circuits/gates.py
@@ -10,25 +10,44 @@ else:
 
 INV2 = 1.0 / np.sqrt(2.0)
 
-# Ora i gate statici usano il backend nativo (Numpy o JAX/GPU)
+# BUG FIX: these used to be built with `xp.array(..., dtype=complex)`
+# (xp = jax.numpy) -- at MODULE IMPORT time. If jax_enable_x64 isn't
+# already True at that exact moment (a real, common case: nothing forces
+# it before this import anymore, see dense_evolution/config.py and the
+# registry.py HARDWARE_REGISTRY removal), JAX silently truncates
+# `dtype=complex` (complex128) to complex64 right here, permanently --
+# these are plain module-level constants, computed once, never rebuilt
+# later even after ensure_x64() turns x64 on for real simulation. That
+# produced a real, measurable bug: gate application mixed a complex128
+# statevector with complex64-truncated gate matrices, breaking unitarity
+# by ~1e-8 (verified directly: tests/unit/test_simulator.py's norm-
+# preservation checks, which require < 1e-12, failed at exactly this
+# scale). Built with plain NumPy instead -- never subject to JAX's
+# process-wide x64 flag, so these are always genuinely complex128
+# regardless of import order; JAX correctly canonicalizes them to
+# whatever precision is actually active at the point they're first fed
+# into a JAX operation (by then, ensure_x64() has already run). Unlike
+# GATES, PARAMETRIC_GATES below is unaffected: its entries are lambdas,
+# evaluated lazily at gate-application time (after ensure_x64()), not at
+# import time.
 GATES = {
-    'h': INV2 * xp.array([[1.0, 1.0], [1.0, -1.0]], dtype=complex),
-    'x': xp.array([[0.0, 1.0], [1.0, 0.0]], dtype=complex),
-    'y': xp.array([[0.0, -1j], [1j, 0.0]], dtype=complex),
-    'z': xp.array([[1.0, 0.0], [0.0, -1.0]], dtype=complex),
-    's': xp.array([[1.0, 0.0], [0.0, 1j]], dtype=complex),
-    'sdg': xp.array([[1.0, 0.0], [0.0, -1j]], dtype=complex),
-    't': xp.array([[1.0, 0.0], [0.0, xp.exp(1j * np.pi / 4)]], dtype=complex),
-    'tdg': xp.array([[1.0, 0.0], [0.0, xp.exp(-1j * np.pi / 4)]], dtype=complex),
-    'sx': 0.5 * xp.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]], dtype=complex),
-    'id': xp.eye(2, dtype=complex),
-    'cx': xp.array([[1, 0, 0, 0],[0, 1, 0, 0],[0, 0, 0, 1],[0, 0, 1, 0]], dtype=complex),
-    'cz': xp.array([[1, 0, 0, 0],[0, 1, 0, 0],[0, 0, 1, 0],[0, 0, 0,-1]], dtype=complex),
-    'cy': xp.array([[1, 0, 0, 0],[0, 1, 0, 0],[0, 0, 0,-1j],[0, 0, 1j, 0]], dtype=complex),
-    'swap': xp.array([[1, 0, 0, 0],[0, 0, 1, 0],[0, 1, 0, 0],[0, 0, 0, 1]], dtype=complex),
-    'iswap': xp.array([[1, 0, 0, 0],[0, 0, 1j, 0],[0, 1j, 0, 0],[0, 0, 0, 1]], dtype=complex),
-    'ecr': INV2 * xp.array([[0, 0, 1, 1j],[0, 0, 1j, 1],[1,-1j, 0, 0],[-1j, 1, 0, 0]], dtype=complex),
-    'ccx': xp.array([[1,0,0,0,0,0,0,0],[0,1,0,0,0,0,0,0],[0,0,1,0,0,0,0,0],[0,0,0,1,0,0,0,0],[0,0,0,0,1,0,0,0],[0,0,0,0,0,1,0,0],[0,0,0,0,0,0,0,1],[0,0,0,0,0,0,1,0]], dtype=complex)
+    'h': INV2 * np.array([[1.0, 1.0], [1.0, -1.0]], dtype=np.complex128),
+    'x': np.array([[0.0, 1.0], [1.0, 0.0]], dtype=np.complex128),
+    'y': np.array([[0.0, -1j], [1j, 0.0]], dtype=np.complex128),
+    'z': np.array([[1.0, 0.0], [0.0, -1.0]], dtype=np.complex128),
+    's': np.array([[1.0, 0.0], [0.0, 1j]], dtype=np.complex128),
+    'sdg': np.array([[1.0, 0.0], [0.0, -1j]], dtype=np.complex128),
+    't': np.array([[1.0, 0.0], [0.0, np.exp(1j * np.pi / 4)]], dtype=np.complex128),
+    'tdg': np.array([[1.0, 0.0], [0.0, np.exp(-1j * np.pi / 4)]], dtype=np.complex128),
+    'sx': 0.5 * np.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]], dtype=np.complex128),
+    'id': np.eye(2, dtype=np.complex128),
+    'cx': np.array([[1, 0, 0, 0],[0, 1, 0, 0],[0, 0, 0, 1],[0, 0, 1, 0]], dtype=np.complex128),
+    'cz': np.array([[1, 0, 0, 0],[0, 1, 0, 0],[0, 0, 1, 0],[0, 0, 0,-1]], dtype=np.complex128),
+    'cy': np.array([[1, 0, 0, 0],[0, 1, 0, 0],[0, 0, 0,-1j],[0, 0, 1j, 0]], dtype=np.complex128),
+    'swap': np.array([[1, 0, 0, 0],[0, 0, 1, 0],[0, 1, 0, 0],[0, 0, 0, 1]], dtype=np.complex128),
+    'iswap': np.array([[1, 0, 0, 0],[0, 0, 1j, 0],[0, 1j, 0, 0],[0, 0, 0, 1]], dtype=np.complex128),
+    'ecr': INV2 * np.array([[0, 0, 1, 1j],[0, 0, 1j, 1],[1,-1j, 0, 0],[-1j, 1, 0, 0]], dtype=np.complex128),
+    'ccx': np.array([[1,0,0,0,0,0,0,0],[0,1,0,0,0,0,0,0],[0,0,1,0,0,0,0,0],[0,0,0,1,0,0,0,0],[0,0,0,0,1,0,0,0],[0,0,0,0,0,1,0,0],[0,0,0,0,0,0,0,1],[0,0,0,0,0,0,1,0]], dtype=np.complex128)
 }
 
 GATE_IDS = {

--- a/dense_evolution/circuits/registry.py
+++ b/dense_evolution/circuits/registry.py
@@ -46,7 +46,16 @@ class QuantumHardwareRegistry:
         print(f"MAX_DENSE={self.max_dense_qubits}q | JAX={self.has_jax} | GPU={self.has_gpu}")
 
 
-HARDWARE_REGISTRY = QuantumHardwareRegistry()
+# BUG FIX: this module used to instantiate a module-level
+# `HARDWARE_REGISTRY = QuantumHardwareRegistry()` singleton here -- never
+# referenced anywhere else in the codebase (dead code), but its __init__
+# calls ensure_x64() unconditionally, so merely `import dense_evolution`
+# still forced jax_enable_x64=True at import time even after PR #130
+# supposedly made that lazy (see dense_evolution/config.py) -- the
+# laziness moved into ensure_x64() itself, but this eager singleton
+# construction defeated it one level up. Removed entirely: nothing
+# needs it, and QuantumHardwareRegistry() remains available for any
+# caller who actually wants one, constructed on their own schedule.
 plt.style.use('dark_background')
 matplotlib.rcParams.update({
     'figure.facecolor': '#010409',

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,86 @@
+"""
+Regression tests for dense_evolution/config.py -- guards against the
+exact critical bug flagged in an external code review (analisi e
+consigli deepseek.txt): registry.py, compiler.py and statevector.py
+used to call jax.config.update("jax_enable_x64", True) unconditionally
+at MODULE IMPORT time, so merely `import dense_evolution` silently
+overrode a precision a caller had already configured for unrelated JAX
+code running earlier in the same process.
+
+PR #130 introduced config.py's lazy ensure_x64() to fix this -- but a
+second, more subtle instance of the same bug survived one level deeper:
+dense_evolution/circuits/registry.py instantiated a module-level
+`HARDWARE_REGISTRY = QuantumHardwareRegistry()` singleton (never
+referenced anywhere else -- dead code), whose __init__ calls
+ensure_x64() unconditionally. That eager construction ran at import
+time regardless, so `import dense_evolution` still forced
+jax_enable_x64=True even after the "lazy" refactor -- verified directly
+here (this exact test, run against the code before the HARDWARE_REGISTRY
+removal, failed: starting from jax_enable_x64=False, a bare import
+turned it True). Fixed by deleting that dead singleton.
+
+Subprocess isolation is required for these tests to mean anything: jax
+and dense_evolution are both already imported by the time any test in
+this suite runs (by pytest's own collection or by other test modules),
+so re-importing dense_evolution in-process would hit sys.modules's
+cache and never re-execute its module-level code at all. Each test here
+spawns a fresh Python interpreter, sets a known precision, imports
+dense_evolution, and checks nothing changed.
+"""
+import subprocess
+import sys
+
+
+def _run(code: str) -> subprocess.CompletedProcess:
+    return subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+
+
+class TestImportDoesNotTogglePrecision:
+
+    def test_import_does_not_flip_true_to_false(self):
+        result = _run(
+            "import jax; jax.config.update('jax_enable_x64', True)\n"
+            "import dense_evolution\n"
+            "assert jax.config.jax_enable_x64 is True, "
+            "f'import flipped jax_enable_x64 from True to {jax.config.jax_enable_x64}'\n"
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_import_does_not_flip_false_to_true(self):
+        """The regression this whole file exists for: with x64 already
+        explicitly False, a bare `import dense_evolution` (no simulator,
+        no registry, nothing constructed) must leave it False."""
+        result = _run(
+            "import jax; jax.config.update('jax_enable_x64', False)\n"
+            "import dense_evolution\n"
+            "assert jax.config.jax_enable_x64 is False, "
+            "f'import flipped jax_enable_x64 from False to {jax.config.jax_enable_x64}'\n"
+        )
+        assert result.returncode == 0, result.stderr
+
+
+class TestLazyEnsureX64:
+    """Confirms the OTHER half of config.py's contract: precision isn't
+    just left alone at import time -- it's still enabled lazily, on
+    first real use, exactly as ensure_x64()'s docstring promises."""
+
+    def test_constructing_a_simulator_enables_x64_by_default(self):
+        result = _run(
+            "import jax; jax.config.update('jax_enable_x64', False)\n"
+            "import dense_evolution as de\n"
+            "de.DenseSVSimulator(1)\n"
+            "assert jax.config.jax_enable_x64 is True, "
+            "'constructing DenseSVSimulator should lazily enable x64 by default'\n"
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_explicit_set_precision_false_sticks_after_constructing_a_simulator(self):
+        result = _run(
+            "import jax\n"
+            "import dense_evolution as de\n"
+            "de.set_precision(False)\n"
+            "de.DenseSVSimulator(1)\n"
+            "assert jax.config.jax_enable_x64 is False, "
+            "'set_precision(False) must not be overridden by a later ensure_x64() call'\n"
+        )
+        assert result.returncode == 0, result.stderr

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -19,6 +19,22 @@ here (this exact test, run against the code before the HARDWARE_REGISTRY
 removal, failed: starting from jax_enable_x64=False, a bare import
 turned it True). Fixed by deleting that dead singleton.
 
+Removing that singleton exposed a THIRD, previously-masked bug:
+dense_evolution/circuits/gates.py built its static GATES dict eagerly
+at module import time via jax.numpy -- if jax_enable_x64 wasn't already
+True at that exact moment, JAX silently truncated dtype=complex
+(complex128) to complex64 right there, permanently (these are plain
+constants, computed once, never rebuilt later even after ensure_x64()
+turns x64 on for real simulation work). HARDWARE_REGISTRY's eager
+ensure_x64() call happened to always win the race against gates.py's
+own import, accidentally masking this the whole time. Verified
+directly: removing HARDWARE_REGISTRY alone (without also fixing
+gates.py) broke tests/unit/test_simulator.py's norm-preservation checks
+(require <1e-12, failed at ~1.7e-8 -- exactly the scale of complex64
+contamination in an otherwise-complex128 computation). Fixed by building
+GATES with plain NumPy instead, which is never subject to JAX's
+process-wide x64 flag.
+
 Subprocess isolation is required for these tests to mean anything: jax
 and dense_evolution are both already imported by the time any test in
 this suite runs (by pytest's own collection or by other test modules),
@@ -82,5 +98,38 @@ class TestLazyEnsureX64:
             "de.DenseSVSimulator(1)\n"
             "assert jax.config.jax_enable_x64 is False, "
             "'set_precision(False) must not be overridden by a later ensure_x64() call'\n"
+        )
+        assert result.returncode == 0, result.stderr
+
+
+class TestGatesSurviveImportTimePrecision:
+    """The regression this class exists for: GATES is built once, at
+    dense_evolution's own import time -- if it were built via jax.numpy
+    (as it used to be), starting from jax_enable_x64=False would bake a
+    permanent complex64 truncation into every gate matrix, silently,
+    with no way to recover it later even after x64 gets enabled for real
+    simulation work. Plain NumPy has no such process-wide flag, so GATES
+    must stay genuinely complex128 regardless of the precision active at
+    the moment dense_evolution is imported."""
+
+    def test_gates_are_complex128_even_when_x64_starts_false(self):
+        result = _run(
+            "import jax; jax.config.update('jax_enable_x64', False)\n"
+            "import numpy as np\n"
+            "from dense_evolution.circuits.gates import GATES\n"
+            "bad = {name: str(m.dtype) for name, m in GATES.items() if m.dtype != np.complex128}\n"
+            "assert not bad, f'GATES entries not complex128 (x64 started False): {bad}'\n"
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_gates_are_plain_numpy_not_jax_arrays(self):
+        """GATES must be plain numpy arrays specifically -- a jax array
+        would be re-subject to the process-wide x64 flag at creation
+        time, reintroducing the exact bug this class guards against."""
+        result = _run(
+            "import numpy as np\n"
+            "from dense_evolution.circuits.gates import GATES\n"
+            "bad = {name: type(m).__name__ for name, m in GATES.items() if not isinstance(m, np.ndarray)}\n"
+            "assert not bad, f'GATES entries not plain numpy arrays: {bad}'\n"
         )
         assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

An external code review (analisi e consigli deepseek.txt) flagged PR
#130's fix for the `jax_enable_x64` import-time-toggle bug as complete.
It wasn't — two real, related bugs survived, one of which was actively
masking the other.

**Bug 1 — `HARDWARE_REGISTRY` dead singleton still forcing x64 at import.**
`dense_evolution/circuits/registry.py` instantiated a module-level
`HARDWARE_REGISTRY = QuantumHardwareRegistry()` singleton — never
referenced anywhere else in the codebase — whose `__init__` calls
`ensure_x64()` unconditionally. That eager construction ran at import
time regardless of `config.py`'s lazy-by-design contract, so a bare
`import dense_evolution` still forced `jax_enable_x64=True` even after
the "lazy" refactor. Verified directly: starting from
`jax_enable_x64=False`, importing the package flipped it to `True`.
Fixed by deleting the unused singleton.

**Bug 2 (exposed by fixing Bug 1) — `GATES` truncated to complex64 at import.**
`dense_evolution/circuits/gates.py` builds the static `GATES` dict
eagerly at *module import time* via `jax.numpy`. If `jax_enable_x64`
isn't already `True` at that exact moment, JAX silently truncates
`dtype=complex` (complex128) to complex64 right there, permanently —
these are plain constants, computed once, never rebuilt later even
after `ensure_x64()` turns x64 on for real simulation work.
`HARDWARE_REGISTRY`'s eager construction happened to run `ensure_x64()`
*before* `GATES` was built, accidentally masking this the whole time.
Removing Bug 1 alone caused 3 real test failures
(`tests/unit/test_simulator.py`'s norm-preservation checks, which
require `<1e-12`, failed at `~1.7e-8` — exactly the scale of complex64
contamination in an otherwise-complex128 computation). Fixed by building
`GATES` with plain NumPy instead — never subject to JAX's process-wide
x64 flag, so it's always genuinely complex128 regardless of import
order, and JAX correctly canonicalizes it to whatever precision is
active wherever it's actually used. `PARAMETRIC_GATES` was already fine:
its entries are lambdas evaluated lazily at gate-application time, not
at import time.

New `tests/unit/test_config.py` guards against all of the above using
subprocess isolation (necessary because `dense_evolution` is already
imported by the time any in-process test runs, so re-importing would
hit `sys.modules`'s cache and never re-execute module-level code):
- `TestImportDoesNotTogglePrecision` — the original PR #130 regression
  plus the `HARDWARE_REGISTRY` one (both directions: `True→False` and
  `False→True`).
- `TestLazyEnsureX64` — confirms precision is still enabled lazily on
  first real use, and that an explicit `set_precision(False)` sticks.
- `TestGatesSurviveImportTimePrecision` — dedicated tests for Bug 2
  specifically: `GATES` entries stay complex128 even when x64 starts
  `False`, and are plain NumPy arrays (not JAX arrays, which would be
  re-subject to the process-wide flag at creation time).

**Known follow-up, out of scope here**: `dense_evolution/mitigation/magic_entropy.py`
and `magic_entropy_shadows.py` have the identical latent pattern
(module-level `jnp` complex128 constants built at import time), but no
current test's tolerance is tight enough to catch it. Flagging for a
separate PR.

## Test plan
- [x] New `tests/unit/test_config.py` (6 tests, subprocess-isolated).
- [x] Confirmed every new test actually catches its bug: temporarily
      reintroduced `HARDWARE_REGISTRY` → `test_import_does_not_flip_false_to_true`
      failed with exactly the expected message; temporarily restored the
      pre-fix `gates.py` (`git show HEAD^:...`) → both
      `TestGatesSurviveImportTimePrecision` tests failed as expected.
      Reverted both times before re-verifying the fix.
- [x] Full `tests/unit/` suite: **668 passed, 19 skipped, 0 failed**
      (was 3 failed immediately after the `HARDWARE_REGISTRY`-only commit,
      before the `GATES` fix).
