### PR TITLE
Release prep: bump to v8.1.68, fix missing dense_evolution.noise in packaging

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/tatopenn-cell/Dense-Evolution"
 url: "https://github.com/tatopenn-cell/Dense-Evolution"
 license: "BUSL-1.1"
-version: "8.1.61"
+version: "8.1.68"
 doi: "10.5281/zenodo.22009005"
 identifiers:
   - type: doi

--- a/README.md
+++ b/README.md
@@ -912,6 +912,44 @@ All circuits stored as OpenQASM 2.0 strings in `dashboard_core.QASM_LIBRARY`.
 
 ## ▍ Changelog
 
+### v8.1.68
+- **Noise gets its own dedicated package, `dense_evolution.noise`.** Every noise-generating
+  mechanism used to be scattered across two unrelated modules: `NoiseModel`/`NoiseSpec` lived
+  in `circuits.registry` (alongside unrelated hardware-detection code), and
+  `global_depolarizing_channel`/`amplitude_damping_channel`/`cosmic_ray_burst_profile` lived in
+  `mitigation.zne` (which should only ever cancel noise, never generate it). All of it now lives
+  under `dense_evolution.noise`, one file per mechanism: `noise/kraus/{ideal,depolarizing,
+  bitflip,phaseflip,amplitude_damping,combined}.py` (the 6 Kraus channels, each its own file,
+  with `noise/kraus_channels.py` as the shared dispatcher), `noise/differentiable.py`
+  (`NoiseSpec`), `noise/density_matrix_channels.py`, `noise/cosmic_ray.py`. Both old locations
+  still re-export everything for backward compatibility; every top-level `dense_evolution.X`
+  import is unaffected.
+- **New: `oscillating_p_eff`** (`dense_evolution.noise.oscillating`) — a noise strength that
+  oscillates instead of scaling smoothly with a ZNE-style scale factor, promoted from
+  Dense-Evolution-Discovery's `jsd_zne_oscillating_noise.py`, for stress-testing mitigation
+  techniques that assume a smooth noise-vs-scale relationship.
+- **New: `dense_evolution.noise.coherent_attack`** — coherent, multi-qubit, JAX-differentiable
+  adversarial noise against a stabilizer code's syndrome (`apply_rz_all`,
+  `x_stabilizer_leakage`, `craft_adversarial_delta`, `craft_adversarial_delta_constrained`,
+  `project_l2_linf`, `decoder_failure_rate`, `random_delta_failure_stats`), promoted from
+  Dense-Evolution-Discovery's Steane [[7,1,3]] investigation and generalized from a hard-coded
+  7-qubit table to any stabilizer list. Keeps the experiment's own honest negative result in the
+  docstring: the unconstrained search (`craft_adversarial_delta`) converges to a direction with
+  *zero* real decoder-failure rate on a distance-3 code -- the L-infinity-constrained version
+  (`craft_adversarial_delta_constrained`) is the real worst-case test.
+- **3 new Composer/MCP tools**: `dense_evolution_cosmic_ray_burst`, `dense_evolution_oscillating_noise`,
+  `dense_evolution_density_matrix_channel` -- the cosmic-ray burst profile, the oscillating
+  noise profile, and the two density-matrix channels, each wired through the full stack
+  (`dashboard_core` wrapper -> Composer server route -> MCP tool). `noise_model_from_qiskit_backend`
+  is deliberately NOT exposed this way: Qiskit's own object construction is known to segfault
+  on macOS, and this server needs to run safely cross-platform.
+- **CI fix**: the docs-only fast path (added to skip the full 6-way test matrix on doc-only PRs)
+  had a `paths-filter` config bug (no base pattern, so it never actually evaluated to "docs-only")
+  and was missing `psutil`/`matplotlib` in its own dependency list, both fixed.
+- **Docs**: new guide-style pages `docs/api/mps.md` and `docs/api/noise.md` (step-by-step, built
+  from real verified QASM examples, details/history moved to the bottom), plus a rewritten guided
+  example for `NoiseModel.apply_to_sv`.
+
 ### v8.1.65
 - **`get_dynamic_chunk`/`SafeMemoryGuard` now read the compute device's own memory, not always host RAM.** Both used to call `psutil.virtual_memory()` unconditionally to decide `chunk_size_bits` and to gate `Chunk.__init__`'s pre-allocation checks -- correct on CPU, where the compute device *is* the host (exactly what this file's own "~2GB constant RAM" benchmark table measures), but wrong on GPU/TPU: chunk sizing got computed off host RAM (often much larger) while the actual chunk data lives in the device's own, usually smaller, VRAM -- causing `MemoryPressureError`/a real `RESOURCE_EXHAUSTED` well before the GPU's VRAM was actually full. Two new helpers, `_device_memory_budget_bytes`/`_device_total_bytes`, read `jax.devices()[0].memory_stats()` when available, falling back to `psutil.virtual_memory()` otherwise (CPU backends return `None` from `memory_stats()` -- confirmed directly, so CPU behavior is unchanged). Verified on a real Colab T4 GPU: `run_chunk()` now reliably reaches n=28 qubits (previously failed well short of that from the RAM/VRAM mismatch). n=29+ still fails, but that's a separate, structural property of `run_chunk()`'s eager multi-chunk path (it holds every chunk in memory simultaneously, so total memory always equals `2**n_qubits * bytes_per_element` regardless of `chunk_size_bits` -- confirmed against a real OOM needing exactly `2**29*8` bytes); going further needs `run_chunk_distributed()` (real multiple physical devices) or a genuinely sequential/streaming execution mode, which is not yet implemented.
 

--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -53,7 +53,7 @@ from .physics.qec import (pauli_commutes, compute_syndrome, erasure_aware_decode
                            blind_minimum_weight_decode, decode_with_erasure_fallback,
                            counts_in_intervals_dimension)
 
-__version__ = "8.1.67"
+__version__ = "8.1.68"
 
 __all__ = [
     "__version__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dense-evolution"
-version = "8.1.67"
+version = "8.1.68"
 description = "Micro-optimized High-Performance NISQ Statevector Quantum Circuit Simulator (Hardware-Adaptive Integration of Native NumPy and CPU/GPU/TPU JAX JIT/XLA Compilation, with Linear Kernel Fusion)"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -147,7 +147,7 @@ Repository = "https://github.com/tatopenn-cell/Dense-Evolution"
 dense-evolution = "dense_evolution.cli:main"
 
 [tool.setuptools]
-packages = ["dense_evolution", "dense_evolution.native_hf", "dense_evolution.utils", "dense_evolution.interop", "dense_evolution.physics", "dense_evolution.circuits", "dense_evolution.backends", "dense_evolution.mitigation", "dense_evolution.solvers", "ia_utils", "dashboard_core", "local_site", "local_site.app", "mcp_server", "mcp_server.utils", "mcp_server.tools"]
+packages = ["dense_evolution", "dense_evolution.native_hf", "dense_evolution.utils", "dense_evolution.interop", "dense_evolution.physics", "dense_evolution.circuits", "dense_evolution.backends", "dense_evolution.mitigation", "dense_evolution.solvers", "dense_evolution.noise", "dense_evolution.noise.kraus", "ia_utils", "dashboard_core", "local_site", "local_site.app", "mcp_server", "mcp_server.utils", "mcp_server.tools"]
 
 # Physical location moved under tools/ and research/ (root cleanup) --
 # import names stay exactly as-is (`import dashboard_core` etc. still


### PR DESCRIPTION
**Critical packaging fix**: `dense_evolution.noise` and `dense_evolution.noise.kraus` (added in #155/#157) were never added to `[tool.setuptools] packages` in `pyproject.toml`. A real `python -m build` confirmed the whole `dense_evolution/noise/` subpackage was silently missing from the built wheel -- anyone installing from PyPI would get a `dense_evolution` with no `noise` package at all, breaking `NoiseModel`/`NoiseSpec` and everything else that moved there. Fixed by adding both to the packages list; rebuilt and confirmed the wheel now contains the full `dense_evolution/noise/` tree.

Also bumps the version to 8.1.68 and adds the changelog entry for this session's work (the `dense_evolution.noise` package split, `oscillating_p_eff`, `coherent_attack`, the 3 new Composer/MCP noise tools, the CI docs-only-path fix, and the new guide pages). No PyPI upload from here -- build artifacts only, upload is manual.