### PR TITLE
Cover dense_evolution_kernel_status's unreachable-kernel branch

### DIFF
--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -521,6 +521,14 @@ def test_kernel_unreachable_gives_actionable_error_not_a_traceback(monkeypatch):
     assert "dense-evolution serve" in result
 
 
+def test_kernel_status_reports_unreachable_kernel_without_raising(monkeypatch):
+    monkeypatch.setattr(mcp_client, "_TEST_TRANSPORT", None)  # force a real (failing) TCP attempt
+    monkeypatch.setattr(mcp_client, "KERNEL_URL", "http://127.0.0.1:1")  # nothing listens here
+    data = json.loads(run(mcp_adapter.dense_evolution_kernel_status()))
+    assert data["kernel_reachable"] is False
+    assert data["kernel_url"] == "http://127.0.0.1:1"
+
+
 def test_kernel_timeout_gives_actionable_error_not_a_traceback(monkeypatch):
     class _TimeoutClient:
         async def request(self, method, path, **kwargs):


### PR DESCRIPTION
## Summary
`codecov/patch` went red on `main` after #161 merged: 87.50% of the diff hit (target 96.84%). The gap was `dense_evolution_kernel_status`'s `except Exception: reachable = False` branch — never exercised, only the happy (kernel-reachable) path was tested.

Adds a test using the same unreachable-kernel pattern already used for `dense_evolution_health` (point `KERNEL_URL` at a port nothing listens on, force a real TCP attempt via `_TEST_TRANSPORT = None`).

## Test plan
- [x] `tools/mcp_server/tools/system_tools.py` now at 100% coverage (was 86.0%, missing line 32 = the except branch)
- [x] Full `tests/integration/test_mcp_server.py` suite: 48 passed (one unrelated test flaked once on JSONDecodeError under repeated back-to-back runs this session, reran clean in isolation immediately after — not related to this change)
