### PR TITLE
Fix broken include-markdown delimiters in docs/benchmarks.md

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -4,11 +4,6 @@ Included directly from the repository [`README.md`](https://github.com/tatopenn-
 so it never goes stale relative to the single source of truth. See the
 [Changelog](changelog.md) for how these numbers evolved release to release.
 
-## Anti-OOM chunking vs. PennyLane, and general benchmarks
+## Anti-OOM chunking vs. PennyLane
 
-> The distributed-dispatch section below covers `run_chunk_distributed` -- multi-device
-> sharding, not a benchmark number itself, but kept here since it's part of the same
-> performance story. General throughput/drift numbers (measured on Google Colab Free Tier)
-> follow further down.
-
-{% include-markdown "../README.md" start="### Benchmark vs PennyLane — Windows CPU (8 GB RAM)" end="## ▍ Dashboard Panels" %}
+{% include-markdown "../README.md" start="## ▍ Benchmarks" end="## ▍ Composer & MCP Server" %}


### PR DESCRIPTION
## Summary
The README.md restructure (PennyLane-style rewrite, this session) renamed/removed the headings `docs/benchmarks.md`'s `include-markdown` directive was anchored to, breaking the strict-mode docs build on `main` (`Docs — Build & Deploy` red).

Updates the delimiters to the new, shorter `## ▍ Benchmarks` section.

## Test plan
- [x] Verified the new start/end markers exist verbatim in the current README.md
