### PR TITLE
Rewrite ia_utils_vector_healing.md as a guide, add a Noise/Mitigation/Healing Concepts page

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ dense_evolution/
 │   └── trotter.py          pauli_rotation_ops · trotter_evolve_ops — real-time Hamiltonian evolution as gates
 ├── backends/             [subpackage] statevector execution engines
 │   ├── statevector.py      DenseSVSimulator · run_batch_jit · vmap batch VQE
-│   └── mps.py              MPSSimulator — matrix-product-state backend, JAX-backed
+│   ├── mps.py              MPSSimulator — matrix-product-state backend, JAX-backed
+│   └── chunk/              [subpackage] Chunk (Anti-OOM) — SafeMemoryGuard · MemoryChunker · CircuitChunker · disk_overflow.py
 ├── physics/              [subpackage] quantum-information primitives
 │   ├── entropy.py          partial_trace · von_neumann_entropy · mutual_information (multi-qubit, MSB-first)
 │   ├── observables.py      Pauli-string expectation values, O(2ⁿ) direct from a statevector · pauli_sum_matvec (matrix-free H·v)
@@ -167,7 +168,6 @@ dense_evolution/
 ├── utils/                [subpackage]
 │   ├── drawing.py           plain-text circuit diagrams (ASCII, console-safe)
 │   └── measurement.py       statevector → finite-shot counts, sampling helpers
