### PR TITLE
Expose 3 more noise mechanisms as Composer/MCP tools

### DIFF
--- a/research/local_site/app/server.py
+++ b/research/local_site/app/server.py
@@ -21,6 +21,7 @@ import base64
 import io
 import sys
 from pathlib import Path
+from typing import List, Optional
 
 import matplotlib
 # FastAPI/Starlette runs sync route handlers in a worker thread, not the
@@ -602,6 +603,77 @@ def mitigate_matrix(req: MitigateMatrixRequest):
         "noise_factors": result.noise_factors,
         "fidelity_raw": result.fidelity_raw,
         "fidelity_corrected": result.fidelity_corrected,
+    }
+
+
+class CosmicRayBurstRequest(BaseModel):
+    baseline_gamma: float
+    times_us: Optional[List[float]] = None
+
+
+@app.post("/api/cosmic_ray_burst")
+def cosmic_ray_burst(req: CosmicRayBurstRequest):
+    """Real cosmic-ray/gamma-ray-induced quasiparticle burst profile,
+    reproducing a real measured event from arXiv:2104.05219."""
+    try:
+        result = dc.run_cosmic_ray_burst(req.baseline_gamma, times_us=req.times_us)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {
+        "times_us": result.times_us,
+        "baseline_gamma": result.baseline_gamma,
+        "decay_probabilities": result.decay_probabilities,
+        "peak_ratio": result.peak_ratio,
+    }
+
+
+class OscillatingNoiseRequest(BaseModel):
+    base_p: float
+    freq: float
+    amp: float
+    factors: Optional[List[float]] = None
+
+
+@app.post("/api/oscillating_noise")
+def oscillating_noise(req: OscillatingNoiseRequest):
+    """Noise strength that oscillates instead of scaling smoothly with a
+    ZNE-style scale factor -- for stress-testing a mitigation technique's
+    smoothness assumption."""
+    try:
+        result = dc.run_oscillating_noise(req.base_p, req.freq, req.amp, factors=req.factors)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {
+        "base_p": result.base_p,
+        "freq": result.freq,
+        "amp": result.amp,
+        "factors": result.factors,
+        "p_eff": result.p_eff,
+    }
+
+
+class DensityMatrixChannelRequest(BaseModel):
+    qasm: str
+    channel: str
+    param: float
+
+
+@app.post("/api/density_matrix_channel")
+def density_matrix_channel(req: DensityMatrixChannelRequest):
+    """Apply a density-matrix-level noise channel ('global_depolarizing'
+    or 'amplitude_damping') to the ideal density matrix of a QASM
+    circuit -- distinct from NoiseModel's per-qubit statevector channels."""
+    try:
+        result = dc.run_density_matrix_channel(req.qasm, req.channel, req.param)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {
+        "n_qubits": result.n_qubits,
+        "channel": result.channel,
+        "param": result.param,
+        "ideal_diagonal": result.ideal_diagonal,
+        "noisy_diagonal": result.noisy_diagonal,
+        "trace": result.trace,
     }
 
 

--- a/tests/integration/test_local_site_server.py
+++ b/tests/integration/test_local_site_server.py
@@ -376,6 +376,47 @@ def test_mitigate_matrix():
     assert 0.0 <= body["fidelity_corrected"] <= 1.0
 
 
