### PR TITLE
Add verified Examples to zne.py/renyi.py, explain h/cx in getting-started

### DIFF
--- a/dense_evolution/mitigation/renyi.py
+++ b/dense_evolution/mitigation/renyi.py
@@ -145,6 +145,17 @@ def sandwiched_renyi_divergence(rho: jnp.ndarray, sigma: jnp.ndarray, alpha: flo
     against a known reference state, not to feed into one (see
     `uhlmann_fidelity`'s docstring for the full "ideal state as oracle"
     argument, which applies here identically).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from dense_evolution.mitigation.renyi import sandwiched_renyi_divergence
+    >>> rho = np.array([[1, 0], [0, 0]], dtype=complex)
+    >>> round(float(sandwiched_renyi_divergence(rho, rho, alpha=1.5)), 4)
+    0.0
+    >>> sigma = np.array([[0.5, 0], [0, 0.5]], dtype=complex)
+    >>> round(float(sandwiched_renyi_divergence(rho, sigma, alpha=1.5)), 4)
+    1.0
     """
     rho = jnp.asarray(rho, dtype=jnp.complex128)
     sigma = jnp.asarray(sigma, dtype=jnp.complex128)

--- a/dense_evolution/mitigation/zne.py
+++ b/dense_evolution/mitigation/zne.py
@@ -47,6 +47,12 @@ def richardson_extrapolate(expectation_values, noise_factors) -> jnp.ndarray:
     visible error, only a low-signal ComplexWarning easy to miss --
     confirmed directly (`richardson_extrapolate([1+2j, 3+4j], ...)` used
     to return a purely real result, dropping real information).
+
+    Examples
+    --------
+    >>> from dense_evolution.mitigation import richardson_extrapolate
+    >>> round(float(richardson_extrapolate([0.90, 0.80, 0.65], [1.0, 2.0, 3.0])), 4)
+    0.95
     """
     lambdas = jnp.asarray(noise_factors, dtype=jnp.float64)
     values_dtype = jnp.complex128 if np.iscomplexobj(np.asarray(expectation_values)) else jnp.float64
@@ -397,6 +403,17 @@ def uhlmann_fidelity(rho_A: jnp.ndarray, rho_B: jnp.ndarray) -> float:
     Forward-pass value is bit-identical to `jnp.linalg.eigh`-based
     computation (same underlying `eigh` call; only the backward rule
     differs), verified end-to-end against the previous implementation.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from dense_evolution.mitigation import uhlmann_fidelity
+    >>> rho = np.array([[1, 0], [0, 0]], dtype=complex)
+    >>> round(float(uhlmann_fidelity(rho, rho)), 4)
+    1.0
+    >>> sigma = np.array([[0.5, 0], [0, 0.5]], dtype=complex)
+    >>> round(float(uhlmann_fidelity(rho, sigma)), 4)
+    0.5
     """
     rho_A = jnp.asarray(rho_A, dtype=jnp.complex128)
     rho_B = jnp.asarray(rho_B, dtype=jnp.complex128)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,10 +27,20 @@ cd Dense-Evolution && pip install -e .[full,dev]
 
 ## Quick start
 
+A qubit starts in state `|0>`. `h` (Hadamard) puts it into an equal superposition of
+`|0>` and `|1>` -- measuring it afterward gives each outcome with 50% probability.
+`cx` (CNOT) entangles two qubits: it flips the second qubit only if the first is `|1>`.
+The circuit below puts qubit 0 into superposition, then uses two `cx` gates to spread
+that same randomness to qubits 1 and 2 -- all three qubits end up perfectly correlated
+(a 3-qubit GHZ state: measuring gives `000` or `111`, each about half the time, never
+anything else).
+
+Circuits are always built from OpenQASM text through `QASMParser`, never by
+hand-writing the internal gate-tuple format yourself:
+
 ```python
 from dense_evolution import DenseSVSimulator, QASMParser
 
-# parse any OpenQASM 2.0 / 3.0 string
 qasm = """
 OPENQASM 2.0;
 include "qelib1.inc";


### PR DESCRIPTION
## Summary
- `richardson_extrapolate`, `uhlmann_fidelity` (zne.py) and `sandwiched_renyi_divergence` (renyi.py) each get a short, self-contained, verified `>>>` example.
- `getting-started.md`'s Quick Start circuit used `h`/`cx` without ever explaining what they do. Added a plain-language explanation (what `h` and `cx` do, why the resulting circuit gives `000`/`111` each ~50% of the time) before the code, matching how Qiskit's own beginner docs introduce gates.

## Test plan
- [x] Every new docstring example verified by running it directly against the current code.
- [x] The GHZ-state claim (`000`/`111` each 50%, nothing else) verified directly against `DenseSVSimulator` output.
