### PR TITLE
Move remaining noise-generating functions out of mitigation.zne into dense_evolution.noise

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -5,7 +5,8 @@ High-performance quantum statevector simulator optimized for NISQ circuits.
 from .backends.statevector import DenseSVSimulator
 from .circuits.parser import QASMParser, QASMCircuit
 from .circuits.compiler import QuantumTranspiler
-from .noise import NoiseModel, NoiseSpec
+from .noise import (NoiseModel, NoiseSpec, global_depolarizing_channel, amplitude_damping_channel,
+                     cosmic_ray_burst_profile, oscillating_p_eff)
 from .circuits.registry import QuantumHardwareRegistry
 from .circuits.gates import GATES, PARAMETRIC_GATES, GATE_IDS
 from .backends.chunk import Chunk
@@ -28,8 +29,7 @@ from .solvers.autodiff import circuit_to_energy_fn
 from .backends.mps import MPSSimulator
 from .mitigation.zne import (richardson_extrapolate, zero_noise_extrapolation, polynomial_extrapolate,
                           project_to_physical, uhlmann_fidelity, zne_density_matrix,
-                          jsd_predictive_zne_density_matrix, global_depolarizing_channel,
-                          amplitude_damping_channel, cosmic_ray_burst_profile,
+                          jsd_predictive_zne_density_matrix,
                           richardson_extrapolate_jit, zero_noise_extrapolation_jit,
                           polynomial_extrapolate_jit, uhlmann_fidelity_jit, zne_density_matrix_jit)
 from .circuits.diagram import plot_circuit
