### PR TITLE
Add dense_evolution_kernel_status MCP tool (closes remaining #78 items)

### DIFF
--- a/.claude/skills/dense-evolution-mcp/SKILL.md
+++ b/.claude/skills/dense-evolution-mcp/SKILL.md
@@ -8,7 +8,7 @@ compatibility: Requires the dense_evolution_mcp MCP server registered (see tools
 
 ## Why this exists
 
-`dense_evolution_mcp` gives you 21 tools that call the *same* local kernel
+`dense_evolution_mcp` gives you 22 tools that call the *same* local kernel
 the published Composer web page uses (`research/local_site/app/server.py`) -- real
 `DenseSVSimulator` runs, real Hartree-Fock Hamiltonians, real VQE with
 adjoint differentiation, real Hellmann-Feynman forces. Prefer these tools
@@ -47,6 +47,7 @@ assuming a size that worked for a small molecule will scale.
 | Task | Tool(s) |
 |---|---|
 | Is the kernel up? What can this machine handle? | `dense_evolution_health`, `dense_evolution_system_limits` |
+| Debug the adapter itself (kernel URL, image dir, cache state) | `dense_evolution_kernel_status` |
 | What circuits/gates/noise models/molecules exist? | `dense_evolution_list_presets`, `_list_gates`, `_list_noise_models`, `_list_molecules` |
 | Build QASM from a gate list instead of hand-writing it | `dense_evolution_build_circuit` |
 | Run a circuit (counts, probabilities, statevector) | `dense_evolution_run_circuit` |

--- a/README.md
+++ b/README.md
@@ -762,7 +762,7 @@ the same relative layout so it opens correctly via `file://`.
 ## ▍ MCP Server — drive the Composer kernel from an agent
 
 `dense_evolution_mcp` (`mcp_server/`) is an MCP ([Model Context
-Protocol](https://modelcontextprotocol.io)) server: 21 tools, one per
+Protocol](https://modelcontextprotocol.io)) server: 22 tools, one per
 Composer kernel endpoint plus a batch energy scan, a batch wormhole
 sweep, and a vector-healing pass, letting an MCP-aware agent (Claude
 Code, Claude Desktop, ...) run circuits, compute molecular ground-state

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -8,7 +8,7 @@ built on top of these modules but aren't part of this generated reference — se
 
 **Driving these modules without writing Python**: every module in the table has a real,
 tested execution path through the Composer kernel, reachable either from a browser
-([Composer](../composer.md)) or from an MCP-aware agent ([MCP Server](../mcp.md), 21 tools —
+([Composer](../composer.md)) or from an MCP-aware agent ([MCP Server](../mcp.md), 22 tools —
 Claude Code, Claude Desktop, ...). Both call the exact same kernel, not a separate
 reimplementation.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -144,7 +144,7 @@ Hartree-Fock, no mocked physics):
   apply ZNE mitigation, and run the [traversable-wormhole-inspired teleportation
   protocol](api/dashboard_core_wormhole.md).
 - **[MCP Server](mcp.md)** — the same kernel, driven by an MCP-aware agent (Claude Code,
-  Claude Desktop, ...) instead of a browser: 21 tools covering everything Composer does,
+  Claude Desktop, ...) instead of a browser: 22 tools covering everything Composer does,
   plus a batch energy scan, a batch wormhole sweep, and healing a noisy vector sequence
   (`dense_evolution_vector_healing`, see `dense_evolution.healing` above).
 

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -72,6 +72,14 @@ def test_system_limits_reports_positive_qubit_ceiling():
     assert data["max_qubits_dense"] > 0
 
 
+def test_kernel_status_reports_adapter_local_state():
+    data = json.loads(run(mcp_adapter.dense_evolution_kernel_status()))
+    assert data["kernel_reachable"] is True
+    assert data["kernel_url"] == mcp_client.KERNEL_URL
+    assert data["molecule_cache_entries"] >= 0
+    assert "image_output_dir" in data
+
+
 def test_list_presets_includes_a_real_bell_state():
     data = json.loads(run(mcp_adapter.dense_evolution_list_presets()))
     assert any("Bell" in name for name in data)

--- a/tools/mcp_server/README.md
+++ b/tools/mcp_server/README.md
@@ -66,11 +66,12 @@ server's environment.
 
 ## Tools
 
-21 tools -- one per Composer kernel endpoint, plus batch scans:
+22 tools -- one per Composer kernel endpoint, plus batch scans:
 
 | Tool | What it does |
 |---|---|
 | `dense_evolution_health` | Check the kernel is up; version, hostname, free RAM |
+| `dense_evolution_kernel_status` | Inspect this adapter's own local state (kernel URL, image dir/count, molecule-cache size) -- distinct from `_health`, which only proxies the kernel |
 | `dense_evolution_system_limits` | Max safe qubit count right now (live RAM-based) |
 | `dense_evolution_list_presets` | Built-in example OpenQASM circuits |
 | `dense_evolution_list_gates` | Gate palette for the graphical builder |

--- a/tools/mcp_server/client.py
+++ b/tools/mcp_server/client.py
@@ -4,14 +4,19 @@ httpx.AsyncClient, the low-level _request helper every tool calls, and the
 boilerplate every tool used to repeat individually.
 
 KERNEL_URL and _TEST_TRANSPORT live here (not config.py) specifically
-because tests/integration/test_mcp_server.py mutates them directly
-(`from mcp_server import client as mcp_client; mcp_client.KERNEL_URL = ...`)
-to exercise the unreachable-kernel and in-process-ASGI-transport paths --
-_get_client/_request must see those mutations as their OWN module globals,
-which only works if the value's single source of truth lives in the same
-module that reads it. Moving _TEST_TRANSPORT into a proper pytest fixture
-instead of a raw mutable global is planned for Phase 4 (see prog.txt
-Sezione 3.3), not done here.
+because tests/integration/test_mcp_server.py mutates them via
+`monkeypatch.setattr(mcp_client, "KERNEL_URL"/"_TEST_TRANSPORT", ...)`
+(autouse fixture + a couple of per-test overrides, never a raw manual
+assignment) to exercise the unreachable-kernel and in-process-ASGI-
+transport paths -- _get_client/_request must see those mutations as
+their OWN module globals, which only works if the value's single source
+of truth lives in the same module that reads it. `_TEST_TRANSPORT`
+staying a real module attribute in production code (rather than
+disappearing entirely behind dependency injection) is a deliberate,
+narrow seam for exactly that monkeypatch, not leftover tech debt --
+Phase 4's original goal (prog.txt Sezione 3.3) of routing every override
+through pytest's own fixture mechanism, not a bare global, is already
+what happens here.
 """
 import functools
 import os

--- a/tools/mcp_server/server.py
+++ b/tools/mcp_server/server.py
@@ -33,7 +33,7 @@ own response can be tens of thousands of floats for a 20+ qubit circuit.
 Structure (prog.txt Sezione 3, now complete): settings live in config.py,
 the HTTP client + error handling in client.py, the Pydantic input schemas
 in models.py (Phase 1); image saving/truncation/molecule-catalog caching
-in utils/ and molecules.py (Phase 2); the 21 tools themselves, split by
+in utils/ and molecules.py (Phase 2); the 22 tools themselves, split by
 topic, in tools/ (Phase 3, this file). This file's only job is to create
 the MCPServer instance, import each tools/*.py module so its `@mcp.tool`
 decorators register against it, re-export every tool function (so
@@ -54,8 +54,9 @@ from mcp.server import MCPServer
 mcp = MCPServer("dense_evolution_mcp")
 
 from .tools.system_tools import (  # noqa: E402
-    dense_evolution_health, dense_evolution_list_gates, dense_evolution_list_molecules,
-    dense_evolution_list_noise_models, dense_evolution_list_presets, dense_evolution_system_limits,
+    dense_evolution_health, dense_evolution_kernel_status, dense_evolution_list_gates,
+    dense_evolution_list_molecules, dense_evolution_list_noise_models, dense_evolution_list_presets,
+    dense_evolution_system_limits,
 )
 from .tools.circuit_tools import dense_evolution_build_circuit, dense_evolution_run_circuit  # noqa: E402
 from .tools.chemistry_tools import (  # noqa: E402

--- a/tools/mcp_server/tools/system_tools.py
+++ b/tools/mcp_server/tools/system_tools.py
@@ -5,11 +5,13 @@ from there (rather than the other way around) is safe despite looking
 circular."""
 import json
 
+from .. import client
 from ..client import _request, catch_errors
 from ..config import READ_ONLY_IDEMPOTENT
 from ..models import ListMoleculesInput
-from ..molecules import _get_annotated_molecule_catalog
+from ..molecules import _get_annotated_molecule_catalog, _molecule_catalog_cache
 from ..server import mcp
+from ..utils import images as _images
 
 
 @mcp.tool(name="dense_evolution_health", annotations={"title": "Check Dense Evolution kernel status", **READ_ONLY_IDEMPOTENT})
@@ -41,6 +43,40 @@ async def dense_evolution_system_limits() -> str:
         str: JSON describing the current safe qubit ceiling for the dense backend.
     """
     return json.dumps(await _request("GET", "/api/system_limits", timeout=5.0), indent=2)
+
+
+@mcp.tool(name="dense_evolution_kernel_status", annotations={"title": "Inspect this MCP adapter's own local state", **READ_ONLY_IDEMPOTENT})
+@catch_errors
+async def dense_evolution_kernel_status() -> str:
+    """Report this MCP adapter's own local configuration and diagnostics --
+    distinct from dense_evolution_health, which only proxies the kernel's
+    own /api/health. Useful for debugging the adapter process itself:
+    which kernel URL it's pointed at, whether that kernel currently
+    answers, how many circuit/histogram/Q-sphere PNGs have piled up on
+    disk (see the module docstring on why images are saved to disk
+    instead of inlined), and how warm the molecule-catalog cache is.
+
+    Returns:
+        str: JSON with {kernel_url, kernel_reachable, image_output_dir,
+        image_count, image_max_files, molecule_cache_entries}.
+    """
+    try:
+        await _request("GET", "/api/health", timeout=5.0)
+        reachable = True
+    except Exception:
+        reachable = False
+
+    image_dir = _images.IMAGE_OUTPUT_DIR
+    image_count = len(list(image_dir.glob("*.png"))) if image_dir.exists() else 0
+
+    return json.dumps({
+        "kernel_url": client.KERNEL_URL,
+        "kernel_reachable": reachable,
+        "image_output_dir": str(image_dir),
+        "image_count": image_count,
+        "image_max_files": _images.IMAGE_MAX_FILES,
+        "molecule_cache_entries": len(_molecule_catalog_cache),
+    }, indent=2)
 
 
 @mcp.tool(name="dense_evolution_list_presets", annotations={"title": "List preset OpenQASM circuits", **READ_ONLY_IDEMPOTENT})

--- a/tools/mcp_server/utils/cache.py
+++ b/tools/mcp_server/utils/cache.py
@@ -46,3 +46,10 @@ class TTLCache:
             self._store.clear()
         else:
             self._store.pop(key, None)
+
+    def __len__(self) -> int:
+        """Raw entry count, including any not-yet-pruned expired ones --
+        entries only drop out on their next get(), not on a timer. Good
+        enough for a diagnostics tool (dense_evolution_kernel_status);
+        don't rely on this for anything that needs an exact live count."""
+        return len(self._store)


### PR DESCRIPTION
## Summary
- Adds `dense_evolution_kernel_status`, the one Phase 3 item from #78 that was never implemented — reports the adapter's own local state (kernel URL, kernel reachability, image dir/count, molecule-cache entry count), distinct from `dense_evolution_health` which only proxies the kernel's own `/api/health`.
- Adds `TTLCache.__len__` so the cache size can be reported.
- Corrects `client.py`'s stale docstring, which claimed `_TEST_TRANSPORT` still needed to move to a "proper pytest fixture" — the test suite already does exactly that via `monkeypatch.setattr` in an autouse fixture, so this was already satisfied, just not documented as such.
- Bumps the tool count (21 → 22) everywhere it's mentioned: `README.md`, `docs/index.md`, `docs/api/index.md`, `tools/mcp_server/README.md`, `tools/mcp_server/server.py`, `.claude/skills/dense-evolution-mcp/SKILL.md`.

## Test plan
- [x] `pytest tests/integration/test_mcp_server.py -q` — 47 passed (46 existing + new `test_kernel_status_reports_adapter_local_state`)

Closes the remaining open items on #78.