+def test_cosmic_ray_burst():
+    resp = client.post("/api/cosmic_ray_burst", json={"baseline_gamma": 0.001})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["decay_probabilities"][0] == pytest.approx(0.001, abs=1e-6)
+    assert body["peak_ratio"] > 1.0
+
+
+def test_oscillating_noise():
+    resp = client.post("/api/oscillating_noise", json={"base_p": 0.1, "freq": 2.0, "amp": 0.5})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["p_eff"][0] == pytest.approx(0.1, abs=1e-6)
+    assert min(body["p_eff"]) < body["base_p"] < max(body["p_eff"])
+
+
+def test_density_matrix_channel_global_depolarizing():
+    resp = client.post("/api/density_matrix_channel", json={
+        "qasm": BELL_QASM, "channel": "global_depolarizing", "param": 0.1,
+    })
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["n_qubits"] == 2
+    assert body["trace"] == pytest.approx(1.0, abs=1e-6)
+    assert body["noisy_diagonal"][1] > body["ideal_diagonal"][1]
+
+
+def test_density_matrix_channel_amplitude_damping_rejects_multi_qubit():
+    resp = client.post("/api/density_matrix_channel", json={
+        "qasm": BELL_QASM, "channel": "amplitude_damping", "param": 0.1,
+    })
+    assert resp.status_code == 400
+
+
+def test_density_matrix_channel_invalid_channel_name():
+    resp = client.post("/api/density_matrix_channel", json={
+        "qasm": BELL_QASM, "channel": "not_a_real_channel", "param": 0.1,
+    })
+    assert resp.status_code == 400
+
+
 def test_mitigate_matrix_invalid_qasm_returns_400():
     resp = client.post("/api/mitigate_matrix", json={
         "qasm": "not qasm", "noise_model": "depolarizing", "noise_p": 0.05,

--- a/tools/dashboard/core/__init__.py
+++ b/tools/dashboard/core/__init__.py
@@ -51,6 +51,11 @@ from .wormhole import (
     run_wormhole_protocol, run_wormhole_protocol_trotter,
 )
 from .vector_healing import VectorHealingResult, run_vector_healing
+from .noise_tools import (
+    CosmicRayBurstResult, run_cosmic_ray_burst,
+    OscillatingNoiseResult, run_oscillating_noise,
+    DensityMatrixChannelResult, run_density_matrix_channel,
+)
 
 __all__ = [
     'QASM_LIBRARY', 'gate_tuples_to_qasm',
@@ -72,4 +77,7 @@ __all__ = [
     'build_sparse_syk_terms', 'commuting_pair_count', 'select_good_instance',
     'run_wormhole_protocol', 'run_wormhole_protocol_trotter',
     'VectorHealingResult', 'run_vector_healing',
+    'CosmicRayBurstResult', 'run_cosmic_ray_burst',
+    'OscillatingNoiseResult', 'run_oscillating_noise',
+    'DensityMatrixChannelResult', 'run_density_matrix_channel',
 ]

--- a/tools/dashboard/core/noise_tools.py
+++ b/tools/dashboard/core/noise_tools.py
@@ -1,0 +1,115 @@
+"""
+Composer-facing wrappers around dense_evolution.noise's standalone noise
+profiles and density-matrix channels -- the ones that take a formula and
+some parameters, not a circuit, so they don't fit run_circuit_from_qasm's
+shape.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import numpy as np
+
+import dense_evolution as de
+
+__all__ = [
+    'CosmicRayBurstResult', 'run_cosmic_ray_burst',
+    'OscillatingNoiseResult', 'run_oscillating_noise',
+    'DensityMatrixChannelResult', 'run_density_matrix_channel',
+]
+
+
+@dataclass
+class CosmicRayBurstResult:
+    times_us: List[float]
+    baseline_gamma: float
+    decay_probabilities: List[float]
+    peak_ratio: float
+
+
+def run_cosmic_ray_burst(baseline_gamma: float, times_us: Optional[List[float]] = None) -> CosmicRayBurstResult:
+    """Real cosmic-ray/gamma-ray-induced quasiparticle burst profile
+    (dense_evolution.cosmic_ray_burst_profile), reproducing a real
+    measured event from arXiv:2104.05219 on a 26-qubit chip. Default
+    `times_us` samples the impact instant, the ~10us and ~1ms rise
+    checkpoints the paper describes, and a point well into the ~25ms
+    recovery."""
+    if times_us is None:
+        times_us = [0.0, 10.0, 1000.0, 50000.0]
+    times_arr = np.asarray(times_us, dtype=float)
+    profile = np.asarray(de.cosmic_ray_burst_profile(times_arr, baseline_gamma=baseline_gamma))
+    return CosmicRayBurstResult(
+        times_us=[float(t) for t in times_arr],
+        baseline_gamma=baseline_gamma,
+        decay_probabilities=[float(p) for p in profile],
+        peak_ratio=float(np.max(profile) / baseline_gamma),
+    )
+
+
+@dataclass
+class OscillatingNoiseResult:
+    base_p: float
+    freq: float
+    amp: float
+    factors: List[float]
+    p_eff: List[float]
+
+
+def run_oscillating_noise(base_p: float, freq: float, amp: float,
+                           factors: Optional[List[float]] = None) -> OscillatingNoiseResult:
+    """Noise strength that oscillates instead of scaling smoothly with
+    `factor` (dense_evolution.oscillating_p_eff) -- for checking whether a
+    mitigation technique that assumes smooth noise-vs-scale still works
+    when that assumption breaks. Default `factors` sample one full period
+    at `freq`."""
+    if factors is None:
+        factors = [0.0, 1.0, 2.0, 3.0]
+    p_eff = [float(de.oscillating_p_eff(base_p, f, freq, amp)) for f in factors]
+    return OscillatingNoiseResult(base_p=base_p, freq=freq, amp=amp, factors=list(factors), p_eff=p_eff)
+
+
+@dataclass
+class DensityMatrixChannelResult:
+    n_qubits: int
+    channel: str
+    param: float
+    ideal_diagonal: List[float]
+    noisy_diagonal: List[float]
+    trace: float
+
+
+def run_density_matrix_channel(qasm_text: str, channel: str, param: float) -> DensityMatrixChannelResult:
+    """Apply a density-matrix-level noise channel (as opposed to
+    NoiseModel's per-qubit statevector channels) to the ideal density
+    matrix of a QASM circuit.
+
+    channel: 'global_depolarizing' (dense_evolution.global_depolarizing_channel,
+    mixes the WHOLE register toward the fully mixed state as one unit --
+    a state-prep/measurement error reported as a single joint parameter)
+    or 'amplitude_damping' (dense_evolution.amplitude_damping_channel,
+    single-qubit only, asymmetric |1>->|0> energy relaxation)."""
+    if channel not in ('global_depolarizing', 'amplitude_damping'):
+        raise ValueError(f"channel must be 'global_depolarizing' or 'amplitude_damping', got {channel!r}")
+
+    parsed = de.QASMParser().parse(qasm_text)
+    n_qubits = parsed.n_qubits
+    sim = de.DenseSVSimulator(n_qubits)
+    sim.run_circuit(parsed.to_tuples())
+    sv = np.asarray(sim.get_statevector())
+    rho = np.outer(sv, sv.conj())
+
+    if channel == 'global_depolarizing':
+        rho_noisy = de.global_depolarizing_channel(rho, param)
+    else:
+        if n_qubits != 1:
+            raise ValueError(f"amplitude_damping is single-qubit only, got a {n_qubits}-qubit circuit")
+        rho_noisy = de.amplitude_damping_channel(rho, param)
+
+    return DensityMatrixChannelResult(
+        n_qubits=n_qubits,
+        channel=channel,
+        param=param,
+        ideal_diagonal=[float(x) for x in np.diag(rho).real],
+        noisy_diagonal=[float(x) for x in np.diag(rho_noisy).real],
+        trace=float(np.trace(rho_noisy).real),
+    )

--- a/tools/mcp_server/models.py
+++ b/tools/mcp_server/models.py
@@ -5,7 +5,7 @@ docstrings) since MCP clients read them directly off the schema to build
 their own UI/validation -- the docstrings still carry the longer
 explanation for a human or agent reading the tool's full documentation.
 """
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -159,6 +159,34 @@ class MitigateDensityMatrixInput(BaseModel):
     noise_model: str = Field(..., description="Noise model name -- see dense_evolution_list_noise_models.")
     noise_p: float = Field(..., ge=0.0, le=1.0, description="Base noise channel error probability.")
     seed: int = Field(default=42, description="Random seed for the Monte-Carlo density-matrix estimate.")
+
+
+class CosmicRayBurstInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    baseline_gamma: float = Field(..., ge=0.0, le=1.0, description="Undisturbed per-slice decay probability.")
+    times_us: Optional[List[float]] = Field(
+        default=None,
+        description="Time points since impact, in microseconds. Defaults to the impact instant, the "
+        "~10us and ~1ms rise checkpoints, and a point well into the ~25ms recovery.",
+    )
+
+
+class OscillatingNoiseInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    base_p: float = Field(..., ge=0.0, le=1.0, description="Noise probability around which p_eff oscillates.")
+    freq: float = Field(..., gt=0.0, description="Oscillation frequency parameter (see dense_evolution.oscillating_p_eff).")
+    amp: float = Field(..., description="Oscillation amplitude, as a fraction of base_p.")
+    factors: Optional[List[float]] = Field(
+        default=None, description="Scale-factor points to evaluate p_eff at. Defaults to one full period.",
+    )
+
+
+class DensityMatrixChannelInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    qasm: str = Field(..., min_length=1, description="OpenQASM circuit whose ideal density matrix the channel is applied to.")
+    channel: str = Field(..., description="'global_depolarizing' (whole-register, SPAM-style) or "
+                          "'amplitude_damping' (single-qubit only, asymmetric energy relaxation).")
+    param: float = Field(..., ge=0.0, le=1.0, description="Channel strength: p for global_depolarizing, gamma for amplitude_damping.")
 
 
 class VectorHealingInput(BaseModel):

--- a/tools/mcp_server/server.py
+++ b/tools/mcp_server/server.py
@@ -69,6 +69,9 @@ from .tools.mitigation_tools import (  # noqa: E402
 from .tools.wormhole_tools import (  # noqa: E402
     dense_evolution_wormhole_scan, dense_evolution_wormhole_select_instance, dense_evolution_wormhole_teleportation,
 )
+from .tools.noise_tools import (  # noqa: E402
+    dense_evolution_cosmic_ray_burst, dense_evolution_oscillating_noise, dense_evolution_density_matrix_channel,
+)
 
 
 def main():

--- a/tools/mcp_server/tools/noise_tools.py
+++ b/tools/mcp_server/tools/noise_tools.py
@@ -1,0 +1,60 @@
+"""Tools: standalone noise profiles and density-matrix channels."""
+import json
+
+from ..client import _request, catch_errors
+from ..config import COMPUTE
+from ..models import CosmicRayBurstInput, OscillatingNoiseInput, DensityMatrixChannelInput
+from ..server import mcp
+
+
+@mcp.tool(name="dense_evolution_cosmic_ray_burst", annotations={"title": "Cosmic-ray burst noise profile", **COMPUTE})
+@catch_errors
+async def dense_evolution_cosmic_ray_burst(params: CosmicRayBurstInput) -> str:
+    """Real time-dependent decay-probability profile for a cosmic-ray/
+    gamma-ray-induced quasiparticle burst, reproducing a real measured
+    event from arXiv:2104.05219 on a 26-qubit chip: a two-stage rise then
+    a single-exponential recovery.
+
+    Args:
+        params (CosmicRayBurstInput): baseline_gamma, times_us.
+
+    Returns:
+        str: JSON with times_us, baseline_gamma, decay_probabilities, peak_ratio.
+    """
+    return json.dumps(await _request("POST", "/api/cosmic_ray_burst", timeout=30.0, json=params.model_dump()), indent=2)
+
+
+@mcp.tool(name="dense_evolution_oscillating_noise", annotations={"title": "Oscillating noise-scale profile", **COMPUTE})
+@catch_errors
+async def dense_evolution_oscillating_noise(params: OscillatingNoiseInput) -> str:
+    """A noise strength that oscillates instead of scaling smoothly with
+    a ZNE-style scale factor -- for checking whether a mitigation
+    technique that assumes smooth noise-vs-scale still works when that
+    assumption breaks down.
+
+    Args:
+        params (OscillatingNoiseInput): base_p, freq, amp, factors.
+
+    Returns:
+        str: JSON with base_p, freq, amp, factors, p_eff.
+    """
+    return json.dumps(await _request("POST", "/api/oscillating_noise", timeout=30.0, json=params.model_dump()), indent=2)
+
+
+@mcp.tool(name="dense_evolution_density_matrix_channel", annotations={"title": "Apply a density-matrix noise channel", **COMPUTE})
+@catch_errors
+async def dense_evolution_density_matrix_channel(params: DensityMatrixChannelInput) -> str:
+    """Apply a density-matrix-level noise channel to the ideal density
+    matrix of a QASM circuit -- distinct from per-qubit statevector
+    noise (see dense_evolution_run_circuit's noise_model/noise_p):
+    'global_depolarizing' mixes the whole register toward the fully
+    mixed state as one unit (a SPAM-style error), 'amplitude_damping' is
+    single-qubit asymmetric energy relaxation.
+
+    Args:
+        params (DensityMatrixChannelInput): qasm, channel, param.
+
+    Returns:
+        str: JSON with n_qubits, channel, param, ideal_diagonal, noisy_diagonal, trace.
+    """
+    return json.dumps(await _request("POST", "/api/density_matrix_channel", timeout=30.0, json=params.model_dump()), indent=2)


### PR DESCRIPTION
Follow-up to #157: 3 of the 5 noise mechanisms not yet reachable via the Composer/MCP layer, each wired through the full 3-layer stack (`dashboard_core` wrapper -> Composer server route -> MCP tool):

- `dense_evolution_cosmic_ray_burst` -> `POST /api/cosmic_ray_burst` -> `dc.run_cosmic_ray_burst`
- `dense_evolution_oscillating_noise` -> `POST /api/oscillating_noise` -> `dc.run_oscillating_noise`
- `dense_evolution_density_matrix_channel` -> `POST /api/density_matrix_channel` -> `dc.run_density_matrix_channel` (`global_depolarizing` or `amplitude_damping`)

Not included here (tracked separately):
- `noise_model_from_qiskit_backend` -- deliberately excluded from Composer/MCP: Qiskit's own object construction is known to segfault on macOS (see `tests/test_interop.py`'s existing macOS skip), and this whole server needs to run safely cross-platform.
- The 7 `dense_evolution.noise.coherent_attack` functions -- more involved (need a real stabilizer-code context, not just a QASM circuit), planned as its own follow-up.

Verified: full unit suite (693 passed earlier on #157's base), 5 new route tests + full existing `test_local_site_server.py`/`test_mcp_server.py` suites (101 passed, 0 failed), and direct end-to-end calls through the real server route functions.