### PR TITLE
Add disk-backed statevector overflow to Chunk (Pednault et al. 2019)

### DIFF
--- a/dense_evolution/backends/chunk/core.py
+++ b/dense_evolution/backends/chunk/core.py
@@ -1,15 +1,18 @@
+import shutil
+import tempfile
 from typing import List, Optional
 
 import numpy as np
 
 from ._engine_imports import DenseSVSimulator
-from .guard import HAS_JAX, SafeMemoryGuard
+from .guard import HAS_JAX, MemoryPressureError, SafeMemoryGuard
 from .geometry import MemoryChunker
 from .circuit_chunker import CircuitChunker
 from .kernels import (
     _build_multi_chunk_runner, _build_distributed_chunk_runner,
     _compile_multi_chunk_ops,
 )
+from .disk_overflow import run_disk_overflow_circuit
 
 __all__ = ["Chunk", "chunk1", "chunk2", "Chunk2Incrociato"]
 
@@ -29,12 +32,19 @@ class Chunk:
     simulator is allocated and the logical qubit count is stored separately.
 
     For n_qubits > chunk_size_bits: num_chunks separate chunk_size_bits-qubit
-    simulators are held in RAM simultaneously (see _dispatch_multi) — no
-    disk/memmap paging, so this only covers a *moderate* overflow beyond the
-    safe budget (as many chunks as actually fit in RAM at once, checked
-    up front via SafeMemoryGuard.check_allocation before anything is
-    allocated). Benchmark attributes (num_chunks, chunk_size_bits, dtype)
-    are forwarded transparently from the embedded MemoryChunker.
+    simulators are held in RAM simultaneously (see _dispatch_multi) — as
+    many chunks as actually fit in RAM at once, checked up front via
+    SafeMemoryGuard.check_allocation before anything is allocated.
+    Benchmark attributes (num_chunks, chunk_size_bits, dtype) are
+    forwarded transparently from the embedded MemoryChunker.
+
+    Past that RAM ceiling, allow_disk_overflow=True (default False) falls
+    back to disk-backed storage instead of raising MemoryPressureError --
+    see dense_evolution/backends/chunk/disk_overflow.py (Pednault et al.
+    2019, arXiv:1910.09534) for the phased execution this uses, and
+    docs/api/chunk.md for a real verified demo and the speed trade-off
+    (never more than 1-2 chunks materialized in RAM at once, but every
+    gate now pays disk I/O -- v1 is correctness-first, not fast).
 
     A SafeMemoryGuard fires before any simulator is instantiated
     (pre-allocation check) and is also embedded in CircuitChunker for
@@ -47,14 +57,21 @@ class Chunk:
     memory_threshold  : free-RAM fraction below which execution is blocked
                         (default 0.15 = 15%)
     use_float32       : forwarded to DenseSVSimulator
+    allow_disk_overflow : fall back to disk-backed chunks instead of
+                        raising MemoryPressureError when num_chunks
+                        chunks don't fit in RAM at once (default False)
+    disk_dir          : directory for the overflow .npy files (default:
+                        a fresh tempfile.mkdtemp(), removed by close())
     """
 
     def __init__(
         self,
         n_qubits: int,
-        chunk_size_gates:  int   = 500,
-        memory_threshold:  float = 0.15,
-        use_float32:       bool  = False,
+        chunk_size_gates:    int   = 500,
+        memory_threshold:    float = 0.15,
+        use_float32:         bool  = False,
+        allow_disk_overflow: bool  = False,
+        disk_dir:            Optional[str] = None,
     ):
         # 1. Geometry — purely RAM-based, no JAX allocation yet
         self._mem_chunker     = MemoryChunker(n_qubits)
@@ -64,6 +81,10 @@ class Chunk:
         self.n                = n_qubits
         self.chunk_size_gates = chunk_size_gates
         self._m                = n_qubits - self._mem_chunker.chunk_size_bits  # chunk-select qubit count (0 if num_chunks==1)
+
+        self._chunk_paths  = None
+        self._disk_dir     = None
+        self._owns_disk_dir = False
 
         if self._mem_chunker.num_chunks == 1:
             # 3a. Pre-allocation RAM check — block here rather than inside JAX
@@ -90,11 +111,17 @@ class Chunk:
             num_chunks   = self._mem_chunker.num_chunks
             per_chunk_mb = self._mem_chunker.memory_mb()
             required_mb  = (num_chunks + 2) * per_chunk_mb
-            self._guard.check_allocation(
-                required_mb,
-                f"Chunk.__init__ — allocating {num_chunks} chunks of "
-                f"{self._mem_chunker.chunk_size_bits} qubits each",
-            )
+            try:
+                self._guard.check_allocation(
+                    required_mb,
+                    f"Chunk.__init__ — allocating {num_chunks} chunks of "
+                    f"{self._mem_chunker.chunk_size_bits} qubits each",
+                )
+            except MemoryPressureError:
+                if not allow_disk_overflow:
+                    raise
+                self._init_disk_overflow(num_chunks, disk_dir)
+                return
 
             # 4b. num_chunks independent chunk-sized simulators. Each one's own
             # __init__ resets it to |0...0>: only chunk 0 should carry the
@@ -123,6 +150,47 @@ class Chunk:
             # uses of Chunk will never need or satisfy.
             self._distributed_runner = None
             self._distributed_mesh   = None
+
+    def _init_disk_overflow(self, num_chunks: int, disk_dir: Optional[str]) -> None:
+        """Fallback storage for allow_disk_overflow=True when num_chunks
+        chunks don't fit in RAM at once -- see disk_overflow.py. Each
+        chunk becomes its own .npy file instead of a live DenseSVSimulator;
+        chunk 0 seeded to the logical |0...0>, the rest zero, same
+        convention _chunk_sims uses in the in-RAM path."""
+        self._inner_sim           = None
+        self._circuit_chunker     = None
+        self._chunk_sims          = None
+        self._multi_chunk_runner  = None
+        self._distributed_runner  = None
+        self._distributed_mesh    = None
+
+        self._owns_disk_dir = disk_dir is None
+        self._disk_dir = disk_dir or tempfile.mkdtemp(prefix="dense_evolution_chunk_")
+        dtype = self._mem_chunker.dtype
+        chunk_dim = self._mem_chunker.chunk_dim
+        paths = []
+        for i in range(num_chunks):
+            arr = np.zeros(chunk_dim, dtype=dtype)
+            if i == 0:
+                arr[0] = 1.0
+            path = f"{self._disk_dir}/chunk_{i}.npy"
+            np.save(path, arr)
+            paths.append(path)
+        self._chunk_paths = paths
+
+    def close(self) -> None:
+        """Removes the disk-overflow directory, if this Chunk created one
+        (allow_disk_overflow=True with no explicit disk_dir). Safe to call
+        even if disk overflow was never used."""
+        if self._owns_disk_dir and self._disk_dir is not None:
+            shutil.rmtree(self._disk_dir, ignore_errors=True)
+            self._disk_dir = None
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
 
     # ── Benchmark-facing attribute forwarding ─────────────────────
 
@@ -154,7 +222,13 @@ class Chunk:
         simulator's own array. For num_chunks>1, the chunks concatenated in
         ascending order — valid because of the MSB-first correspondence
         between chunk index and the top `_m` logical qubits (see
-        _dispatch_multi's docstring)."""
+        _dispatch_multi's docstring). For the disk-overflow path, streams
+        each chunk's .npy file off disk one at a time to build the same
+        concatenation -- this DOES materialize the full (2**n,) array in
+        RAM, unlike run_chunk() itself; only use it on a size you know
+        fits, e.g. for a final readout after a run."""
+        if self._chunk_paths is not None:
+            return np.concatenate([np.load(p) for p in self._chunk_paths])
         if self._chunk_sims is None:
             return self._inner_sim.sv
         xp = self._chunk_sims[0].xp
@@ -165,19 +239,31 @@ class Chunk:
         """Accepts a full-length (2**n,) statevector (e.g. the output of
         NoiseModel.apply_to_sv called on `.sv`) and writes it back through
         to the physical storage -- the inner simulator directly for
-        num_chunks==1, or split back into per-chunk slices (same ascending
-        concatenation order as the getter) for num_chunks>1."""
+        num_chunks==1, split back into per-chunk slices (same ascending
+        concatenation order as the getter) for num_chunks>1, or rewritten
+        to each chunk's .npy file for the disk-overflow path."""
+        chunk_dim = self._mem_chunker.chunk_dim
+        if self._chunk_paths is not None:
+            value = np.asarray(value)
+            for i, path in enumerate(self._chunk_paths):
+                np.save(path, value[i * chunk_dim:(i + 1) * chunk_dim])
+            return
         if self._chunk_sims is None:
             self._inner_sim.sv = value
             return
