### PR TITLE
Update simulation method to run_circuit_jit

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ desc  = NoiseModel.kraus_description('amplitude_damping')
 parser  = QASMParser()
 circuit = parser.parse(qasm_str)                  # → QASMCircuit
 sim     = DenseSVSimulator(n_qubits=circuit.n_qubits)
-sim.run_circuit(circuit.to_tuples())               # dicts -> tuples, then execute
+sim.run_circuit_jit(circuit.to_tuples())          # dicts -> tuples, then execute
 
 sv_noisy = NoiseModel().apply_to_sv(
     sim.get_statevector(), n=circuit.n_qubits, model='depolarizing', p=0.01,


### PR DESCRIPTION
## What & why

What does this change, and why is it needed — not just what it does mechanically.

## Testing

- [ ] Added/updated tests for the change (especially for anything numerical — statevector/probability outputs)
- [ ] `pytest tests/` passes locally
- [ ] Updated `README.md`'s changelog section if this is user-visible

## Notes for the reviewer

Anything that needs extra attention, or context that isn't obvious from the diff.