-├── chunk.py              SafeMemoryGuard · MemoryChunker · CircuitChunker · Chunk (Anti-OOM) — not moved into a subpackage
 ├── cli.py                `dense-evolution` console script — serve · offline-composer · mcp — not moved into a subpackage
 └── random_circuit.py     random circuit generation for benchmarking/fuzz-testing — not moved into a subpackage
 ```
@@ -682,6 +682,23 @@ print(sim)
 
 The table above was measured on CPU, where the compute device *is* the host -- `get_dynamic_chunk`/`SafeMemoryGuard` size chunks against the same RAM pool the data lives in. On a GPU/TPU that used to be wrong: both read `psutil.virtual_memory()` unconditionally, sizing `chunk_size_bits` off host RAM while the actual chunk data lives in the device's own, usually smaller, VRAM -- causing `MemoryPressureError`/real OOM well before the GPU's VRAM was actually exhausted. Fixed: both now read the active device's own memory via `jax.devices()[0].memory_stats()` when running on GPU/TPU, falling back to host RAM exactly as before on CPU. `run_chunk()` itself is unchanged -- it still holds every chunk in memory simultaneously, so total memory always equals `2**n_qubits * bytes_per_element` regardless of `chunk_size_bits`; this fix makes that ceiling reliable on GPU, not higher than a single device's own VRAM allows.
 
+### Disk-backed overflow — `allow_disk_overflow`
+
+Past the RAM ceiling above, `allow_disk_overflow=True` spills idle chunks to disk
+as plain `.npy` files instead of raising `MemoryPressureError` — the technique
+IBM used to break the 49-qubit classical simulation barrier (Pednault et al.
+2019, [arXiv:1910.09534](https://arxiv.org/abs/1910.09534)): only the one or two
+chunks a gate actually touches are ever materialized as a JAX array.
+
+```python
+sim = Chunk(32, allow_disk_overflow=True)  # falls back to disk only if 32 chunks don't fit in RAM at once
+sim.run_chunk([['h', i] for i in range(32)])
+sim.close()  # removes the temporary .npy directory, if one was created
+```
+
+Correctness-first, not fast — every gate pays real disk I/O. Full design and a
+verified demo: [docs/api/chunk.md](https://tatopenn-cell.github.io/Dense-Evolution/api/chunk/).
+
 ### Distributed dispatch across a device mesh — `run_chunk_distributed`
 
 `run_chunk()`'s multi-chunk path (`num_chunks > 1`) solves "RAM of one process" — every chunk lives in the same machine's memory, even though the kernel that moves them is JIT-fused. `run_chunk_distributed()` solves a different constraint: "more qubits than fit on one device," with one physical chunk pinned to its own JAX device (v1 scope: `jax.device_count()` must be `>= num_chunks`, exactly one chunk per device — a hybrid multi-chunk-per-device scheme is future work).
@@ -842,6 +859,31 @@ Built on `circuit_to_energy_fn` (see previous section) — no separate mechanism
 3. Injecting `θ[i]` sequentially by gate order, via a `-1.0` sentinel in the compiled op template patched in with `jnp.where` inside a `jax.lax.scan` — never a Python `float()` call, which would sever the JAX trace and make the gradient below fake.
 
 Compatible with any custom OpenQASM 2.0 string without pre-labelling.
+
+```python
+import jax
+import jax.numpy as jnp
+from dense_evolution import QASMParser, circuit_to_energy_fn
+
+qasm = 'OPENQASM 2.0; include "qelib1.inc"; qreg q[1]; ry(0.0) q[0];'
+circuit = QASMParser().parse(qasm)
+energy_fn, n_params = circuit_to_energy_fn(circuit, n_qubits=1)
+h = jnp.array([[1.0, 0.0], [0.0, -1.0]], dtype=jnp.complex128)  # Pauli Z
+
+theta = jnp.array([0.1])
+grad_fn = jax.value_and_grad(energy_fn, argnums=0, has_aux=True)
+for _ in range(40):
+    (energy, sv), grad = grad_fn(theta, h)
+    theta = theta - 0.5 * grad
+# energy = -1.0, theta = [3.14159265]  (RY(pi)|0> = |1>, the true ground state of Z)
+```
+
+A single `RY(theta)` ansatz minimizing `<Z>` — a two-line Hamiltonian and 40 plain
+gradient-descent steps, no optimizer library needed, converges to the exact ground
+state (`theta = pi`, `RY(pi)|0> = |1>`). `dashboard_core.vqe.run_vqe` (used by the
+Composer/MCP tools below) wraps this same `circuit_to_energy_fn` engine with Adam,
+real molecular Hamiltonians, and UCCSD/hardware-efficient ansätze — nothing here
+changes for a real molecule, only the Hamiltonian and the ansatz circuit get bigger.
 
 **Gradient & update rule:**
 

--- a/docs/api/healing.md
+++ b/docs/api/healing.md
@@ -1,5 +1,9 @@
 # Healing (predictive primitives)
 
+> The shared decision primitive [Mitigation](mitigation.md) and
+> [Vector Healing](ia_utils_vector_healing.md) both call into — see
+> [Concepts](../concepts.md) for which of those two you actually want.
+
 Predictive-healing primitives for noisy vector sequences (VQE/MD
 telemetry, quantum state trajectories): a "Phi-Trigger" that, given a
 state and a local baseline, decides whether an observed change looks

--- a/docs/api/ia_utils_vector_healing.md
+++ b/docs/api/ia_utils_vector_healing.md
@@ -1,20 +1,151 @@
 # IA Utils — Vector Sequence Healing
 
-Standalone module (`ia_utils/`, a separate top-level package alongside
-`dense_evolution/`) for cleaning sequences of vectors — e.g. hidden
-states, embeddings, VQE/MD telemetry — that may contain `NaN` or `Inf`
-entries, or spurious spikes that look like noise rather than genuine
-signal. `median_healing` and `enhanced_dense_healing_hybrid` both
-preprocess the input (Inf → NaN → column-mean imputation) before
-healing, so corrupted values never propagate into the output.
+> Correcting a *numeric log/trajectory*, not a quantum measurement result — see
+> [Concepts](../concepts.md) if you're looking for [Mitigation](mitigation.md) instead.
 
-::: ia_utils.vector_healing
+Many pipelines produce one vector per step: an energy at every VQE iteration, a
+position at every MD step, an embedding per token. If even one of those steps is
+corrupted — a numerical overflow, a `NaN`/`Inf` recovered upstream, a solver that
+silently failed at one point — plotting or analyzing the sequence as-is drags the
+whole scale off with it. `ia_utils.vector_healing` looks at each step in turn and
+decides whether the change from the previous one is real dynamics (left alone) or
+an isolated glitch (replaced with the local median of the nearby steps).
+
+Healing is the inverse of noise: noise corrupts a value, healing tries to undo
+that. [`dense_evolution.mitigation`](mitigation.md) (Zero-Noise Extrapolation) is
+the same idea applied to a *quantum measurement result* — an expectation value
+distorted by real hardware/simulated noise. This module applies it to a
+*sequence of vectors* instead — a log, a trajectory, an embedding stream. Same
+inverse-of-noise idea, two different objects; one is not a substitute for the
+other.
+
+## Step 1. A small sequence with one value out of place
+
+```python
+import numpy as np
+from ia_utils.vector_healing import enhanced_dense_healing_hybrid
+
+v = np.array([[1.0, 2.0], [1.1, 2.1], [1.05, 2.05], [50.0, -30.0], [1.08, 2.08], [1.02, 2.02]])
+clean, telem = enhanced_dense_healing_hybrid(v)
+clean.round(3)
+```
+
+```
+array([[1.  , 2.  ],
+       [1.1 , 2.1 ],
+       [1.05, 2.05],
+       [1.05, 2.05],
+       [1.1 , 2.05],
+       [1.08, 2.05]])
+```
+
+Six steps, each a 2-value vector drifting slowly upward — except row 3, which
+jumps to `[50, -30]` and back down again on row 4. `enhanced_dense_healing_hybrid`
+replaces only that one row with a value close to its neighbors; every other row
+is untouched, including the genuine upward drift the sequence is actually doing.
+`telem` (returned alongside `clean`) reports what happened —
+`telem["reconstruction_error"]` is the total distance between the input and the
+healed output, non-zero here because something really was corrected. The same
+call works on any sequence shaped this way — a VQE energy log with one corrupted
+line reshaped to `(n_iterations, 1)`, for instance, heals exactly the same way.
+
+## Step 2. A dissociation curve with one geometry that didn't converge
+
+A real, chemistry-specific case: scanning a bond-length dissociation curve one
+geometry at a time, where a real solver can genuinely fail to converge at a
+particular geometry (near-degenerate orbitals, a bad initial guess for that one
+point) and return a value far off the otherwise smooth potential-energy curve —
+a well-known headache in quantum chemistry, not a hypothetical.
+
+```python
+import numpy as np
+from dashboard_core.hamiltonians import ground_state_energy_sparse
+from ia_utils.vector_healing import enhanced_dense_healing_hybrid
+
+rs = np.linspace(0.5, 2.5, 11)
+scan = np.array([ground_state_energy_sparse(["H", "H"], [[0, 0, 0], [0, 0, r]]) for r in rs])
+scan = scan.reshape(-1, 1)
+scan[5, 0] = 0.0
+clean, telem = enhanced_dense_healing_hybrid(scan)
+clean.ravel().round(5)
+```
+
+```
+array([-1.05516, -1.13619, -1.12056, -1.07919, -1.03519, -1.07919, -0.97143,
+       -0.95434, -0.94437, -0.93892, -0.93605])
+```
+
+`ground_state_energy_sparse` (see [Hamiltonians](dashboard_core_hamiltonians.md))
+gives the real H2 ground-state energy at each of 11 bond lengths from 0.5 to 2.5
+Å — a real dissociation curve, smooth after its minimum near the true equilibrium
+bond length. Point 5 (r=1.5 Å) is overwritten with `0.0`, standing in for that one
+geometry's solver failing to converge. Healing puts it back near the curve
+(`-1.07919`, the local median of its neighbors — close to, though not identical
+to, the true `-0.99815` that solver would have returned if it had converged: a
+median is an estimate from nearby points, not a re-run of the failed calculation)
+while leaving the other 10 real points on the curve untouched.
+
+## See Also
+
+- [`dense_evolution.mitigation`](mitigation.md) — the inverse-of-noise idea
+  applied to a quantum measurement result instead of a vector sequence.
+- [`dense_evolution.healing`](healing.md) — the predictive "Phi-Trigger"
+  primitives `enhanced_dense_healing_hybrid` calls internally to decide, per
+  step, whether an observed change looks like genuine dynamics or static noise.
+- [Hamiltonians](dashboard_core_hamiltonians.md) — `ground_state_energy_sparse`,
+  the source of Step 2's real dissociation curve.
+- [`ia_utils.adversarial_vector_attack`](ia_utils_adversarial_vector_attack.md) —
+  a gradient-based robustness test of that same Phi-Trigger decision.
 
 ---
 
-**See also**: [`dense_evolution.healing`](healing.md) for the predictive
-"Phi-Trigger" primitives `enhanced_dense_healing_hybrid` calls internally
-to decide, per step, whether an observed change looks like genuine
-dynamics (kept as-is) or static noise (replaced with the local median).
-[`ia_utils.adversarial_vector_attack`](ia_utils_adversarial_vector_attack.md)
-for a gradient-based robustness test of that same Phi-Trigger decision.
+## Details
+
+### `median_healing` vs. `enhanced_dense_healing_hybrid`
+
+`median_healing` always applies a median filter to every step, with no
+notion of "genuine vs. corrupted" — a plain, unconditional smoothing pass.
+`enhanced_dense_healing_hybrid` is the one worth reaching for in practice:
+it only replaces a step when its own decision rule (`trigger_mode`, below)
+judges that step to be noise, leaving every other step bit-for-bit as it was.
+Both preprocess `NaN`/`Inf` first (column-mean imputation) so a corrupted
+value never propagates into a healthy neighbor's own repair.
+
+### `trigger_mode`: `'phi'` vs. `'adaptive'`
+
+`'phi'` (the default) is the original Phi-Trigger
+(`dense_evolution.mitigation.healing.evaluate_phi_trigger`): a fixed threshold,
+`|v_dinamic| > 0.01`, on the normalized step-to-step change. `'adaptive'` adjusts
+that threshold to the sequence's own local variability instead of a fixed
+constant. Both call the same underlying decision machinery and, on every real
+sequence tried while writing this page, gave identical output — the difference
+only shows up on sequences whose natural noise level is far from what the fixed
+0.01 threshold assumes.
+
+### When this does nothing, on purpose
+
+Fed a sequence of TF-IDF vectors from consecutive chunks of a real paper (this
+project's own local `quantumrag` index, 76 chunks from Pednault et al. 2019 —
+see [Chunk](chunk.md)'s disk-overflow section for why that specific paper
+mattered here), `enhanced_dense_healing_hybrid` left every single chunk
+unchanged, in both `trigger_mode`s. That's the correct outcome, not a bug: two
+consecutive chunks of running text about different subsections of a paper are
+*supposed* to look very different in vector space — that's a real topic change,
+not corruption, and nothing here should try to smooth it away. The same applies
+to Step 2's own dissociation curve before the corrupted point was added to it —
+zero points changed on the clean curve. Reaching for this module makes sense
+once there's an actual bad reading in the sequence, not merely a bumpy but
+genuine one.
+
+### `reconstruction_error` and `fallback_triggered`
+
+`telem["reconstruction_error"]` is `0.0` whenever nothing was changed (both
+cases in the previous section) and positive whenever at least one step was
+replaced — a quick way to check, in code, whether healing actually did
+anything to a given sequence without diffing the arrays by hand.
+`telem["fallback_triggered"]` records whether the hybrid strategy fell back to
+a plain median pass instead of the Phi-Trigger decision — see
+`enhanced_dense_healing_hybrid`'s own docstring below for exactly when that
+happens.
+
+::: ia_utils.vector_healing

--- a/docs/api/mitigation.md
+++ b/docs/api/mitigation.md
@@ -1,5 +1,8 @@
 # Mitigation (Zero-Noise Extrapolation & Density-Matrix Diagnostics)
 
+> Correcting a *quantum measurement result*, not a numeric log/trajectory — see
+> [Concepts](../concepts.md) if you're looking for [Vector Healing](ia_utils_vector_healing.md) instead.
+
 A real circuit run on noisy hardware gives the wrong answer. Zero-Noise Extrapolation
 (ZNE) gets closer to the right one without needing a better device: run the *same*
 circuit at several deliberately-worsened noise strengths, then extrapolate the trend

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,37 @@
+# Concepts: Noise, Mitigation, and Healing
+
+One decision primitive, `evaluate_phi_trigger` — is this step's change genuine
+dynamics, or noise? — lives in `dense_evolution.mitigation.healing` and gets
+reused by two different modules for two different kinds of data. That reuse,
+not a family of similar-sounding names, is the real reason "healing" and
+"mitigation" are easy to mix up. This page exists to make the difference
+un-ambiguous.
+
+| | Corrupts / heals what | Object it acts on | Module |
+|---|---|---|---|
+| **Noise** | Corrupts a real computation | A statevector, via a stochastic Kraus channel | [Noise](api/noise.md) |
+| **Mitigation** | Un-corrupts a noisy result | An expectation value / density matrix, extrapolated across noise strengths (Zero-Noise Extrapolation) | [Mitigation](api/mitigation.md) |
+| **Vector Healing** | Un-corrupts one bad reading in a sequence | Any `(n_steps, dim)` numeric sequence — a VQE/MD log, an embedding stream. Nothing quantum-specific. | [IA Utils — Vector Healing](api/ia_utils_vector_healing.md) |
+
+[Healing](api/healing.md) (`dense_evolution.mitigation.healing`, still
+importable as `dense_evolution.healing` via a compatibility shim after an
+internal move) is the shared primitive layer the last two both call into — not
+a fourth thing to run on its own.
+
+## The actual code-level connection
+
+`dense_evolution.mitigation.zne`'s own "healing-adapted" extrapolation branch
+imports `calculate_delta_preemp` from `.healing` and uses it directly on the
+noise-strength extrapolation curve. `ia_utils.vector_healing.enhanced_dense_healing_hybrid`'s
+default `trigger_mode='phi'` imports `evaluate_phi_trigger` — the *same*
+function — from `dense_evolution.mitigation.healing`, and applies it to
+whatever plain vector sequence was passed in. Same decision primitive, two
+call sites, two unrelated kinds of data: a quantum-noise-strength curve on one
+side, an arbitrary numeric log on the other.
+
+## Which page do I actually want?
+
+- "I ran a noisy circuit and want the *ideal* result back" → [Mitigation](api/mitigation.md).
+- "I have a log/trajectory/embedding sequence and one entry looks wrong" →
+  [IA Utils — Vector Healing](api/ia_utils_vector_healing.md).
+- "I want to add noise to a circuit on purpose" → [Noise](api/noise.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
   - Composer: composer.md
   - MCP Server: mcp.md
   - Getting Started: getting-started.md
+  - Concepts (Noise vs Mitigation vs Healing): concepts.md
   - Examples: examples.md
   - Benchmarks: benchmarks.md
   - API Reference:


### PR DESCRIPTION
## Summary
- `docs/api/ia_utils_vector_healing.md` was an intro paragraph + an `mkdocstrings` directive, no worked examples. Rewritten in this project's guide style:
  - Step 1: a small synthetic sequence with one out-of-place value (foundational).
  - Step 2: a real, chemistry-specific case — a dissociation-curve point that failed to converge, healed against a real H2 potential-energy curve (`ground_state_energy_sparse`, 11 real bond-length points).
  - Details: `median_healing` vs. the hybrid Phi-Trigger path, `trigger_mode`, and two real **negative** results verified this session — healing correctly does *nothing* on a real 76-chunk paper's TF-IDF sequence (this project's own `quantumrag` index) and on a real, uncorrupted VQE convergence trace. Only an actual bad reading gets touched, confirmed directly rather than assumed.
- New `docs/concepts.md`: "healing" and "mitigation" read as near-synonyms because they share one literal function — `evaluate_phi_trigger` in `dense_evolution.mitigation.healing` — called from two unrelated places: ZNE's own healing-adapted extrapolation branch, and `ia_utils.vector_healing`'s default `trigger_mode`, applied to two different kinds of data (a noise-strength curve vs. an arbitrary vector sequence). Cross-linked from `mitigation.md`, `healing.md`, and `ia_utils_vector_healing.md` so the disambiguation isn't only discoverable by finding the new page first.
- Registered in `mkdocs.yml` nav, between Getting Started and Examples.

## Verification
- Every number in both examples actually run (`enhanced_dense_healing_hybrid` on the synthetic sequence and on the real dissociation curve) — no invented output.
- `mkdocs build --strict` passes (no broken links/nav errors); the only pre-existing warning is unrelated (`api/compiler.md`).