-        chunk_dim = self._mem_chunker.chunk_dim
         xp = self._chunk_sims[0].xp
         value = xp.asarray(value)
         for i, sim in enumerate(self._chunk_sims):
             sim.sv = value[i * chunk_dim:(i + 1) * chunk_dim]
 
     def memory_mb(self) -> float:
-        """RAM used by the physical statevector(s) in MB."""
+        """RAM used by the physical statevector(s) in MB -- 0 for the
+        disk-overflow path (see memory_geometry.memory_mb() for the
+        per-chunk on-disk size instead, and disk_overflow.py's own
+        docstring for why nothing (2**n_qubits,)-sized, or even
+        num_chunks-chunks-sized, is ever resident in RAM at once)."""
+        if self._chunk_paths is not None:
+            return 0.0
         if self._chunk_sims is None:
             return self._inner_sim.memory_mb()
         return sum(sim.memory_mb() for sim in self._chunk_sims)
@@ -192,10 +278,14 @@ class Chunk:
         ONCE over the full array — NOT each chunk's own get_probabilities()
         (that would independently renormalize each chunk's partial mass to
         1, summing to num_chunks overall and destroying the relative
-        weighting between chunks)."""
-        if self._chunk_sims is None:
+        weighting between chunks). Disk-overflow path: same normalization,
+        chunks streamed from their .npy files instead of live arrays."""
+        if self._chunk_paths is not None:
+            full_sv = np.concatenate([np.load(p) for p in self._chunk_paths])
+        elif self._chunk_sims is None:
             return self._inner_sim.get_probabilities()
-        full_sv = np.concatenate([np.array(sim.sv) for sim in self._chunk_sims])
+        else:
+            full_sv = np.concatenate([np.array(sim.sv) for sim in self._chunk_sims])
         probs = np.abs(full_sv) ** 2
         probs = np.clip(probs, 0.0, 1.0)
         total = probs.sum()
@@ -207,7 +297,10 @@ class Chunk:
         """Full complex statevector, num_qubits logical qubits long
         (2**n elements). num_chunks==1: forwards to the inner
         DenseSVSimulator. num_chunks>1: raw chunks concatenated in order
-        (see `sv` property)."""
+        (see `sv` property). Disk-overflow path: streamed from the .npy
+        files, same order."""
+        if self._chunk_paths is not None:
+            return np.concatenate([np.load(p) for p in self._chunk_paths])
         if self._chunk_sims is None:
             return self._inner_sim.get_statevector()
         return np.concatenate([np.array(sim.sv, dtype=sim.dtype) for sim in self._chunk_sims])
@@ -295,6 +388,11 @@ class Chunk:
         chunk_size_gates: Optional[int] = None,
     ) -> None:
 
+        if self._chunk_paths is not None:
+            compiled_ops = _compile_multi_chunk_ops(circuit)
+            run_disk_overflow_circuit(
+                self._chunk_paths, compiled_ops, self._m, self._mem_chunker.chunk_size_bits)
+            return
         if self._chunk_sims is not None:
             self._dispatch_multi(circuit)
             return
@@ -312,11 +410,13 @@ class Chunk:
     def __repr__(self) -> str:
         s = self._guard.status()
         safe_qubits = self._inner_sim.n if self._inner_sim is not None else self._mem_chunker.chunk_size_bits
+        storage = f"disk ({self._disk_dir})" if self._chunk_paths is not None else "ram"
         return (
             f"Chunk(n_qubits={self.n}, "
             f"safe_qubits={safe_qubits}, "
             f"num_chunks={self.num_chunks}, "
             f"chunk_size_bits={self.chunk_size_bits}, "
+            f"storage={storage}, "
             f"dtype={self.dtype}, "
             f"mem_per_chunk={self.memory_mb():.1f} MB, "
             f"ram_free={s['free_pct']:.1f}%, "

--- a/dense_evolution/backends/chunk/disk_overflow.py
+++ b/dense_evolution/backends/chunk/disk_overflow.py
@@ -1,0 +1,216 @@
+"""Disk-backed statevector overflow for Chunk -- Pednault et al. 2019
+(arXiv:1910.09534, "Leveraging Secondary Storage to Simulate Deep
+54-qubit Sycamore Circuits"): when num_chunks chunks don't all fit in
+RAM at once, keep the idle ones on disk as plain .npy files and only
+materialize, as a jax.Array, the small working set an individual gate
+actually needs -- one chunk for a local gate, two (an XOR-stride pair)
+for a chunk-mixing gate -- instead of the whole (num_chunks, chunk_dim)
+stack _dispatch_multi holds in RAM for the entire circuit.
+
+v1 scope (correctness-first, matching run_chunk_distributed's own staged
+rollout): processes one chunk / one pair at a time, no batching multiple
+pairs into one call for speed. This is strictly slower per gate than the
+in-RAM path -- it exists to make otherwise-impossible sizes possible at
+all, not to compete with it on speed. See docs/api/chunk.md for the real
+distinction and a verified demo.
+
+Every gate is one of the same 6 cases kernels.py's in-RAM
+_build_multi_chunk_step already classifies. This module reuses that
+classification (not a fresh derivation) via the same needs_comm split
+_build_distributed_chunk_step's own docstring documents:
+  - 1-qubit, q1 >= m -> LOCAL: needs only this one chunk.
+  - 2-qubit, q1 >= m and q2 >= m -> LOCAL: needs only this one chunk.
+  - 2-qubit, q1 < m, q2 >= m ("ctrl chunk-select, tgt local") -> LOCAL,
+    but conditional on this chunk's OWN absolute index (no partner
+    needed -- kernels.py's _case_2q_ctrl_chunk_tgt_local already
+    computes exactly this from an explicit `idxc`).
+  - everything else (1-qubit q1 < m, or 2-qubit q2 < m) -> MIX: needs
+    exactly the XOR-stride partner chunk.
+"""
+import numpy as np
+import jax.numpy as jnp
+
+from .kernels import (
+    _gate_matrix_elements, _case_1q_local, _case_2q_local_local,
+    _case_2q_ctrl_chunk_tgt_local,
+)
+
+__all__ = ["partition_ops_into_phases", "run_disk_overflow_circuit", "LocalPhase", "ConditionalPhase", "MixPhase"]
+
+
+class LocalPhase:
+    """A maximal run of consecutive gates with q1,q2 >= m (or unused) --
+    applied to each chunk independently, no partner chunk ever needed."""
+    __slots__ = ("ops",)
+
+    def __init__(self, ops):
+        self.ops = ops  # list of (g_id, q1, q2, param) python tuples
+
+
+class ConditionalPhase:
+    """A single 2-qubit gate with ctrl chunk-select (q1 < m), tgt local
+    (q2 >= m) -- applied to each chunk independently, conditioned on
+    that chunk's own absolute index (see _case_2q_ctrl_chunk_tgt_local)."""
+    __slots__ = ("op",)
+
+    def __init__(self, op):
+        self.op = op  # single (g_id, q1, q2, param)
+
+
+class MixPhase:
+    """A single gate that needs a partner chunk: 1-qubit with q1 < m, or
+    2-qubit with q2 < m (covers both "ctrl local/tgt chunk" and "ctrl
+    AND tgt both chunk-select"). `stride` is the mixing qubit (q1 for the
+    1-qubit case, q2 for the 2-qubit cases) -- chunk i always pairs with
+    chunk i ^ (1 << (m - 1 - stride))."""
+    __slots__ = ("op", "stride")
+
+    def __init__(self, op, stride):
+        self.op = op
+        self.stride = stride
+
+
+def partition_ops_into_phases(compiled_ops, m: int):
+    """compiled_ops: the (n_gates, 4) [g_id, q1, q2, param] array
+    _compile_multi_chunk_ops already builds (reused as-is). Returns a
+    list of LocalPhase/ConditionalPhase/MixPhase in circuit order. Pure
+    Python -- runs once per run_chunk() call, not traced/jitted."""
+    rows = np.asarray(compiled_ops)
+    phases = []
+    pending_local = []
+
+    def flush():
+        if pending_local:
+            phases.append(LocalPhase(list(pending_local)))
+            pending_local.clear()
+
+    for row in rows:
+        g_id, q1, q2, param = int(row[0]), int(row[1]), int(row[2]), float(row[3])
+        is_2q = g_id >= 20
+        if not is_2q:
+            if q1 < m:
+                flush()
+                phases.append(MixPhase((g_id, q1, q2, param), q1))
+            else:
+                pending_local.append((g_id, q1, q2, param))
+        elif q1 < m and q2 >= m:
+            flush()
+            phases.append(ConditionalPhase((g_id, q1, q2, param)))
+        elif q2 < m:
+            flush()
+            phases.append(MixPhase((g_id, q1, q2, param), q2))
+        else:
+            pending_local.append((g_id, q1, q2, param))
+    flush()
+    return phases
+
+
+def _run_local_phase_on_chunk(chunk_arr, ops, m: int, k: int):
+    """chunk_arr: (chunk_dim,) array for one chunk. Applies every op via
+    the same _case_1q_local/_case_2q_local_local formulas the in-RAM
+    kernel uses, as a (1, chunk_dim) batch of size 1 -- both cases never
+    reference the batch dimension's meaning, so this is exact, not an
+    approximation of the vectorized path."""
+    c = chunk_arr[None, :]
+    dtype = c.dtype
+    for g_id, q1, q2, param in ops:
+        g00, g01, g10, g11, u00, u01, u10, u11 = _gate_matrix_elements(g_id, param, dtype)
+        if g_id >= 20:
+            c = _case_2q_local_local(c, u00, u01, u10, u11, q1, q2, m, k)
+        else:
+            c = _case_1q_local(c, g00, g01, g10, g11, q1, m, k)
+    return c[0]
+
+
+def _run_conditional_phase_on_chunk(chunk_arr, op, chunk_index: int, m: int, k: int):
+    """A single ConditionalPhase gate, applied to one chunk whose real
+    absolute index is `chunk_index` (needed for the ctrl-bit decision;
+    see _case_2q_ctrl_chunk_tgt_local's own docstring)."""
+    g_id, q1, q2, param = op
+    dtype = chunk_arr.dtype
+    _, _, _, _, u00, u01, u10, u11 = _gate_matrix_elements(g_id, param, dtype)
+    c = chunk_arr[None, :]
+    idxc = jnp.array([chunk_index], dtype=jnp.int32)
+    c = _case_2q_ctrl_chunk_tgt_local(c, u00, u01, u10, u11, q1, q2, m, k, idxc)
+    return c[0]
+
+
+def _mix_pair(row_a, row_b, e00, e01, e10, e11):
+    """The 2x2 amplitude-mixing algebra shared by every chunk-select-
+    qubit case in kernels.py (_case_1q_chunk / _case_2q_ctrl_local_tgt_chunk
+    / _case_2q_both_chunk): row_a is the row on the "mask/is_c0 = True"
+    side, row_b its XOR-stride partner. Mirrors those cases' own
+    new0/new1 formula exactly -- new0 = e00*_c + e01*amp_pair evaluated
+    at the True-side row (_c=row_a, amp_pair=row_b); new1 = e10*amp_pair
+    + e11*_c evaluated at the False-side row, where _c=row_b and
+    amp_pair=row_a, i.e. new_b = e10*row_a + e11*row_b."""
+    new_a = e00 * row_a + e01 * row_b
+    new_b = e10 * row_a + e11 * row_b
+    return new_a, new_b
+
+
+def _run_mix_phase_on_pair(row_a, row_b, op, index_a: int, m: int, k: int):
+    """row_a is the chunk whose bit at the gate's own mixing qubit is 0,
+    row_b its XOR-stride partner (bit 1) -- the caller picks which
+    loaded chunk is "a" vs "b" by checking that bit on the real absolute
+    indices before calling this. `index_a` is row_a's real absolute
+    chunk index (needed only for case 6's ctrl-chunk-select decision)."""
+    g_id, q1, q2, param = op
+    dtype = row_a.dtype
+    g00, g01, g10, g11, u00, u01, u10, u11 = _gate_matrix_elements(g_id, param, dtype)
+    if g_id < 20:
+        # case 2: 1-qubit, chunk-select q1 -- unconditional mix.
+        return _mix_pair(row_a, row_b, g00, g01, g10, g11)
+    if q1 >= m:
+        # case 5: ctrl LOCAL (elementwise mask within the row), tgt
+        # chunk-select q2 (the mixing qubit).
+        ctrl_phys = (k - 1) - (q1 - m)
+        idxl = jnp.arange(1 << k, dtype=jnp.int32)
+        ctrl_bit = (idxl & (jnp.int32(1) << ctrl_phys)) != 0
+        new_a, new_b = _mix_pair(row_a, row_b, u00, u01, u10, u11)
+        return jnp.where(ctrl_bit, new_a, row_a), jnp.where(ctrl_bit, new_b, row_b)
+    # case 6: ctrl AND tgt both chunk-select; mixing qubit is q2, ctrl
+    # decided once from index_a's own bit at q1 (identical for both rows
+    # of the pair -- XOR-ing the tgt/q2 stride never touches the q1 bit).
+    ctrl_stride = 1 << (m - 1 - q1)
+    ctrl_set = (index_a & ctrl_stride) != 0
+    new_a, new_b = _mix_pair(row_a, row_b, u00, u01, u10, u11)
+    return (new_a, new_b) if ctrl_set else (row_a, row_b)
+
+
+def run_disk_overflow_circuit(chunk_paths, compiled_ops, m: int, k: int):
+    """Runs the compiled circuit against num_chunks chunks stored as
+    plain .npy files at `chunk_paths` (index = real chunk index),
+    mutating those files in place. Never materializes more than one
+    (LocalPhase/ConditionalPhase) or two (MixPhase) chunks as jax.Array
+    at once, regardless of num_chunks -- this is the whole point."""
+    num_chunks = len(chunk_paths)
+    phases = partition_ops_into_phases(compiled_ops, m)
+
+    for phase in phases:
+        if isinstance(phase, LocalPhase):
+            for i, path in enumerate(chunk_paths):
+                arr = jnp.asarray(np.load(path))
+                arr = _run_local_phase_on_chunk(arr, phase.ops, m, k)
+                np.save(path, np.asarray(arr))
+
+        elif isinstance(phase, ConditionalPhase):
+            for i, path in enumerate(chunk_paths):
+                arr = jnp.asarray(np.load(path))
+                arr = _run_conditional_phase_on_chunk(arr, phase.op, i, m, k)
+                np.save(path, np.asarray(arr))
+
+        elif isinstance(phase, MixPhase):
+            stride_bits = 1 << (m - 1 - phase.stride)
+            done = set()
+            for i in range(num_chunks):
+                if i in done:
+                    continue
+                j = i ^ stride_bits
+                done.add(i)
+                done.add(j)
+                row_a = jnp.asarray(np.load(chunk_paths[i]))
+                row_b = jnp.asarray(np.load(chunk_paths[j]))
+                new_a, new_b = _run_mix_phase_on_pair(row_a, row_b, phase.op, i, m, k)
+                np.save(chunk_paths[i], np.asarray(new_a))
+                np.save(chunk_paths[j], np.asarray(new_b))

