### PR TITLE
Fix red CI on main: docs-examples job missing psutil/matplotlib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: "3.12"
       - run: |
           python -m pip install --upgrade pip
-          pip install pytest numpy jax jaxlib pennylane
+          pip install pytest numpy jax jaxlib pennylane psutil matplotlib
           pip install -e . --no-deps
       - run: pytest tests/integration/test_docs_examples.py -v --tb=short
 


### PR DESCRIPTION
Main is currently red: commit abd76cc's push-triggered "Docs examples (docs-only change)" job fails with `ModuleNotFoundError: No module named 'psutil'`. Root cause: `dense_evolution/circuits/registry.py` imports `psutil` and `matplotlib` at module load time (used by `QuantumHardwareRegistry`), but the lightweight docs-only CI job (added in #150/#152) only installs `pytest numpy jax jaxlib pennylane` — importing `dense_evolution` at all fails in that job, regardless of what the docs examples themselves need. Adds both to the job's pip install list.