@@ -82,7 +82,7 @@ __all__ = [
     "richardson_extrapolate", "zero_noise_extrapolation", "polynomial_extrapolate",
     "project_to_physical", "uhlmann_fidelity", "zne_density_matrix",
     "jsd_predictive_zne_density_matrix", "global_depolarizing_channel", "amplitude_damping_channel",
-    "cosmic_ray_burst_profile",
+    "cosmic_ray_burst_profile", "oscillating_p_eff",
     "richardson_extrapolate_jit", "zero_noise_extrapolation_jit",
     "polynomial_extrapolate_jit", "uhlmann_fidelity_jit", "zne_density_matrix_jit",
     # Physics -- states, observables, entropy, fermions, QEC

--- a/dense_evolution/mitigation/zne.py
+++ b/dense_evolution/mitigation/zne.py
@@ -420,103 +420,12 @@ def uhlmann_fidelity(rho_A: jnp.ndarray, rho_B: jnp.ndarray) -> float:
     return float(_uhlmann_fidelity_core(rho_A, rho_B))
 
 
-def global_depolarizing_channel(rho: jnp.ndarray, p: float) -> jnp.ndarray:
-    """Global n-qubit depolarizing channel, D_p(rho) = (1-p)*rho + (p/dim)*I.
-
-    Distinct from `NoiseModel`'s `'depolarizing'` model in `circuits.registry`,
-    which applies an independent PER-QUBIT local Kraus channel -- a different
-    physical map from this GLOBAL channel, which mixes the whole `dim`-
-    dimensional state toward the fully mixed state as one unit. Use this one
-    when modeling e.g. state-prep/measurement (SPAM) error reported as a
-    single joint depolarizing parameter over the whole register, not per-
-    qubit gate noise (promoted from a real reproduction of arXiv:2608.16716's
-    own SPAM model, Dense-Evolution-Discovery Experiment 33).
-    """
-    rho = jnp.asarray(rho, dtype=jnp.complex128)
-    dim = rho.shape[0]
-    identity = jnp.eye(dim, dtype=jnp.complex128)
-    return (1.0 - p) * rho + (p / dim) * identity
-
-
-def amplitude_damping_channel(rho: jnp.ndarray, gamma: float) -> jnp.ndarray:
-    """Single-qubit amplitude-damping channel: E0 @ rho @ E0.conj().T +
-    E1 @ rho @ E1.conj().T, with E0=diag(1, sqrt(1-gamma)) and
-    E1=[[0,sqrt(gamma)],[0,0]] -- population only ever moves |1>->|0>,
-    never the reverse.
-
-    Distinct from `global_depolarizing_channel` (symmetric, mixes toward
-    the fully-mixed state regardless of which state is |1> or |0>) -- this
-    one is asymmetric by construction, the real signature of energy-relaxation
-    (T1) processes and of quasiparticle poisoning (promoted from a real
-    reproduction of arXiv:2104.05219's measured cosmic-ray-induced error
-    bursts, Dense-Evolution-Discovery Experiment 34, where this asymmetry is
-    exactly the mechanism's own reported signature: decay errors only, no
-    excess excitation errors).
-
-    Single-qubit only (rho must be 2x2) -- unlike `global_depolarizing_channel`,
-    this is not dimension-generic, since amplitude damping is inherently a
-    per-qubit process, not a joint-register one.
-    """
-    rho = jnp.asarray(rho, dtype=jnp.complex128)
-    e0 = jnp.array([[1.0, 0.0], [0.0, jnp.sqrt(1.0 - gamma)]], dtype=jnp.complex128)
-    e1 = jnp.array([[0.0, jnp.sqrt(gamma)], [0.0, 0.0]], dtype=jnp.complex128)
-    return e0 @ rho @ e0.conj().T + e1 @ rho @ e1.conj().T
-
-
-def cosmic_ray_burst_profile(time_us, baseline_gamma: float, ratio_intermediate: float = 2.5,
-                              ratio_peak: float = 3.75, tau1_us: float = 3.0,
-                              tau2_us: float = 300.0, tau_decay_ms: float = 25.0) -> jnp.ndarray:
-    """Time-dependent decay-probability profile for a cosmic-ray/gamma-ray-
-    induced quasiparticle burst: a two-stage rise (fast to
-    `ratio_intermediate`x baseline, slower to `ratio_peak`x baseline) times
-    a single-exponential recovery, generalized out of a fixed, paper-number
-    validation (Dense-Evolution-Discovery Experiment 34, reproducing
-    arXiv:2104.05219's real measured event on a 26-qubit chip).
-
-    Feed the result to `continuous_dissipative_evolve` alongside
-    `amplitude_damping_channel` (or any other single-time-varying-parameter
-    channel) to inject a realistic burst into any circuit or QEC study,
-    without re-deriving this shape by hand each time.
-
-    The default ratios/timescales are the paper's own real numbers -- see
-    Experiment 34's docstring for exactly which are paper-fitted (the 25ms
-    decay) versus chosen to match the paper's two described rise points
-    (tau1/tau2). All are overridable for a different event severity or
-    device generation; `baseline_gamma` is never derived here -- pass
-    whatever per-slice decay probability corresponds to your own dt/T1
-    convention (see Experiment 34 for one worked example of that
-    conversion).
-
-    Parameters
-    ----------
-    time_us : array_like
-        Time since impact, in microseconds (t=0 is the impact instant).
-    baseline_gamma : float
-        Undisturbed per-slice decay probability; this profile scales it
-        up, it does not derive it.
-    ratio_intermediate, ratio_peak : float
-        Multiplier on `baseline_gamma` at the two described checkpoints
-        (paper defaults 2.5=10/4, 3.75=15/4, from Fig. 3's ~10us/~1ms
-        readings).
-    tau1_us, tau2_us : float
-        Rise timescales for the two saturating-exponential stages (paper
-        defaults 3, 300 -- chosen to match its ~10us/~1ms descriptions,
-        not fitted by the paper itself).
-    tau_decay_ms : float
-        Recovery time constant (paper default 25 -- its own fitted central
-        value, real range 25-30ms across 415 events).
-
-    Returns
-    -------
-    jnp.ndarray
-        Per-slice decay probability at each entry of `time_us`.
-    """
-    time_us = jnp.asarray(time_us)
-    stage1 = (ratio_intermediate - 1.0) * (1.0 - jnp.exp(-time_us / tau1_us))
-    stage2 = (ratio_peak - ratio_intermediate) * (1.0 - jnp.exp(-time_us / tau2_us))
-    decay = jnp.exp(-time_us / (tau_decay_ms * 1000.0))
-    scaling = 1.0 + (stage1 + stage2) * decay
-    return baseline_gamma * scaling
+# global_depolarizing_channel, amplitude_damping_channel, and
+# cosmic_ray_burst_profile moved to dense_evolution.noise -- they generate
+# noise, they don't mitigate it, so this module (mitigation) was the wrong
+# home. Re-exported below for backward compatibility; new code should
+# import from dense_evolution.noise directly.
+from ..noise import global_depolarizing_channel, amplitude_damping_channel, cosmic_ray_burst_profile
 
 
 def _uhlmann_fidelity_core(rho_A: jnp.ndarray, rho_B: jnp.ndarray) -> jnp.ndarray:

--- a/dense_evolution/noise/__init__.py
+++ b/dense_evolution/noise/__init__.py
@@ -1,7 +1,5 @@
 """Every way to put noise into a Dense-Evolution simulation, in one place.
 
-Three complementary mechanisms:
-
 - **`NoiseModel`** (`.kraus_channels`, dispatching to one file per channel
   under `.kraus`: `ideal`, `depolarizing`, `bitflip`, `phaseflip`,
   `amplitude_damping`, `combined`) -- 6 stochastic single-qubit Kraus
@@ -16,17 +14,27 @@ Three complementary mechanisms:
   a stabilizer code's syndrome -- promoted from Dense-Evolution-Discovery's
   Steane [[7,1,3]] investigation, including its honest negative result
   (see `coherent_attack`'s module docstring).
+- **Density-matrix channels** (`.density_matrix_channels`) --
+  `global_depolarizing_channel`, `amplitude_damping_channel`: noise applied
+  directly to a density matrix instead of a statevector, for density-matrix
+  ZNE's noise ensemble.
+- **`cosmic_ray_burst_profile`** (`.cosmic_ray`) -- a real, time-dependent
+  noise-strength profile for a cosmic-ray-induced quasiparticle burst.
+- **`oscillating_p_eff`** (`.oscillating`) -- a noise strength that
+  oscillates instead of scaling smoothly, for stress-testing mitigation
+  techniques that assume smoothness.
 
 Real device noise from a Qiskit backend's own calibration data
 (`noise_model_from_qiskit_backend`) lives in `dense_evolution.interop`,
 not here, since it needs a Qiskit `BackendV2` object as input rather than
 a noise-specific dependency.
 
-This subpackage previously lived inside `dense_evolution.circuits.registry`
-alongside unrelated hardware-detection code (`QuantumHardwareRegistry`);
-`registry.py` re-exports `NoiseModel`/`NoiseSpec` from here for backward
-compatibility, but `dense_evolution.noise` is the canonical import path
-for new code.
+Everything in this package previously lived scattered across
+`dense_evolution.circuits.registry` (alongside unrelated hardware-detection
+code) and `dense_evolution.mitigation.zne` (alongside unrelated mitigation
+techniques, which only ever cancel noise, never generate it). Both modules
+re-export the relevant names from here for backward compatibility, but
+`dense_evolution.noise` is the canonical import path for new code.
 """
 from .kraus_channels import NoiseModel
 from .differentiable import NoiseSpec
@@ -39,6 +47,9 @@ from .coherent_attack import (
     decoder_failure_rate,
     random_delta_failure_stats,
 )
+from .density_matrix_channels import global_depolarizing_channel, amplitude_damping_channel
+from .cosmic_ray import cosmic_ray_burst_profile
+from .oscillating import oscillating_p_eff
 
 __all__ = [
     "NoiseModel",
@@ -50,4 +61,8 @@ __all__ = [
     "craft_adversarial_delta_constrained",
     "decoder_failure_rate",
     "random_delta_failure_stats",
+    "global_depolarizing_channel",
+    "amplitude_damping_channel",
+    "cosmic_ray_burst_profile",
+    "oscillating_p_eff",
 ]

--- a/dense_evolution/noise/cosmic_ray.py
+++ b/dense_evolution/noise/cosmic_ray.py
@@ -1,0 +1,61 @@
+"""A cosmic-ray/gamma-ray-induced quasiparticle burst, as a real
+time-dependent noise-strength profile instead of a constant rate."""
+import jax.numpy as jnp
+
+__all__ = ["cosmic_ray_burst_profile"]
+
+
+def cosmic_ray_burst_profile(time_us, baseline_gamma: float, ratio_intermediate: float = 2.5,
+                              ratio_peak: float = 3.75, tau1_us: float = 3.0,
+                              tau2_us: float = 300.0, tau_decay_ms: float = 25.0) -> jnp.ndarray:
+    """Time-dependent decay-probability profile for a cosmic-ray/gamma-ray-
+    induced quasiparticle burst: a two-stage rise (fast to
+    `ratio_intermediate`x baseline, slower to `ratio_peak`x baseline) times
+    a single-exponential recovery, generalized out of a fixed, paper-number
+    validation (Dense-Evolution-Discovery Experiment 34, reproducing
+    arXiv:2104.05219's real measured event on a 26-qubit chip).
+
+    Feed the result to `continuous_dissipative_evolve` alongside
+    `amplitude_damping_channel` (or any other single-time-varying-parameter
+    channel) to inject a realistic burst into any circuit or QEC study,
+    without re-deriving this shape by hand each time.
+
+    The default ratios/timescales are the paper's own real numbers -- see
+    Experiment 34's docstring for exactly which are paper-fitted (the 25ms
+    decay) versus chosen to match the paper's two described rise points
+    (tau1/tau2). All are overridable for a different event severity or
+    device generation; `baseline_gamma` is never derived here -- pass
+    whatever per-slice decay probability corresponds to your own dt/T1
+    convention (see Experiment 34 for one worked example of that
+    conversion).
+
+    Parameters
+    ----------
+    time_us : array_like
+        Time since impact, in microseconds (t=0 is the impact instant).
+    baseline_gamma : float
+        Undisturbed per-slice decay probability; this profile scales it
+        up, it does not derive it.
+    ratio_intermediate, ratio_peak : float
+        Multiplier on `baseline_gamma` at the two described checkpoints
+        (paper defaults 2.5=10/4, 3.75=15/4, from Fig. 3's ~10us/~1ms
+        readings).
+    tau1_us, tau2_us : float
+        Rise timescales for the two saturating-exponential stages (paper
+        defaults 3, 300 -- chosen to match its ~10us/~1ms descriptions,
+        not fitted by the paper itself).
+    tau_decay_ms : float
+        Recovery time constant (paper default 25 -- its own fitted central
+        value, real range 25-30ms across 415 events).
+
+    Returns
+    -------
+    jnp.ndarray
+        Per-slice decay probability at each entry of `time_us`.
+    """
+    time_us = jnp.asarray(time_us)
+    stage1 = (ratio_intermediate - 1.0) * (1.0 - jnp.exp(-time_us / tau1_us))
+    stage2 = (ratio_peak - ratio_intermediate) * (1.0 - jnp.exp(-time_us / tau2_us))
+    decay = jnp.exp(-time_us / (tau_decay_ms * 1000.0))
+    scaling = 1.0 + (stage1 + stage2) * decay
+    return baseline_gamma * scaling

--- a/dense_evolution/noise/density_matrix_channels.py
+++ b/dense_evolution/noise/density_matrix_channels.py
@@ -1,0 +1,49 @@
+"""Noise applied directly to a density matrix, instead of a statevector --
+what density-matrix ZNE (`dense_evolution.mitigation.zne_density_matrix`)
+needs its noise ensemble built from."""
+import jax.numpy as jnp
+
+__all__ = ["global_depolarizing_channel", "amplitude_damping_channel"]
+
+
+def global_depolarizing_channel(rho: jnp.ndarray, p: float) -> jnp.ndarray:
+    """Global n-qubit depolarizing channel, D_p(rho) = (1-p)*rho + (p/dim)*I.
+
+    Distinct from `NoiseModel`'s `'depolarizing'` model, which applies an
+    independent PER-QUBIT local Kraus channel -- a different physical map
+    from this GLOBAL channel, which mixes the whole `dim`-dimensional state
+    toward the fully mixed state as one unit. Use this one when modeling
+    e.g. state-prep/measurement (SPAM) error reported as a single joint
+    depolarizing parameter over the whole register, not per-qubit gate
+    noise (promoted from a real reproduction of arXiv:2608.16716's own
+    SPAM model, Dense-Evolution-Discovery Experiment 33).
+    """
+    rho = jnp.asarray(rho, dtype=jnp.complex128)
+    dim = rho.shape[0]
+    identity = jnp.eye(dim, dtype=jnp.complex128)
+    return (1.0 - p) * rho + (p / dim) * identity
+
+
+def amplitude_damping_channel(rho: jnp.ndarray, gamma: float) -> jnp.ndarray:
+    """Single-qubit amplitude-damping channel: E0 @ rho @ E0.conj().T +
+    E1 @ rho @ E1.conj().T, with E0=diag(1, sqrt(1-gamma)) and
+    E1=[[0,sqrt(gamma)],[0,0]] -- population only ever moves |1>->|0>,
+    never the reverse.
+
+    Distinct from `global_depolarizing_channel` (symmetric, mixes toward
+    the fully-mixed state regardless of which state is |1> or |0>) -- this
+    one is asymmetric by construction, the real signature of energy-relaxation
+    (T1) processes and of quasiparticle poisoning (promoted from a real
+    reproduction of arXiv:2104.05219's measured cosmic-ray-induced error
+    bursts, Dense-Evolution-Discovery Experiment 34, where this asymmetry is
+    exactly the mechanism's own reported signature: decay errors only, no
+    excess excitation errors).
+
+    Single-qubit only (rho must be 2x2) -- unlike `global_depolarizing_channel`,
+    this is not dimension-generic, since amplitude damping is inherently a
+    per-qubit process, not a joint-register one.
+    """
+    rho = jnp.asarray(rho, dtype=jnp.complex128)
+    e0 = jnp.array([[1.0, 0.0], [0.0, jnp.sqrt(1.0 - gamma)]], dtype=jnp.complex128)
+    e1 = jnp.array([[0.0, jnp.sqrt(gamma)], [0.0, 0.0]], dtype=jnp.complex128)
+    return e0 @ rho @ e0.conj().T + e1 @ rho @ e1.conj().T

--- a/dense_evolution/noise/oscillating.py
+++ b/dense_evolution/noise/oscillating.py
@@ -1,0 +1,32 @@
+"""A noise strength that oscillates instead of scaling smoothly/linearly
+-- for stress-testing mitigation techniques whose extrapolation assumes a
+smooth noise-vs-scale relationship."""
+import jax.numpy as jnp
+
+__all__ = ["oscillating_p_eff"]
+
+
+def oscillating_p_eff(base_p: float, factor: float, freq: float, amp: float) -> jnp.ndarray:
+    """Effective noise probability that oscillates around `base_p` as a
+    function of `factor` (e.g. a ZNE noise-scale factor), instead of
+    scaling smoothly with it: `base_p * (1 + amp * sin(factor * pi /
+    freq))`, clipped to `[0.01, 0.5]` so it always stays a valid
+    probability.
+
+    Promoted from Dense-Evolution-Discovery's jsd_zne_oscillating_noise.py,
+    where it was used to build a noise-vs-scale relationship deliberately
+    NOT smooth/monotonic, to stress-test
+    `dense_evolution.mitigation.jsd_predictive_zne_density_matrix` against
+    noise models where plain Richardson extrapolation's smoothness
+    assumption breaks down.
+
+    Examples
+    --------
+    >>> from dense_evolution.noise import oscillating_p_eff
+    >>> round(float(oscillating_p_eff(base_p=0.1, factor=0.0, freq=2.0, amp=0.5)), 4)
+    0.1
+    >>> round(float(oscillating_p_eff(base_p=0.1, factor=1.0, freq=2.0, amp=0.5)), 4)
+    0.15
+    """
+    p = base_p * (1.0 + amp * jnp.sin(factor * jnp.pi / freq))
+    return jnp.clip(p, 0.01, 0.5)

--- a/docs/api/noise.md
+++ b/docs/api/noise.md
@@ -155,6 +155,50 @@ down over tens of milliseconds. Feed the result into
 inject a real burst shape into a circuit or QEC study, instead of a
 constant noise rate.
 
+## Step 8. Apply noise to a density matrix instead of a statevector
+
+Steps 2-7 above all work on a statevector. Density-matrix ZNE (see
+[Density-matrix ZNE healing](../examples.md#density-matrix-zne-healing))
+needs noise applied directly to a density matrix instead.
+
+```python
+rho = np.outer(sv, sv.conj())
+
+from dense_evolution.noise import global_depolarizing_channel
+
+rho_noisy = global_depolarizing_channel(rho, 0.1)
+round(float(np.trace(rho_noisy).real), 6)
+```
+
+```
+1.0
+```
+
+`global_depolarizing_channel` mixes the *whole* register toward the fully
+mixed state as one unit — a different physical process from `NoiseModel`'s
+`"depolarizing"`, which acts independently per qubit. Use this one for a
+state-prep/measurement (SPAM) error reported as a single number over the
+whole register, not per-qubit gate noise. `amplitude_damping_channel(rho,
+gamma)` is the density-matrix equivalent of Step 3's `"amplitude_damping"`,
+single-qubit only, and is what Step 7's burst profile is meant to drive.
+
+## Step 9. Make the noise strength oscillate instead of scaling smoothly
+
+```python
+from dense_evolution.noise import oscillating_p_eff
+
+[round(float(oscillating_p_eff(base_p=0.1, factor=f, freq=2.0, amp=0.5)), 4) for f in [0.0, 1.0, 2.0, 3.0]]
+```
+
+```
+[0.1, 0.15, 0.1, 0.05]
+```
+
+Most mitigation techniques (Richardson extrapolation, for one) assume noise
+grows smoothly as you scale it up. `oscillating_p_eff` builds a
+deliberately non-smooth noise-vs-scale relationship instead, to check
+whether a technique still works when that assumption doesn't hold.
+
 ---
 
 ## Details
@@ -184,13 +228,13 @@ Photon loss on a dual-rail-encoded qubit is exactly this library's
 `amplitude_damping` channel (Step 3 above) — there is no separate photon
 noise model, and none is needed.
 
-### cosmic_ray_burst_profile lives outside this package
+### Moved here from mitigation.zne
 
-`cosmic_ray_burst_profile` (Step 7) is defined in
-[`dense_evolution.mitigation`](mitigation.md#dense_evolution.mitigation.zne.cosmic_ray_burst_profile),
-not `dense_evolution.noise` — it was built alongside the mitigation
-technique it was first validated against
-(`jsd_predictive_zne_density_matrix`), and has not been moved here.
+`global_depolarizing_channel`, `amplitude_damping_channel`,
+`cosmic_ray_burst_profile`, and `oscillating_p_eff` used to live in
+`dense_evolution.mitigation.zne` — they generate noise, they don't
+mitigate it, so that was the wrong home. `dense_evolution.mitigation.zne`
+still re-exports all four for backward compatibility.
 
 ### Coherent adversarial noise: an honest negative result
 


### PR DESCRIPTION
`dense_evolution.mitigation` should only contain error-cancellation techniques, never noise generation. Moves `global_depolarizing_channel` and `amplitude_damping_channel` (density-matrix Kraus channels) and `cosmic_ray_burst_profile` (time-dependent burst profile) into `dense_evolution.noise`, alongside a new `oscillating_p_eff` promoted from Dense-Evolution-Discovery's `jsd_zne_oscillating_noise.py` (a noise strength that oscillates instead of scaling smoothly, for stress-testing mitigation techniques that assume smoothness).

`dense_evolution.mitigation.zne` re-exports all three original functions for backward compatibility; all existing top-level `dense_evolution.X` imports are unaffected (they now come from `.noise` instead of `.mitigation.zne`, same name, same behavior).

Verified: full unit suite (693 passed, 19 skipped, 0 failed), the 4 existing tests that specifically exercise these functions, a fresh doctest for `oscillating_p_eff`, and a local `mkdocs build --strict` pass with `docs/api/noise.md` updated to reflect the new location.