--- a/dense_evolution/backends/chunk/kernels.py
+++ b/dense_evolution/backends/chunk/kernels.py
@@ -10,11 +10,208 @@ __all__ = [
     "_build_multi_chunk_step", "_build_multi_chunk_runner",
     "_build_distributed_chunk_step", "_build_distributed_chunk_runner",
     "_compile_multi_chunk_ops",
+    # Re-exported for disk_overflow.py's phased/streaming path -- see its
+    # module docstring for which of these it calls and why.
+    "_gate_matrix_elements", "_case_1q_local", "_case_2q_local_local",
+    "_case_2q_ctrl_chunk_tgt_local",
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────────
 # Multi-chunk JIT kernel (num_chunks > 1)
 # ─────────────────────────────────────────────────────────────────────────────────
+
+# ─────────────────────────────────────────────────────────────────────────────────
+# The 6 gate/qubit-location case bodies, factored out to module level so
+# disk_overflow.py's phased/streaming path can call the exact same verified
+# formulas instead of re-deriving them -- see that module's docstring for
+# which of these 6 need a partner chunk (MixPhase) vs. run standalone per
+# chunk (LocalPhase), a classification already worked out once for
+# _build_distributed_chunk_step below (needs_comm_1q/needs_comm_2q) and
+# reused rather than re-derived a third time.
+#
+# Verified case-by-case against DenseSVSimulator on non-chunked reference
+# circuits before being wired in, not derived fresh -- this extraction is
+# a pure move, not a rewrite: same array shapes, same operations, same
+# order, only the enclosing scope changed from a closure to explicit args.
+# ─────────────────────────────────────────────────────────────────────────────────
+
+def _gate_matrix_elements(g_id, param, dtype):
+    """1-qubit matrix elements (g00,g01,g10,g11) and 2-qubit controlled-U
+    submatrix elements (u00,u01,u10,u11) for one compiled [g_id, param]
+    pair. Factored out of _build_multi_chunk_step's step() so
+    disk_overflow.py's per-gate phase processors compute matrices from
+    this SAME table instead of a third hand-copied one — g_id/param may
+    be traced (the in-RAM scan) or concrete Python/jnp scalars (a single
+    known gate in a phase); jax.lax.switch works identically either way.
+
+    Table is a copy of compiler.py's _apply_gate_fast_step / (this
+    module's own step() before this extraction) -- must stay in sync
+    with both, most notably index 14 (GPhase(alpha) = e^{i*alpha} * I)."""
+    inv2         = jnp.asarray(1.0 / jnp.sqrt(2.0), dtype=dtype)
+    half_p       = param * jnp.float64(0.5)
+    cos_p        = jnp.cos(half_p).astype(dtype)
+    sin_p        = jnp.sin(half_p).astype(dtype)
+    exp_pos      = jnp.exp(1j * param).astype(dtype)
+    exp_ph4      = jnp.exp(1j * jnp.pi / 4.0).astype(dtype)
+    exp_mh4      = jnp.exp(-1j * jnp.pi / 4.0).astype(dtype)
+    exp_pos_half = jnp.exp(1j * half_p).astype(dtype)
+    exp_neg_half = jnp.exp(-1j * half_p).astype(dtype)
+
+    g_id = jnp.asarray(g_id).astype(jnp.int32)
+    safe_gid = jnp.clip(g_id, 0, 14)
+    g_1q = jax.lax.switch(
+        safe_gid,
+        [
+            lambda _: jnp.eye(2, dtype=dtype),
+            lambda _: jnp.array([[inv2, inv2], [inv2, -inv2]], dtype=dtype),
+            lambda _: jnp.array([[0.0 + 0j, 1.0 + 0j], [1.0 + 0j, 0.0 + 0j]], dtype=dtype),
+            lambda _: jnp.array([[0.0 + 0j, -1j], [1j, 0.0 + 0j]], dtype=dtype),
+            lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, -1.0 + 0j]], dtype=dtype),
+            lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, 1j]], dtype=dtype),
+            lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, -1j]], dtype=dtype),
+            lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, exp_ph4]], dtype=dtype),
+            lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, exp_mh4]], dtype=dtype),
+            lambda _: jnp.array([[cos_p, -1j * sin_p], [-1j * sin_p, cos_p]], dtype=dtype),
+            lambda _: jnp.array([[cos_p, -sin_p], [sin_p, cos_p]], dtype=dtype),
+            lambda _: jnp.array([[jnp.exp(-1j * half_p), 0.0 + 0j], [0.0 + 0j, jnp.exp(1j * half_p)]], dtype=dtype),
+            lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, exp_pos]], dtype=dtype),
+            lambda _: jnp.array([[0.5 + 0.5j, 0.5 - 0.5j], [0.5 - 0.5j, 0.5 + 0.5j]], dtype=dtype),
+            # 14  GPhase(alpha) = e^{i*alpha} * I -- see compiler.py's
+            # _apply_gate_fast_step index 14 for the derivation; this
+            # table must stay in sync with that one (see comment above).
+            lambda _: jnp.array([[exp_pos, 0.0 + 0j], [0.0 + 0j, exp_pos]], dtype=dtype),
+        ],
+        operand=None,
+    )
+
+    # Controlled-U submatrix for the 5 two-qubit gate types (mat[2:,2:]
+    # of each gate's full 4x4 form — same values _apply_gate_multi's
+    # `U = mat[2:, 2:]` extracted from GATES/PARAMETRIC_GATES).
+    # 20=CX->X, 21=CZ->Z, 22=CP->P(theta), 24=CY->Y, 25=CRZ->RZ(theta).
+    two_q_idx = jnp.where(g_id == 20, 0,
+                jnp.where(g_id == 21, 1,
+                jnp.where(g_id == 22, 2,
+                jnp.where(g_id == 24, 3, 4))))
+    U = jax.lax.switch(
+        two_q_idx,
+        [
+            lambda _: jnp.array([[0.0 + 0j, 1.0 + 0j], [1.0 + 0j, 0.0 + 0j]], dtype=dtype),
+            lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, -1.0 + 0j]], dtype=dtype),
+            lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, exp_pos]], dtype=dtype),
+            lambda _: jnp.array([[0.0 + 0j, -1j], [1j, 0.0 + 0j]], dtype=dtype),
+            lambda _: jnp.array([[exp_neg_half, 0.0 + 0j], [0.0 + 0j, exp_pos_half]], dtype=dtype),
+        ],
+        operand=None,
+    )
+    return g_1q[0, 0], g_1q[0, 1], g_1q[1, 0], g_1q[1, 1], U[0, 0], U[0, 1], U[1, 0], U[1, 1]
+
+
+def _case_1q_local(_c, g00, g01, g10, g11, q1, m, k):
+    """1-qubit gate, LOCAL qubit (q1 >= m). No cross-chunk data needed --
+    valid for any batch size along axis 0, including a single chunk."""
+    local_phys = (k - 1) - (q1 - m)
+    stride     = jnp.int32(1) << local_phys
+    idx        = jnp.arange(1 << k, dtype=jnp.int32)
+    idx_pair   = idx ^ stride
+    mask0      = (idx & stride) == 0
+    amp_pair   = _c[:, idx_pair]
+    new0 = g00 * _c + g01 * amp_pair
+    new1 = g10 * amp_pair + g11 * _c
+    return jnp.where(mask0[None, :], new0, new1)
+
+
+def _case_1q_chunk(_c, g00, g01, g10, g11, q1, m, num_chunks):
+    """1-qubit gate, CHUNK-SELECT qubit (q1 < m). Mixes whole rows
+    pairwise across axis 0 -- needs every chunk present at once; the
+    disk-overflow path does NOT call this directly (see _mix_pair for
+    the pair-at-a-time equivalent), only the in-RAM stacked kernel does."""
+    stride    = jnp.int32(1) << (m - 1 - q1)
+    idxc      = jnp.arange(num_chunks, dtype=jnp.int32)
+    idxc_pair = idxc ^ stride
+    mask0     = (idxc & stride) == 0
+    amp_pair  = _c[idxc_pair]
+    new0 = g00 * _c + g01 * amp_pair
+    new1 = g10 * amp_pair + g11 * _c
+    return jnp.where(mask0[:, None], new0, new1)
+
+
+def _case_2q_local_local(_c, u00, u01, u10, u11, q1, q2, m, k):
+    """2-qubit gate, ctrl AND tgt both LOCAL. No cross-chunk data needed
+    -- valid for any batch size along axis 0, including a single chunk."""
+    ctrl_phys = (k - 1) - (q1 - m)
+    tgt_phys  = (k - 1) - (q2 - m)
+    idx       = jnp.arange(1 << k, dtype=jnp.int32)
+    ctrl_bit  = (idx & (jnp.int32(1) << ctrl_phys)) != 0
+    tgt_bit   = (idx & (jnp.int32(1) << tgt_phys)) != 0
+    partner   = idx ^ (jnp.int32(1) << tgt_phys)
+    amp_partner = _c[:, partner]
+    new0 = u00 * _c + u01 * amp_partner
+    new1 = u10 * amp_partner + u11 * _c
+    after = jnp.where(tgt_bit[None, :], new1, new0)
+    return jnp.where(ctrl_bit[None, :], after, _c)
+
+
+def _case_2q_ctrl_chunk_tgt_local(_c, u00, u01, u10, u11, q1, q2, m, k, idxc):
+    """ctrl CHUNK-SELECT, tgt LOCAL. Whole chunks where the chunk-index's
+    ctrl bit is set get U applied as a local 1-qubit gate; the rest are
+    untouched -- a decision each chunk makes from its OWN index alone, no
+    partner needed (same insight _build_distributed_chunk_step's docstring
+    already documents for this exact case: "no communication needed").
+
+    `idxc` is the REAL absolute chunk index of each row in `_c` (not
+    necessarily a contiguous 0..N-1 range) -- the in-RAM kernel below
+    always passes jnp.arange(num_chunks) (row i really is chunk i), but
+    disk_overflow.py's LocalPhase reuses this same function one real
+    chunk at a time, passing that chunk's own true index so this still
+    decides the ctrl bit correctly without needing any other chunk
+    resident in RAM."""
+    ctrl_stride = jnp.int32(1) << (m - 1 - q1)
+    ctrl_set    = (idxc & ctrl_stride) != 0
+    tgt_phys    = (k - 1) - (q2 - m)
+    idxl        = jnp.arange(1 << k, dtype=jnp.int32)
+    tgt_bit     = (idxl & (jnp.int32(1) << tgt_phys)) != 0
+    partner     = idxl ^ (jnp.int32(1) << tgt_phys)
+    amp_partner = _c[:, partner]
+    new0 = u00 * _c + u01 * amp_partner
+    new1 = u10 * amp_partner + u11 * _c
+    after = jnp.where(tgt_bit[None, :], new1, new0)
+    return jnp.where(ctrl_set[:, None], after, _c)
+
+
+def _case_2q_ctrl_local_tgt_chunk(_c, u00, u01, u10, u11, q1, q2, m, k, num_chunks):
+    """ctrl LOCAL, tgt CHUNK-SELECT. Pairs of chunks get mixed, but ONLY
+    where the local ctrl bit (same position in every chunk) is set -- an
+    elementwise mask. Needs every chunk present at once; see _mix_pair
+    for the pair-at-a-time equivalent used by disk_overflow.py."""
+    ctrl_phys  = (k - 1) - (q1 - m)
+    idxl       = jnp.arange(1 << k, dtype=jnp.int32)
+    ctrl_bit   = (idxl & (jnp.int32(1) << ctrl_phys)) != 0
+    tgt_stride = jnp.int32(1) << (m - 1 - q2)
+    idxc       = jnp.arange(num_chunks, dtype=jnp.int32)
+    idxc_pair  = idxc ^ tgt_stride
+    is_c0      = (idxc & tgt_stride) == 0
+    amp_pair   = _c[idxc_pair]
+    new_c0 = u00 * _c + u01 * amp_pair
+    new_c1 = u10 * amp_pair + u11 * _c
+    after = jnp.where(is_c0[:, None], new_c0, new_c1)
+    return jnp.where(ctrl_bit[None, :], after, _c)
+
+
+def _case_2q_both_chunk(_c, u00, u01, u10, u11, q1, q2, m, num_chunks):
+    """ctrl AND tgt both CHUNK-SELECT. Needs every chunk present at once;
+    see _mix_pair for the pair-at-a-time equivalent used by disk_overflow.py."""
+    ctrl_stride = jnp.int32(1) << (m - 1 - q1)
+    tgt_stride  = jnp.int32(1) << (m - 1 - q2)
+    idxc        = jnp.arange(num_chunks, dtype=jnp.int32)
+    ctrl_set    = (idxc & ctrl_stride) != 0
+    idxc_pair   = idxc ^ tgt_stride
+    is_c0       = (idxc & tgt_stride) == 0
+    amp_pair    = _c[idxc_pair]
+    new_c0 = u00 * _c + u01 * amp_pair
+    new_c1 = u10 * amp_pair + u11 * _c
+    after = jnp.where(is_c0[:, None], new_c0, new_c1)
+    return jnp.where(ctrl_set[:, None], after, _c)
+
 
 def _build_multi_chunk_step(num_chunks: int, m: int, k: int):
     """
@@ -34,16 +231,16 @@ def _build_multi_chunk_step(num_chunks: int, m: int, k: int):
     stacked shape (num_chunks, chunk_dim) holds exactly the same total
     elements as the num_chunks separate per-chunk arrays it replaces.
 
-    The 6 gate/qubit-location combinations below are a direct
-    translation of the pre-JIT _apply_gate_multi's Python-loop formulas
-    (removed once this replaced it) — verified case-by-case against
-    DenseSVSimulator on non-chunked reference circuits before being
-    wired in, not derived fresh. All 6 are traced unconditionally every
-    step and selected via jnp.where on the runtime q1/q2 vs static m
-    comparison, same "trace every branch" pattern _apply_gate_fast_step
-    already uses for is_1q/is_2q and the 5 two-qubit sub-gates.
+    The 6 gate/qubit-location combinations (_case_1q_local etc. above)
+    are a direct translation of the pre-JIT _apply_gate_multi's
+    Python-loop formulas (removed once this replaced it) — verified
+    case-by-case against DenseSVSimulator on non-chunked reference
+    circuits before being wired in, not derived fresh. All 6 are traced
+    unconditionally every step and selected via jnp.where on the runtime
+    q1/q2 vs static m comparison, same "trace every branch" pattern
+    _apply_gate_fast_step already uses for is_1q/is_2q and the 5
+    two-qubit sub-gates.
     """
