### PR TITLE
Fix paths-filter missing base pattern for docs-only CI fast path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           # just the handful of tests that actually exec docs code blocks.
           filters: |
             code:
+              - '**'
               - '!docs/**'
               - '!mkdocs.yml'
 


### PR DESCRIPTION
The docs-only fast path added in #150 never actually skipped the full matrix: the `code` filter only had negated patterns (`!docs/**`, `!mkdocs.yml`) with no positive base pattern, so `dorny/paths-filter` never correctly evaluated it to `false` for a docs-only diff. Adds the missing `'**'` base pattern.

This PR itself touches `ci.yml`, so it will correctly run the full matrix (not the fast path) — that's expected, CI config changes should always get full validation.