### PR TITLE
Fix red docs-build CI: mkdocstrings docstring_style was google, code is numpy

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,7 +71,7 @@ plugins:
         python:
           paths: ["."]
           options:
-            docstring_style: google
+            docstring_style: numpy
             show_source: true
             show_root_heading: true
             show_root_full_path: false


### PR DESCRIPTION
## Summary

`main`'s "Docs — Build & Deploy (MkDocs Material)" workflow is currently **red**. Verified exactly when it broke: every run before PR #146 merged was green (including the one right after PR #144's merge); the run right after #146 failed with:

```
WARNING - mkdocs_autorefs: api/dashboard_core_engine.md: ... Could not find cross-reference target 'bits for bits, _ in top2'
WARNING - mkdocs_autorefs: api/dashboard_core_hamiltonians.md: ... Could not find cross-reference target ''n_qubits''
... (6 total)
Aborted with 6 warnings in strict mode!
```

**Root cause**: `mkdocs.yml` has `docstring_style: google`, but the actual codebase — both PR #146's new `dashboard_core` docstrings and long-preexisting ones (e.g. `dense_evolution/physics/qec.py`'s `blind_minimum_weight_decode`) — is written in **NumPy style** (`Parameters\n----------`, `Examples\n--------`). Under the `google` parser, griffe doesn't recognize NumPy-style section headers, so an "Examples" section's `>>>` doctest content never gets wrapped in a real code fence — leaving raw `[...]` syntax (list comprehensions, dict/array indexing) exposed to markdown/`mkdocs-autorefs`'s link-shorthand scanner, which tries to resolve each `[...]` as a cross-reference and fails under `--strict`.

This mismatch predates PR #146 (it's a config/reality mismatch, not something that PR introduced) — it just never happened to hit content that triggered the specific `[...]`-as-link misparse until then.

**Fix**: set `docstring_style: numpy`, matching what the codebase actually uses.

**Bonus, not just a fix**: verified the rendered output actually *improved*, not just stopped erroring — doctest examples now render as real syntax-highlighted Pygments code blocks (checked the built HTML: proper `<span class="gp">`/`<span class="kn">` highlighting with line numbers). Under the mismatched `google` parser they were previously unstyled raw text.

## Test plan
- [x] `mkdocs build --strict` reproduces all 6 warnings on current `main` (confirmed before making any change).
- [x] Same build, same content, only `docstring_style: numpy` changed → **0 warnings, clean build**.
- [x] Spot-checked rendered HTML for `dashboard_core_engine` and `qec` pages: `Examples` sections render as properly syntax-highlighted code blocks.