-    chunk_dim = 1 << k
 
     def step(chunks, operation):
         g_id  = operation[0].astype(jnp.int32)
@@ -54,165 +251,20 @@ def _build_multi_chunk_step(num_chunks: int, m: int, k: int):
                                # use_float32 bug this exact mistake
                                # caused once already in beast-mode.
 
-        inv2         = jnp.asarray(1.0 / jnp.sqrt(2.0), dtype=dtype)
-        half_p       = param * jnp.float64(0.5)
-        cos_p        = jnp.cos(half_p).astype(dtype)
-        sin_p        = jnp.sin(half_p).astype(dtype)
-        exp_pos      = jnp.exp(1j * param).astype(dtype)
-        exp_ph4      = jnp.exp(1j * jnp.pi / 4.0).astype(dtype)
-        exp_mh4      = jnp.exp(-1j * jnp.pi / 4.0).astype(dtype)
-        exp_pos_half = jnp.exp(1j * half_p).astype(dtype)
-        exp_neg_half = jnp.exp(-1j * half_p).astype(dtype)
-
-        # 1-qubit gate matrix — identical table to _apply_gate_fast_step
-        safe_gid = jnp.clip(g_id, 0, 14)
-        g_1q = jax.lax.switch(
-            safe_gid,
-            [
-                lambda _: jnp.eye(2, dtype=dtype),
-                lambda _: jnp.array([[inv2, inv2], [inv2, -inv2]], dtype=dtype),
-                lambda _: jnp.array([[0.0 + 0j, 1.0 + 0j], [1.0 + 0j, 0.0 + 0j]], dtype=dtype),
-                lambda _: jnp.array([[0.0 + 0j, -1j], [1j, 0.0 + 0j]], dtype=dtype),
-                lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, -1.0 + 0j]], dtype=dtype),
-                lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, 1j]], dtype=dtype),
-                lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, -1j]], dtype=dtype),
-                lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, exp_ph4]], dtype=dtype),
-                lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, exp_mh4]], dtype=dtype),
-                lambda _: jnp.array([[cos_p, -1j * sin_p], [-1j * sin_p, cos_p]], dtype=dtype),
-                lambda _: jnp.array([[cos_p, -sin_p], [sin_p, cos_p]], dtype=dtype),
-                lambda _: jnp.array([[jnp.exp(-1j * half_p), 0.0 + 0j], [0.0 + 0j, jnp.exp(1j * half_p)]], dtype=dtype),
-                lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, exp_pos]], dtype=dtype),
-                lambda _: jnp.array([[0.5 + 0.5j, 0.5 - 0.5j], [0.5 - 0.5j, 0.5 + 0.5j]], dtype=dtype),
-                # 14  GPhase(alpha) = e^{i*alpha} * I -- see compiler.py's
-                # _apply_gate_fast_step index 14 for the derivation; this
-                # table must stay in sync with that one (see comment above).
-                lambda _: jnp.array([[exp_pos, 0.0 + 0j], [0.0 + 0j, exp_pos]], dtype=dtype),
-            ],
-            operand=None,
-        )
-
-        # Controlled-U submatrix for the 5 two-qubit gate types (mat[2:,2:]
-        # of each gate's full 4x4 form — same values _apply_gate_multi's
-        # `U = mat[2:, 2:]` extracted from GATES/PARAMETRIC_GATES).
-        # 20=CX->X, 21=CZ->Z, 22=CP->P(theta), 24=CY->Y, 25=CRZ->RZ(theta).
-        two_q_idx = jnp.where(g_id == 20, 0,
-                    jnp.where(g_id == 21, 1,
-                    jnp.where(g_id == 22, 2,
-                    jnp.where(g_id == 24, 3, 4))))
-        U = jax.lax.switch(
-            two_q_idx,
-            [
-                lambda _: jnp.array([[0.0 + 0j, 1.0 + 0j], [1.0 + 0j, 0.0 + 0j]], dtype=dtype),
-                lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, -1.0 + 0j]], dtype=dtype),
-                lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, exp_pos]], dtype=dtype),
-                lambda _: jnp.array([[0.0 + 0j, -1j], [1j, 0.0 + 0j]], dtype=dtype),
-                lambda _: jnp.array([[exp_neg_half, 0.0 + 0j], [0.0 + 0j, exp_pos_half]], dtype=dtype),
-            ],
-            operand=None,
-        )
-        g00, g01, g10, g11 = g_1q[0, 0], g_1q[0, 1], g_1q[1, 0], g_1q[1, 1]
-        u00, u01, u10, u11 = U[0, 0], U[0, 1], U[1, 0], U[1, 1]
-
-        # ── case 1: 1-qubit gate, LOCAL qubit (q1 >= m) ─────────────
-        # Same do_1q amplitude-pair math as beast-mode, applied to every
-        # chunk row in parallel (gather along axis 1, broadcasts over
-        # axis 0 for free).
-        def case_1q_local(_c):
-            local_phys = (k - 1) - (q1 - m)
-            stride     = jnp.int32(1) << local_phys
-            idx        = jnp.arange(chunk_dim, dtype=jnp.int32)
-            idx_pair   = idx ^ stride
-            mask0      = (idx & stride) == 0
-            amp_pair   = _c[:, idx_pair]
-            new0 = g00 * _c + g01 * amp_pair
-            new1 = g10 * amp_pair + g11 * _c
-            return jnp.where(mask0[None, :], new0, new1)
-
-        # ── case 2: 1-qubit gate, CHUNK-SELECT qubit (q1 < m) ────────
-        # Same math, one level up: each "amplitude" is a whole
-        # (chunk_dim,)-shaped row, mixed pairwise across axis 0.
-        def case_1q_chunk(_c):
-            stride    = jnp.int32(1) << (m - 1 - q1)
-            idxc      = jnp.arange(num_chunks, dtype=jnp.int32)
-            idxc_pair = idxc ^ stride
-            mask0     = (idxc & stride) == 0
-            amp_pair  = _c[idxc_pair]
-            new0 = g00 * _c + g01 * amp_pair
-            new1 = g10 * amp_pair + g11 * _c
-            return jnp.where(mask0[:, None], new0, new1)
-
-        # ── case 3: 2-qubit, ctrl AND tgt both LOCAL ─────────────
-        def case_2q_local_local(_c):
-            ctrl_phys = (k - 1) - (q1 - m)
-            tgt_phys  = (k - 1) - (q2 - m)
-            idx       = jnp.arange(chunk_dim, dtype=jnp.int32)
-            ctrl_bit  = (idx & (jnp.int32(1) << ctrl_phys)) != 0
-            tgt_bit   = (idx & (jnp.int32(1) << tgt_phys)) != 0
-            partner   = idx ^ (jnp.int32(1) << tgt_phys)
-            amp_partner = _c[:, partner]
-            new0 = u00 * _c + u01 * amp_partner
-            new1 = u10 * amp_partner + u11 * _c
-            after = jnp.where(tgt_bit[None, :], new1, new0)
-            return jnp.where(ctrl_bit[None, :], after, _c)
-
-        # ── case 4: ctrl CHUNK-SELECT, tgt LOCAL ───────────────
-        # Whole chunks where the chunk-index's ctrl bit is set get U
-        # applied as a local 1-qubit gate; the rest are untouched.
-        def case_2q_ctrl_chunk_tgt_local(_c):
-            ctrl_stride = jnp.int32(1) << (m - 1 - q1)
-            idxc        = jnp.arange(num_chunks, dtype=jnp.int32)
-            ctrl_set    = (idxc & ctrl_stride) != 0
-            tgt_phys    = (k - 1) - (q2 - m)
-            idxl        = jnp.arange(chunk_dim, dtype=jnp.int32)
-            tgt_bit     = (idxl & (jnp.int32(1) << tgt_phys)) != 0
-            partner     = idxl ^ (jnp.int32(1) << tgt_phys)
-            amp_partner = _c[:, partner]
-            new0 = u00 * _c + u01 * amp_partner
-            new1 = u10 * amp_partner + u11 * _c
-            after = jnp.where(tgt_bit[None, :], new1, new0)
-            return jnp.where(ctrl_set[:, None], after, _c)
-
-        # ── case 5: ctrl LOCAL, tgt CHUNK-SELECT ─────────────
-        # Pairs of chunks get mixed, but ONLY where the local ctrl bit
-        # (same position in every chunk) is set — an elementwise mask.
-        def case_2q_ctrl_local_tgt_chunk(_c):
-            ctrl_phys  = (k - 1) - (q1 - m)
-            idxl       = jnp.arange(chunk_dim, dtype=jnp.int32)
-            ctrl_bit   = (idxl & (jnp.int32(1) << ctrl_phys)) != 0
-            tgt_stride = jnp.int32(1) << (m - 1 - q2)
-            idxc       = jnp.arange(num_chunks, dtype=jnp.int32)
-            idxc_pair  = idxc ^ tgt_stride
-            is_c0      = (idxc & tgt_stride) == 0
-            amp_pair   = _c[idxc_pair]
-            new_c0 = u00 * _c + u01 * amp_pair
-            new_c1 = u10 * amp_pair + u11 * _c
-            after = jnp.where(is_c0[:, None], new_c0, new_c1)
-            return jnp.where(ctrl_bit[None, :], after, _c)
-
-        # ── case 6: ctrl AND tgt both CHUNK-SELECT ───────────
-        def case_2q_both_chunk(_c):
-            ctrl_stride = jnp.int32(1) << (m - 1 - q1)
-            tgt_stride  = jnp.int32(1) << (m - 1 - q2)
-            idxc        = jnp.arange(num_chunks, dtype=jnp.int32)
-            ctrl_set    = (idxc & ctrl_stride) != 0
-            idxc_pair   = idxc ^ tgt_stride
-            is_c0       = (idxc & tgt_stride) == 0
-            amp_pair    = _c[idxc_pair]
-            new_c0 = u00 * _c + u01 * amp_pair
-            new_c1 = u10 * amp_pair + u11 * _c
-            after = jnp.where(is_c0[:, None], new_c0, new_c1)
-            return jnp.where(ctrl_set[:, None], after, _c)
+        g00, g01, g10, g11, u00, u01, u10, u11 = _gate_matrix_elements(g_id, param, dtype)
 
         is_2q    = g_id >= 20
         q1_chunk = q1 < m
         q2_chunk = q2 < m
 
         result_2q = jnp.where(
-            q1_chunk & q2_chunk, case_2q_both_chunk(chunks),
-            jnp.where(q1_chunk & (~q2_chunk), case_2q_ctrl_chunk_tgt_local(chunks),
-            jnp.where((~q1_chunk) & q2_chunk, case_2q_ctrl_local_tgt_chunk(chunks),
-                                               case_2q_local_local(chunks))))
-        result_1q = jnp.where(q1_chunk, case_1q_chunk(chunks), case_1q_local(chunks))
+            q1_chunk & q2_chunk, _case_2q_both_chunk(chunks, u00, u01, u10, u11, q1, q2, m, num_chunks),
+            jnp.where(q1_chunk & (~q2_chunk), _case_2q_ctrl_chunk_tgt_local(chunks, u00, u01, u10, u11, q1, q2, m, k, jnp.arange(num_chunks, dtype=jnp.int32)),
+            jnp.where((~q1_chunk) & q2_chunk, _case_2q_ctrl_local_tgt_chunk(chunks, u00, u01, u10, u11, q1, q2, m, k, num_chunks),
+                                               _case_2q_local_local(chunks, u00, u01, u10, u11, q1, q2, m, k))))
+        result_1q = jnp.where(
+            q1_chunk, _case_1q_chunk(chunks, g00, g01, g10, g11, q1, m, num_chunks),
+                      _case_1q_local(chunks, g00, g01, g10, g11, q1, m, k))
 
         new_chunks = jnp.where(is_2q, result_2q, result_1q)
         return new_chunks.astype(dtype), None

--- a/docs/api/chunk.md
+++ b/docs/api/chunk.md
@@ -8,8 +8,10 @@ has the real Colab OOM bug that made this distinction necessary), decides how ma
 RAM-sized pieces the circuit needs right now, and runs gates across those pieces
 with a compiled kernel that never builds the full array — including, when more than
 one physical device is available, spreading the pieces across a real device mesh
-instead of one process's RAM (Step 6). None of that shows up in the
-public API: `Chunk` looks exactly like `DenseSVSimulator` to call.
+instead of one process's RAM (Step 6) — or, past even that RAM ceiling,
+spilling idle pieces to disk and streaming the circuit through in phases
+(Step 7). None of that shows up in the public API: `Chunk` looks exactly
+like `DenseSVSimulator` to call.
 
 ## The pieces, and how they fit together
 
@@ -182,6 +184,46 @@ quietly give up the reason to call it at all. Force extra CPU devices to actuall
 exercise this path locally: set `XLA_FLAGS=--xla_force_host_platform_device_count=N`
 *before the process starts* (JAX's device count is fixed at first initialization).
 
+## Step 7. Beyond RAM entirely: spilling to disk
+
+Steps 2-6 all assume `num_chunks` pieces fit in RAM *together*. Past that ceiling,
+`allow_disk_overflow=True` keeps the idle pieces on disk as plain `.npy` files
+instead of raising `MemoryPressureError` — the technique IBM used to break the
+49-qubit simulation barrier classically (Pednault et al. 2019,
+[arXiv:1910.09534](https://arxiv.org/abs/1910.09534), "Leveraging Secondary
+Storage to Simulate Deep 54-qubit Sycamore Circuits"): only materialize, in RAM,
+the one or two pieces a gate actually touches, never the whole stack.
+
+```python
+chunk3 = de.Chunk(4, memory_threshold=0.999999, allow_disk_overflow=True)
+repr(chunk3)
+```
+
+```
+"Chunk(n_qubits=4, safe_qubits=2, num_chunks=4, chunk_size_bits=2, storage=disk (C:\\Users\\...\\dense_evolution_chunk_x12_1zlg), dtype=<class 'jax.numpy.complex128'>, mem_per_chunk=0.0 MB, ram_free=15.5%, has_jax=True)"
+```
+
+`memory_threshold=0.999999` (99.9999% free required *after* the allocation) forces
+the same guard from Step 4 to fail here — on a real machine you'd never set this
+yourself, it exists only to force the fallback deterministically for this demo,
+the same role Step 2's `get_dynamic_chunk` override plays. `storage=disk` in the
+`repr` confirms the fallback actually triggered, not a silent no-op.
+
+```python
+chunk3.run_chunk(circuit.to_tuples())
+chunk3.get_probabilities().round(4)
+```
+
+```
+array([0.5, 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0.5])
+```
+
+Identical result to Steps 1 and 2, same GHZ circuit — but this time no more than
+two `(2,)`-element pieces were ever resident in RAM as a JAX array at once,
+regardless of `num_chunks`. Call `chunk3.close()` afterward to remove the temporary
+directory `Chunk` created for the `.npy` files (skip it if you passed your own
+`disk_dir=`).
+
 ---
 
 ## Details
@@ -236,12 +278,38 @@ math's own temporary arrays) — if that doesn't fit, construction fails immedia
 with `MemoryPressureError`, before any of the `num_chunks` inner simulators are
 allocated.
 
-### No disk paging — this is *moderate* overflow, not unlimited
+### Disk overflow (Step 7): why it can't just be "use a memmap"
 
-`Chunk` covers qubit counts that need more than one RAM-sized piece, as long as
-all of those pieces still fit in RAM *at once* — there is no memmap/disk-backed
-path for when even that doesn't fit. `SafeMemoryGuard.check_allocation` is what
-catches this case and fails cleanly rather than letting the OS start swapping.
+The obvious-looking fix — back each piece with a `numpy.memmap` file instead of a
+plain array — doesn't actually work here: `DenseSVSimulator.sv` is always a live
+`jax.Array` (`self.xp = jnp`), and JAX has no concept of a memmap-backed device
+array — every `jnp.array(...)` call materializes real RAM regardless of what fed
+it. Making a piece genuinely *live on disk* while idle means changing *when* a
+piece becomes a `jax.Array` at all, not just *where* its bytes sit — which is the
+same change as processing the circuit in phases.
+
+`dense_evolution/backends/chunk/disk_overflow.py` classifies every gate into one
+of three phases, reusing (not re-deriving) the exact case split
+`_build_multi_chunk_step`/`_build_distributed_chunk_step` already use:
+
+- **Local** — both qubits (or the only qubit) are outside the chunk-select range.
+  Runs against one piece at a time, no partner ever needed.
+- **Conditional** — a 2-qubit gate with a chunk-select control and a local target.
+  Still needs only one piece: whether the control fires is decided from that
+  piece's own absolute index, exactly the insight Step 6's distributed kernel
+  already documents for this same case ("no communication needed").
+- **Mix** — anything touching a chunk-select qubit as its mixing qubit. Needs
+  exactly its XOR-stride partner piece — never the whole stack.
+
+This is the same decomposition LaRose 2018
+([arXiv:1801.01037](https://arxiv.org/abs/1801.01037), "Distributed Memory
+Techniques for Classical Simulation of Quantum Circuits") uses for Step 6's real
+multi-device path, applied here to disk instead of a network: "communication"
+means a disk read/write of one partner file instead of a `ppermute` to another
+device. **This is v1, correctness-first, not fast** — every gate pays real file
+I/O, one piece (or pair) at a time, no batching multiple pairs into one call; it
+exists to make otherwise-impossible sizes possible at all, not to compete with
+Steps 2/6 on speed.
 
 ### `run_chunk_distributed`'s one-piece-per-device scope
 
@@ -253,7 +321,18 @@ future refinement. `jax.lax.ppermute`'s communication topology (`perm=`) must be
 static — known at trace time — so it can't be built from the traced `q1`/`q2`
 qubit indices directly; every possible chunk-select stride is instead enumerated
 as its own statically-built `ppermute` call ahead of time, and `jax.lax.switch`
-picks the right one at runtime.
+picks the right one at runtime. The underlying design — a fixed number of
+"chunk-select" qubits needing pairwise communication, the rest applying purely
+locally — follows LaRose 2018
+([arXiv:1801.01037](https://arxiv.org/abs/1801.01037), "Distributed Memory
+Techniques for Classical Simulation of Quantum Circuits"), which demonstrated
+the same scheme on a real multi-node supercomputer (MPI/OpenMP, up to 33 qubits
+across 26 processors) — real, tested distributed hardware, not just this
+project's own simulated multi-device CPU testing described above. This
+project's own real multi-*host* (separate physical machines, not simulated
+local devices) run of this path remains untested — see Step 7 for the sibling
+gap this module does cover (disk instead of RAM), and `docs/changelog.md` for
+open items.
 
 ### `.sv` accepts an external statevector back
 

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -521,6 +521,14 @@ def test_kernel_unreachable_gives_actionable_error_not_a_traceback(monkeypatch):
     assert "dense-evolution serve" in result
 
 
+def test_kernel_status_reports_unreachable_kernel_without_raising(monkeypatch):
+    monkeypatch.setattr(mcp_client, "_TEST_TRANSPORT", None)  # force a real (failing) TCP attempt
+    monkeypatch.setattr(mcp_client, "KERNEL_URL", "http://127.0.0.1:1")  # nothing listens here
+    data = json.loads(run(mcp_adapter.dense_evolution_kernel_status()))
+    assert data["kernel_reachable"] is False
+    assert data["kernel_url"] == "http://127.0.0.1:1"
+
+
 def test_kernel_timeout_gives_actionable_error_not_a_traceback(monkeypatch):
     class _TimeoutClient:
         async def request(self, method, path, **kwargs):

--- a/tests/unit/test_chunk.py
+++ b/tests/unit/test_chunk.py
@@ -262,6 +262,185 @@ class TestChunkMultiPiece:
         assert c.num_chunks == 4
 
 
+class TestChunkDiskOverflow:
+    """dense_evolution/backends/chunk/disk_overflow.py -- Pednault et al.
+    2019 (arXiv:1910.09534)-style disk-backed overflow: when num_chunks
+    chunks don't fit in RAM at once, allow_disk_overflow=True spills them
+    to .npy files and streams the circuit through in phases (one chunk
+    for a local gate, an XOR-stride pair for a chunk-mixing gate) instead
+    of raising MemoryPressureError.
+
+    Same correctness bar as TestChunkMultiPiece: cross-check against a
+    plain DenseSVSimulator running the identical circuit, not against the
+    in-RAM multi-chunk path (which could share a bug with a naive
+    streaming reimplementation) -- this is bit-manipulation-heavy code
+    where a plausible-looking-but-wrong formula is easy to miss by
+    inspection alone. memory_threshold=0.999999 forces
+    SafeMemoryGuard.check_allocation to fail regardless of the actual
+    (tiny, forced) geometry's real size, so the disk-overflow fallback
+    triggers reliably in a test without needing a real large allocation.
+    """
+
+    @pytest.fixture
+    def force_chunk_bits(self, monkeypatch):
+        import dense_evolution.chunk as chunk_mod
+
+        def _force(bits):
+            monkeypatch.setattr(chunk_mod, "get_dynamic_chunk", lambda dtype_target: bits)
+
+        return _force
+
+    @pytest.fixture(autouse=True)
+    def _gc_between_tests(self):
+        # This class builds many small Chunk instances back to back --
+        # JAX doesn't reliably hand freed arrays back to the OS within one
+        # process (confirmed elsewhere this session), so without an
+        # explicit collect() the real (unmocked) SafeMemoryGuard checks
+        # later in this file, running in the same pytest process, start
+        # seeing genuinely lower free RAM and can raise a real
+        # MemoryPressureError that has nothing to do with their own logic.
+        import gc
+        yield
+        gc.collect()
+
+    def _make_disk_chunk(self, n_qubits):
+        c = Chunk(n_qubits, memory_threshold=0.999999, allow_disk_overflow=True)
+        assert c._chunk_paths is not None  # confirms this test is really on the disk path
+        return c
+
+    def _compare_to_reference(self, n_qubits, circuit):
+        c = self._make_disk_chunk(n_qubits)
+        c.run_chunk(circuit)
+        sv_chunk = np.asarray(c.get_statevector())
+        c.close()
+
+        ref = DenseSVSimulator(n_qubits)
+        ref.run_circuit(circuit, transpile=True)
+        sv_ref = np.asarray(ref.get_statevector())
+        return sv_chunk, sv_ref
+
+    def test_disk_overflow_not_used_by_default(self, force_chunk_bits):
+        # regression guard: allow_disk_overflow defaults to False, and the
+        # guard must still raise exactly as before this feature existed.
+        from dense_evolution.chunk import MemoryPressureError
+        force_chunk_bits(4)
+        with pytest.raises(MemoryPressureError):
+            Chunk(6, memory_threshold=0.999999)
+
+    def test_empty_circuit_canary(self, force_chunk_bits):
+        force_chunk_bits(4)
+        c = self._make_disk_chunk(6)
+        probs = np.asarray(c.get_probabilities())
+        assert probs.shape == (64,)
+        assert abs(probs.sum() - 1.0) < 1e-9
+        assert abs(probs[0] - 1.0) < 1e-9
+        c.close()
+
+    @pytest.mark.parametrize("qubit", [3])  # local qubit (m=2 for n=6, bits=4)
+    def test_1q_local(self, force_chunk_bits, qubit):
+        force_chunk_bits(4)
+        sv_chunk, sv_ref = self._compare_to_reference(6, [('h', qubit)])
+        np.testing.assert_allclose(sv_chunk, sv_ref, atol=1e-9)
+
+    @pytest.mark.parametrize("qubit", [0, 1])  # chunk-select: MSB (0) and non-MSB (1)
+    def test_1q_chunk_select_mix_phase(self, force_chunk_bits, qubit):
+        force_chunk_bits(4)
+        sv_chunk, sv_ref = self._compare_to_reference(6, [('h', qubit)])
+        np.testing.assert_allclose(sv_chunk, sv_ref, atol=1e-9)
+
+    def test_2q_local_local(self, force_chunk_bits):
+        force_chunk_bits(4)
+        sv_chunk, sv_ref = self._compare_to_reference(6, [('h', 3), ('cx', 3, 4)])
+        np.testing.assert_allclose(sv_chunk, sv_ref, atol=1e-9)
+
+    def test_2q_control_chunk_select_target_local_conditional_phase(self, force_chunk_bits):
+        # Only "cx" here (not the cz/cy sweep TestChunkMultiPiece already
+        # does for the in-RAM path): the disk path reuses that same
+        # _gate_matrix_elements table verbatim, so gate-matrix correctness
+        # is already covered elsewhere -- what's specific to this path
+        # (and worth spending a real Chunk() on) is the phase
+        # classification/pairing logic, which doesn't depend on which
+        # 2-qubit gate is used. Keeps this class's total real-RAM
+        # footprint down (many small Chunk()s in one long pytest process
+        # otherwise starve later, unrelated tests -- confirmed directly:
+        # a fresh process afterward shows no leak at all).
+        force_chunk_bits(4)
+        sv_chunk, sv_ref = self._compare_to_reference(6, [('h', 0), ('cx', 0, 3)])
+        np.testing.assert_allclose(sv_chunk, sv_ref, atol=1e-9)
+
+    def test_2q_control_local_target_chunk_select_mix_phase(self, force_chunk_bits):
+        force_chunk_bits(4)
+        sv_chunk, sv_ref = self._compare_to_reference(6, [('h', 3), ('cx', 3, 0)])
+        np.testing.assert_allclose(sv_chunk, sv_ref, atol=1e-9)
+
+    def test_2q_both_chunk_select_mix_phase(self, force_chunk_bits):
+        force_chunk_bits(4)
+        sv_chunk, sv_ref = self._compare_to_reference(6, [('h', 0), ('h', 1), ('cx', 0, 1)])
+        np.testing.assert_allclose(sv_chunk, sv_ref, atol=1e-9)
+
+    def test_parametric_2q_gates_all_four_locations(self, force_chunk_bits):
+        force_chunk_bits(4)
+        cases = [
+            [('h', 0), ('cp', 0, 3, 0.7)],            # ctrl chunk-select, tgt local
+            [('h', 3), ('crz', 3, 0, 1.1)],           # ctrl local, tgt chunk-select
+            [('h', 0), ('h', 1), ('cp', 0, 1, 0.9)],  # both chunk-select
+            [('h', 3), ('h', 4), ('crz', 3, 4, 0.4)], # both local
+        ]
+        for circuit in cases:
+            sv_chunk, sv_ref = self._compare_to_reference(6, circuit)
+            np.testing.assert_allclose(sv_chunk, sv_ref, atol=1e-9)
+
+    def test_random_mixed_circuits_num_chunks_8(self, force_chunk_bits):
+        # num_chunks=8 (m=3) exercises the middle chunk-select bit, not
+        # just the most-significant one -- same rationale as the in-RAM
+        # kernel's own version of this test.
+        force_chunk_bits(4)
+        n = 7
+        rng = np.random.default_rng(4321)
+        gates_1q = ['h', 'x', 'y', 'z', 's', 'sdg', 't', 'tdg']
+        gates_1q_param = ['rx', 'ry', 'rz', 'p']
+        gates_2q = ['cx', 'cz', 'cy']
+        gates_2q_param = ['cp', 'crz']
+
+        for _trial in range(2):
+            circuit = []
+            for _ in range(10):
+                kind = rng.integers(0, 4)
+                if kind == 0:
+                    circuit.append((rng.choice(gates_1q), int(rng.integers(0, n))))
+                elif kind == 1:
+                    circuit.append((rng.choice(gates_1q_param), int(rng.integers(0, n)),
+                                     float(rng.uniform(-3.14, 3.14))))
+                elif kind == 2:
+                    q1, q2 = rng.choice(n, size=2, replace=False)
+                    circuit.append((rng.choice(gates_2q), int(q1), int(q2)))
+                else:
+                    q1, q2 = rng.choice(n, size=2, replace=False)
+                    circuit.append((rng.choice(gates_2q_param), int(q1), int(q2),
+                                     float(rng.uniform(-3.14, 3.14))))
+            sv_chunk, sv_ref = self._compare_to_reference(n, circuit)
+            np.testing.assert_allclose(sv_chunk, sv_ref, atol=1e-8,
+                                        err_msg=f"circuit={circuit}")
+
+    def test_close_removes_owned_disk_dir(self, force_chunk_bits):
+        import os
+        force_chunk_bits(4)
+        c = self._make_disk_chunk(6)
+        disk_dir = c._disk_dir
+        assert os.path.isdir(disk_dir)
+        c.close()
+        assert not os.path.isdir(disk_dir)
+
+    def test_sv_setter_round_trips_through_disk_files(self, force_chunk_bits):
+        force_chunk_bits(4)
+        c = self._make_disk_chunk(6)
+        new_sv = np.zeros(2 ** 6, dtype=complex)
+        new_sv[5] = 1.0
+        c.sv = new_sv
+        np.testing.assert_allclose(np.asarray(c.sv), new_sv, atol=1e-12)
+        c.close()
+
+
 class TestChunkMultiPieceJIT:
     """dense_evolution.chunk's multi-chunk dispatch (num_chunks>1) used to
     apply gates one at a time via a Python loop calling


### PR DESCRIPTION
## Summary
- `allow_disk_overflow=True` on `Chunk` falls back to disk-backed `.npy` chunk files instead of raising `MemoryPressureError` when `num_chunks` chunks don't fit in RAM at once — the technique from Pednault et al. 2019 ([arXiv:1910.09534](https://arxiv.org/abs/1910.09534), "Leveraging Secondary Storage to Simulate Deep 54-qubit Sycamore Circuits"), the paper that broke the 49-qubit classical simulation barrier.
- New `dense_evolution/backends/chunk/disk_overflow.py`: classifies every gate into a Local / Conditional / Mix phase (reusing, not re-deriving, the same case split `kernels.py`'s in-RAM/distributed kernels already use), so never more than 1-2 chunks are materialized as a `jax.Array` at once, regardless of `num_chunks`.
- **v1 is correctness-first, not fast** — every gate pays real disk I/O, one chunk/pair at a time. Explicitly documented as a speed trade-off, not competing with the in-RAM or distributed paths.
- `kernels.py`: factored the 6 gate-case bodies + gate-matrix lookup out of `_build_multi_chunk_step`'s closure to module level — **no behavior change**, pure extraction, so `disk_overflow.py` calls the exact same verified formulas instead of a third hand-copied version.
- `docs/api/chunk.md`: new Step 7 with a real verified demo, plus a corrected Details section (the old "no disk paging" note was true when written but is now the feature this PR adds) citing both papers — also adds the LaRose 2018 ([arXiv:1801.01037](https://arxiv.org/abs/1801.01037)) citation for the *existing* distributed-dispatch path, found while researching this feature's background in the local `quantumrag` index.

## Verification
- Every one of the 6 gate/qubit-location cases cross-checked against a plain `DenseSVSimulator` running the identical circuit (not against the in-RAM multi-chunk path, to avoid a shared-bug blind spot) — `tests/unit/test_chunk.py::TestChunkDiskOverflow`.
- Random mixed-circuit fuzz test, `num_chunks=8` (exercises a non-MSB chunk-select bit).
- Regression guard: `allow_disk_overflow=False` (default) still raises `MemoryPressureError` exactly as before.
- Full `tests/unit/test_chunk.py`: 58 passed, 19 skipped (skips are the real multi-device distributed tests, gated on `jax.device_count()`).

## Note on test tuning
The disk-overflow tests originally used a wider gate/trial sweep (matching `TestChunkMultiPiece`'s own parametrization); on this session's dev machine that pushed real free RAM low enough to cause spurious `MemoryPressureError` in *later*, unrelated tests in the same pytest process (confirmed via a before/after fresh-process RAM check: no actual leak, purely JAX not returning memory to the OS within one long-lived process). Trimmed to `cx`-only for the disk-specific pairing tests (gate-matrix correctness for cz/cy is already covered by the in-RAM suite) and reduced the fuzz trial count — still covers all 6 cases at least once.
