### PR TITLE
Promote stabilizer_renyi_entropy and the Klein-factor total_parity_operator from Discovery

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -35,7 +35,8 @@ from .mitigation.zne import (richardson_extrapolate, zero_noise_extrapolation, p
                           polynomial_extrapolate_jit, uhlmann_fidelity_jit, zne_density_matrix_jit)
 from .circuits.diagram import plot_circuit
 from .circuits.topology import entangling_layer
-from .physics.observables import pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix, pauli_sum_matvec
+from .physics.observables import (pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix,
+                                   pauli_sum_matvec, multiply_pauli_terms)
 from .physics.states import ghz_state
 from .utils.measurement import sample_counts, statevector_fidelity
 from .circuits.qft import qft
@@ -45,7 +46,7 @@ from .solvers.harrison_tb import (ELEMENTS as HARRISON_ELEMENTS, ETA as HARRISON
                                    sp3_dimer_hamiltonian, zincblende_hamiltonian)
 from .solvers.vhd_tb import (MATERIALS as VHD_MATERIALS, sp3s_star_hamiltonian,
                               direct_gap_at_gamma, band_extrema_along_path)
-from .physics.fermions import majorana_pauli_terms
+from .physics.fermions import majorana_pauli_terms, total_parity_operator
 from .physics.entropy import partial_trace, von_neumann_entropy, mutual_information
 from .circuits.trotter import (pauli_rotation_ops, trotter_evolve_ops, continuous_pulse_evolve,
                                 continuous_dissipative_evolve)
@@ -90,8 +91,9 @@ __all__ = [
     # Physics -- states, observables, entropy, fermions, QEC
     "ghz_state",
     "pauli_expectation", "pauli_sum_expectation", "pauli_hamiltonian_to_matrix", "pauli_sum_matvec",
+    "multiply_pauli_terms",
     "partial_trace", "von_neumann_entropy", "mutual_information",
-    "majorana_pauli_terms",
+    "majorana_pauli_terms", "total_parity_operator",
     "pauli_commutes", "compute_syndrome", "erasure_aware_decode", "pymatching_decode", "blind_minimum_weight_decode",
     "decode_with_erasure_fallback", "counts_in_intervals_dimension", "nearest_coset_decode",
     # Utils -- drawing, measurement, random circuits

--- a/dense_evolution/mitigation/__init__.py
+++ b/dense_evolution/mitigation/__init__.py
@@ -3,8 +3,10 @@ predictive-healing primitives (healing) it composes, plus density-matrix
 diagnostics validated in Dense-Evolution-Discovery: the sandwiched
 quantum Renyi divergence (renyi), magic entropy (magic_entropy), a
 classical-shadows-based estimator for magic entropy from measurement
-snapshots (magic_entropy_shadows), and the classical Kullback-Leibler
-divergence over probability distributions (kl_divergence)."""
+snapshots (magic_entropy_shadows), a multi-qubit per-state magic monotone
+(stabilizer_renyi_entropy -- NOT the same quantity as magic_entropy, see
+that module's own docstring for the distinction), and the classical
+Kullback-Leibler divergence over probability distributions (kl_divergence)."""
 from .zne import (
     richardson_extrapolate, zero_noise_extrapolation, polynomial_extrapolate,
     bounded_exponential_extrapolate,
@@ -20,6 +22,7 @@ from .healing import (
 )
 from .renyi import sandwiched_renyi_divergence, sandwiched_renyi_divergence_jit
 from .magic_entropy import magic_entropy, magic_entropy_jit
+from .stabilizer_renyi_entropy import stabilizer_renyi_entropy, stabilizer_renyi_entropy_jit
 from .magic_entropy_shadows import (
     sample_classical_shadow, magic_entropy_from_shadows,
     approx_shadow_std, fit_shadow_sample_complexity,
@@ -38,6 +41,7 @@ __all__ = [
     "calculate_jax_reflection", "MemoryReflectionEngine", "GLOBAL_CONSTANTS",
     "sandwiched_renyi_divergence", "sandwiched_renyi_divergence_jit",
     "magic_entropy", "magic_entropy_jit",
+    "stabilizer_renyi_entropy", "stabilizer_renyi_entropy_jit",
     "sample_classical_shadow", "magic_entropy_from_shadows",
     "approx_shadow_std", "fit_shadow_sample_complexity",
     "kl_divergence", "kl_divergence_jit",

--- a/dense_evolution/mitigation/stabilizer_renyi_entropy.py
+++ b/dense_evolution/mitigation/stabilizer_renyi_entropy.py
@@ -1,0 +1,103 @@
+"""Stabilizer Renyi Entropy (SRE): a per-STATE nonstabilizerness ("magic")
+monotone (Leone, Oliviero, Hamma, "Stabilizer Renyi Entropy",
+arXiv:2106.12587, Phys. Rev. Lett. 128, 050402 (2022), Eq. 5-8 there,
+labeled Eq. 14/18 in the paper that motivated promoting this).
+
+NOT the same quantity as `dense_evolution.mitigation.magic_entropy`
+(Bu-Gu-Jaffe's 3-fold self-convolution "Key Unitary" construction,
+single-qubit only) or `sandwiched_renyi_divergence` (Muller-Lennert et
+al., a DIVERGENCE between TWO density matrices -- "how different are rho
+and sigma", answering a different question entirely; the shared "Renyi"
+in both names is a coincidence of both being alpha-generalizations of
+entropy applied to different objects, not overlapping math). This SRE is
+a genuinely different, MULTI-qubit, SINGLE-state magic monotone: zero for
+every stabilizer state, positive otherwise.
+
+M_2(psi) = -log2[ (1/d) * sum_a sum_b |WHT[c_a](b)|^4 ], where
+c_a(x) = conj(psi(x)) * psi(x XOR a) and WHT is the length-d Walsh-Hadamard
+transform (signmat[b,x] = (-1)^popcount(b AND x)), d = 2**n_qubits.
+
+Verified against known values: every computational-basis/stabilizer state
+gives exactly 0; a single T state ((cos(pi/8), sin(pi/8)) in the
+computational basis) gives -log2(0.75) = 0.415037 bits, matching the
+closed-form derivation of Eq. 5 by hand (not a value copied from
+elsewhere).
+
+Promoted from Dense-Evolution-Discovery's wormhole_magic_entropy.py
+(2026-08-29), where it was implemented fresh because the existing
+magic_entropy is single-qubit only -- this quantity has no dependency on
+that use case (wormhole teleportation), so it belongs here as a general
+multi-qubit magic diagnostic.
+
+VECTORIZATION NOTE: the Discovery script's original version had an
+explicit Python `for a in range(d)` loop, each iteration doing its own
+(d,d)@(d,) matrix-vector product -- d sequential small matmuls. This
+promoted version instead builds the (d,d) matrix of every c_a(x) pair at
+once (broadcasting over x and a together) and applies the Walsh-Hadamard
+transform as ONE (d,d)@(d,d) matmul -- same O(d^3) total FLOP count, but
+expressed as a single large matmul JAX/XLA can execute efficiently
+(GPU/TPU-friendly, no per-iteration Python dispatch overhead), matching
+this package's JAX-by-default convention. Still O(d^3), not the paper's
+own asymptotically-better O(4^n * n) Walsh-Hadamard butterfly algorithm
+(n = log2(d) qubits) -- unimplemented here, same as the Discovery
+original; fine for d up to a few thousand (n up to ~11-12 qubits), the
+sizes this package's exact-statevector backends already target.
+"""
+import jax
+import jax.numpy as jnp
+
+__all__ = ["stabilizer_renyi_entropy", "stabilizer_renyi_entropy_jit"]
+
+
+def _stabilizer_renyi_entropy_core(psi):
+    d = psi.shape[0]
+    idx = jnp.arange(d)
+    # Static (trace-time) construction, same style as magic_entropy.py's
+    # _cnot_matrix -- one Python loop per distinct d, cached by jax.jit.
+    popcount = jnp.array([bin(i).count("1") for i in range(d)])
+
+    bitwise_and = idx[:, None] & idx[None, :]          # [b, x] = b & x
+    signmat = (-1.0) ** popcount[bitwise_and]            # Walsh-Hadamard sign matrix
+
+    xor_table = idx[:, None] ^ idx[None, :]              # [x, a] = x ^ a
+    c = jnp.conj(psi)[:, None] * psi[xor_table]          # [x, a] = c_a(x)
+
+    wht = signmat @ c                                     # [b, a] = WHT[c_a](b)
+    total = jnp.sum(jnp.abs(wht) ** 4)
+    return -jnp.log2(total / d)
+
+
+def stabilizer_renyi_entropy(psi):
+    """Stabilizer Renyi Entropy of a pure state `psi` (length 2**n_qubits),
+    in bits (log2) -- the paper's own convention.
+
+    Zero for every stabilizer state, positive for non-stabilizer ("magic")
+    states -- e.g. a single T state gives 0.415037 bits.
+
+    Parameters
+    ----------
+    psi : array-like, shape (2**n_qubits,)
+        A normalized pure statevector.
+
+    Returns
+    -------
+    float
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> psi0 = np.zeros(8, dtype=complex); psi0[0] = 1.0
+    >>> round(stabilizer_renyi_entropy(psi0), 6)  # computational basis state: stabilizer, expect 0
+    0.0
+    """
+    psi = jnp.asarray(psi, dtype=jnp.complex128)
+    d = psi.shape[0]
+    if d < 1 or (d & (d - 1)) != 0:
+        raise ValueError(f"psi length {d} is not a power of 2 (must be 2**n_qubits)")
+    return float(_stabilizer_renyi_entropy_core(psi))
+
+
+stabilizer_renyi_entropy_jit = jax.jit(_stabilizer_renyi_entropy_core)
+"""`jax.jit`-compiled entry point for `stabilizer_renyi_entropy`. `psi`
+must already be `complex128`. Returns a jnp scalar, not a Python `float`
+-- call `float(...)` yourself if you need one outside a jitted context."""

--- a/dense_evolution/physics/__init__.py
+++ b/dense_evolution/physics/__init__.py
@@ -1,16 +1,18 @@
 """Physics subpackage: state preparation, observables, entropy, fermions, QEC."""
 from .states import ghz_state
-from .observables import pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix, pauli_sum_matvec
+from .observables import (pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix,
+                           pauli_sum_matvec, multiply_pauli_terms)
 from .entropy import partial_trace, von_neumann_entropy, mutual_information
-from .fermions import majorana_pauli_terms
+from .fermions import majorana_pauli_terms, total_parity_operator
 from .qec import (pauli_commutes, compute_syndrome, erasure_aware_decode, pymatching_decode,
                    blind_minimum_weight_decode, nearest_coset_decode)
 
 __all__ = [
     "ghz_state",
     "pauli_expectation", "pauli_sum_expectation", "pauli_hamiltonian_to_matrix", "pauli_sum_matvec",
+    "multiply_pauli_terms",
     "partial_trace", "von_neumann_entropy", "mutual_information",
-    "majorana_pauli_terms",
+    "majorana_pauli_terms", "total_parity_operator",
     "pauli_commutes", "compute_syndrome", "erasure_aware_decode", "pymatching_decode", "blind_minimum_weight_decode",
     "nearest_coset_decode",
 ]

--- a/dense_evolution/physics/fermions.py
+++ b/dense_evolution/physics/fermions.py
@@ -20,9 +20,22 @@ molecule-specific Hartree-Fock Jordan-Wigner, not a general Majorana map).
 Combine the returned Pauli term with dense_evolution.pauli_hamiltonian_to_matrix
 to build any Majorana-operator Hamiltonian as a dense matrix, e.g. a
 sparse SYK model: H = sum_{ijkl} J_ijkl * chi_i*chi_j*chi_k*chi_l.
-"""
 
-__all__ = ['majorana_pauli_terms']
+total_parity_operator (the "Klein factor" for a set of Majorana modes) was
+promoted alongside majorana_pauli_terms from Dense-Evolution-Discovery's
+wormhole_magic_entropy.py (2026-08-29): a second, independently-Jordan-
+Wigner-mapped fermionic register (e.g. the "R" side of a two-copy/thermofield-
+double construction) puts its Majoranas on disjoint qubits, so cross-register
+Majorana products COMMUTE by construction instead of anticommuting -- the
+well-known "Klein factor" problem from bosonization / fermionic-entanglement
+literature (e.g. Fidkowski-Kitaev). Multiplying one register's operators by
+its own total_parity_operator before combining them with the other
+register's restores the correct anticommutation; see that function's
+docstring for the algebraic proof.
+"""
+from .observables import multiply_pauli_terms
+
+__all__ = ['majorana_pauli_terms', 'total_parity_operator']
 
 
 def majorana_pauli_terms(mode_index, n_qubits):
@@ -50,3 +63,81 @@ def majorana_pauli_terms(mode_index, n_qubits):
     pauli = {k: 'Z' for k in range(j)}
     pauli[j] = 'Y' if is_even else 'X'
     return (1.0, pauli)
+
+
+def total_parity_operator(mode_indices, n_qubits):
+    """Total fermion-parity ("Klein factor") operator for a set of Majorana
+    modes: i^(N/2) times the ORDERED product of majorana_pauli_terms(m,
+    n_qubits) for every m in `mode_indices` (N = len(mode_indices)),
+    computed via multiply_pauli_terms (exact symbolic Pauli algebra, no
+    numerical approximation).
+
+    The i^(N/2) PHASE CORRECTION is not optional decoration -- found
+    necessary by testing, not assumed from the general anticommutation
+    argument alone: for N mutually anticommuting HERMITIAN operators, the
+    raw ordered product Pi = chi_1*chi_2*...*chi_N satisfies
+    Pi^dagger = chi_N*...*chi_1 = (-1)**(N*(N-1)/2) * Pi (reversing N
+    anticommuting factors takes N*(N-1)/2 transpositions, each contributing
+    -1) -- so Pi itself is Hermitian only when N*(N-1)/2 is even (N=4, 8,
+    12, ... i.e. N%4==0), and ANTI-Hermitian when N*(N-1)/2 is odd (N=2, 6,
+    10, ... i.e. N%4==2). This was caught by a test at N=6 (n_qubits=3)
+    that the original N=8-only manual check never exercised. Multiplying
+    by i^(N/2) fixes this for every even N: verified numerically for
+    N=2,4,6,8,10 that i**(N/2) * Pi is exactly Hermitian AND squares to
+    exactly the identity in every case (see tests/unit/test_fermions.py).
+
+    Why this fixes cross-register anticommutation: an even number of
+    mutually anticommuting, squares-to-identity operators, correctly
+    phase-normalized to be Hermitian and square to I (as above), still
+    anticommutes with each individual factor -- multiplying an overall
+    scalar phase never changes an operator's (anti)commutation relations
+    with OTHER operators. Concretely: if psi_L (from THIS register) and
+    psi_R (from an independently Jordan-Wigner-mapped SECOND register,
+    e.g. dense_evolution.physics.fermions.majorana_pauli_terms called
+    again with its own qubit offset) act on disjoint qubits, they commute
+    by construction -- but P_L = total_parity_operator(all_of_this_
+    register's_modes, n_qubits) anticommutes with every psi_L, so
+    replacing psi_R with multiply_pauli_terms([P_L, psi_R]) (P_L applied
+    first) makes it anticommute with psi_L instead, while leaving
+    {psi_R, psi_R'} (two operators from the SAME second register)
+    unchanged, since P_L^2 = I factors out trivially:
+    {P_L*psi_R, P_L*psi_R'} = P_L^2 * {psi_R, psi_R'}.
+
+    len(mode_indices) must be even -- an odd-length parity operator would
+    anticommute with an EVEN number of factors' worth of sign flips, i.e.
+    NOT anticommute with its own members, defeating the purpose (raises
+    ValueError rather than silently returning something that doesn't have
+    the intended algebraic property).
+
+    Parameters
+    ----------
+    mode_indices : iterable of int
+        1-indexed Majorana modes (same indexing as majorana_pauli_terms),
+        typically ALL of one register's modes (range(1, n_majorana+1)) to
+        get that register's total parity, though any even-length subset
+        is algebraically valid.
+    n_qubits : int
+        Same meaning as majorana_pauli_terms's n_qubits.
+
+    Returns
+    -------
+    (complex, dict)
+        A (coeff, pauli_dict) term, same shape as majorana_pauli_terms's
+        return -- ready for pauli_hamiltonian_to_matrix / pauli_expectation
+        / another multiply_pauli_terms call.
+
+    Examples
+    --------
+    >>> total_parity_operator([1, 2], n_qubits=1)  # i^1 * chi_1*chi_2 = i*(i*Z) = -Z
+    ((-1+0j), {0: 'Z'})
+    """
+    mode_indices = list(mode_indices)
+    n = len(mode_indices)
+    if n % 2 != 0:
+        raise ValueError(
+            f"total_parity_operator needs an EVEN number of modes to anticommute "
+            f"with each of its own members, got {n}"
+        )
+    factors = [majorana_pauli_terms(m, n_qubits) for m in mode_indices]
+    coeff, pauli_dict = multiply_pauli_terms(factors)
+    return coeff * (1j ** (n / 2)), pauli_dict

--- a/dense_evolution/physics/observables.py
+++ b/dense_evolution/physics/observables.py
@@ -22,7 +22,7 @@ import numpy as np
 
 __all__ = [
     'pauli_expectation', 'pauli_sum_expectation', 'pauli_hamiltonian_to_matrix',
-    'pauli_sum_matvec',
+    'pauli_sum_matvec', 'multiply_pauli_terms',
 ]
 
 _PAULI_MATRICES = {
@@ -304,3 +304,76 @@ def pauli_sum_matvec(vector, terms, n_qubits=None):
         result += coeff * _apply_pauli_term(vector, normalized, inferred_n_qubits)
 
     return result
+
+
+_SAME_QUBIT_PAULI_PRODUCT = {
+    ('X', 'X'): (1, None), ('Y', 'Y'): (1, None), ('Z', 'Z'): (1, None),
+    ('X', 'Y'): (1j, 'Z'), ('Y', 'X'): (-1j, 'Z'),
+    ('Y', 'Z'): (1j, 'X'), ('Z', 'Y'): (-1j, 'X'),
+    ('Z', 'X'): (1j, 'Y'), ('X', 'Z'): (-1j, 'Y'),
+}
+
+
+def multiply_pauli_terms(factors):
+    """
+    Multiplies several Pauli-string OPERATORS together into one combined
+    term, tracking the i^k phase picked up whenever two factors act on the
+    same qubit (X*Y=iZ, Y*X=-iZ, etc.) -- the exact symbolic algebra
+    needed to compose Pauli strings by hand, e.g. building the "Klein
+    factor" total-parity operator for a set of Jordan-Wigner-mapped
+    Majorana modes (see dense_evolution.physics.fermions.total_parity_operator),
+    or any other manual Pauli-operator product.
+
+    This multiplies OPERATORS (order matters -- Pauli matrices don't
+    commute), unlike pauli_hamiltonian_to_matrix/pauli_sum_expectation,
+    which take a SUM of independent terms (order doesn't matter there).
+
+    Promoted from Dense-Evolution-Discovery's dashboard_core.wormhole
+    module (`_multiply_pauli_dicts`), where it was originally written to
+    combine independently-Jordan-Wigner-mapped Majorana operators across
+    the two sides of a wormhole-teleportation simulation -- a generic
+    Pauli-algebra operation with no dependency on that use case, so it
+    belongs here instead of duplicated wherever it's next needed.
+
+    Parameters
+    ----------
+    factors : iterable of (coeff, pauli_terms)
+        Same (coeff, pauli_terms) pair format pauli_hamiltonian_to_matrix's
+        `terms` accepts -- no bare-term shorthand (a Python int coefficient
+        would be indistinguishable from a bare (qubit, pauli) pair, e.g.
+        (1, 'X'), so this deliberately doesn't try to support one; pass
+        (1.0, pauli_terms) explicitly instead). Applied left to right --
+        the first factor is the leftmost operator in the product.
+
+    Returns
+    -------
+    (complex, dict)
+        combined_coeff : the product of every factor's own coefficient,
+        times the i^k phase accumulated from same-qubit collisions.
+        combined_pauli_dict : {qubit: 'X'|'Y'|'Z'}, identity qubits
+        dropped -- ready for pauli_hamiltonian_to_matrix / pauli_expectation
+        / another multiply_pauli_terms call.
+
+    Examples
+    --------
+    >>> multiply_pauli_terms([(1.0, 'X'), (1.0, 'Y')])  # X0 * Y0 = i*Z0
+    (1j, {0: 'Z'})
+    >>> multiply_pauli_terms([(2.0, 'X'), (3.0, {1: 'Z'})])  # disjoint qubits, no collision
+    (6.0, {0: 'X', 1: 'Z'})
+    """
+    merged = {}
+    total_coeff = 1.0 + 0j
+    for coeff, pauli_terms in factors:
+        total_coeff *= coeff
+        normalized = _normalize_terms(pauli_terms)
+        for q, p in normalized.items():
+            if q not in merged:
+                merged[q] = p
+            else:
+                phase, new_p = _SAME_QUBIT_PAULI_PRODUCT[(merged[q], p)]
+                total_coeff *= phase
+                if new_p is None:
+                    del merged[q]
+                else:
+                    merged[q] = new_p
+    return total_coeff, merged

--- a/docs/api/fermions.md
+++ b/docs/api/fermions.md
@@ -12,6 +12,18 @@ Combine the returned Pauli term with
 Majorana-operator Hamiltonian as a dense matrix, e.g. a sparse
 Sachdev-Ye-Kitaev (SYK) model: `H = sum_{ijkl} J_ijkl * chi_i*chi_j*chi_k*chi_l`.
 
+`total_parity_operator` builds the "Klein factor" for a set of Majorana
+modes — the tool needed when TWO independently-Jordan-Wigner-mapped
+registers (e.g. the two sides of a thermofield-double/wormhole
+construction) must be combined into one joint fermionic algebra: their
+Majoranas commute across registers by construction (disjoint qubits),
+but a genuine cross-register Dirac fermion needs them to anticommute.
+Dressing one register's operators with its own `total_parity_operator`
+before combining fixes this — see the function's own docstring for the
+full derivation, and
+[Dense-Evolution-Discovery's wormhole_magic_entropy.py](https://tatopenn-cell.github.io/Dense-Evolution-Discovery/)
+for the real construction this was promoted from.
+
 ::: dense_evolution.physics.fermions
 
 ---

--- a/docs/api/mitigation.md
+++ b/docs/api/mitigation.md
@@ -294,6 +294,35 @@ feed into one.
 
 ---
 
+## Multi-qubit magic monotone (pure states)
+
+A second, unrelated magic quantity: `stabilizer_renyi_entropy` (Leone, Oliviero, Hamma,
+[arXiv:2106.12587](https://arxiv.org/abs/2106.12587)) is zero for every stabilizer state
+and positive otherwise, like `magic_entropy` above -- but it works on a MULTI-qubit
+pure statevector (`magic_entropy` is single-qubit density-matrices only), and it is a
+genuinely different construction (a Walsh-Hadamard transform of Pauli-string overlaps,
+not the 3-fold self-convolution "Key Unitary" `magic_entropy` uses). Promoted from
+[Dense-Evolution-Discovery's wormhole_magic_entropy.py](https://tatopenn-cell.github.io/Dense-Evolution-Discovery/),
+where it tracked how "magic" a wormhole-teleportation state stayed across the protocol,
+regardless of how well the teleportation itself worked.
+
+```python
+import numpy as np
+from dense_evolution.mitigation import stabilizer_renyi_entropy
+
+ghz = np.zeros(8, dtype=complex)
+ghz[0] = ghz[-1] = 1.0 / np.sqrt(2.0)
+round(stabilizer_renyi_entropy(ghz), 6)
+```
+
+```
+0.0
+```
+
+::: dense_evolution.mitigation.stabilizer_renyi_entropy
+
+---
+
 ## Shadow-based estimation
 
 A classical-shadows-based estimator for `magic_entropy` above, estimating it from randomized

--- a/docs/api/observables.md
+++ b/docs/api/observables.md
@@ -6,6 +6,12 @@ the same technique for `H @ vector` (not reduced to a scalar) -- the matrix-free
 behind [`ground_state_energy_sparse`](dashboard_core_hamiltonians.md)'s
 `scipy.sparse.linalg.eigsh` path for molecules too large to diagonalize densely.
 
+`multiply_pauli_terms` multiplies several Pauli-string OPERATORS together (order matters --
+unlike every function above, which sums independent terms), tracking the `i^k` phase from
+same-qubit collisions (`X*Y=iZ`, etc.) -- the manual Pauli-algebra primitive behind
+[`total_parity_operator`](fermions.md)'s Klein-factor construction, or any other by-hand
+Pauli-operator product.
+
 ::: dense_evolution.physics.observables
 
 ---

--- a/tests/unit/test_fermions.py
+++ b/tests/unit/test_fermions.py
@@ -8,6 +8,7 @@ import pytest
 
 from dense_evolution import majorana_pauli_terms
 from dense_evolution.observables import pauli_hamiltonian_to_matrix
+from dense_evolution.physics.fermions import total_parity_operator
 
 
 def test_backward_compat_shim_fermions_reexports_majorana_pauli_terms():
@@ -77,3 +78,90 @@ class TestMajoranaPauliTerms:
         n_qubits = 3
         majorana_pauli_terms(1, n_qubits)
         majorana_pauli_terms(2 * n_qubits, n_qubits)
+
+
+class TestTotalParityOperator:
+    """The 'Klein factor' for a set of Majorana modes -- see the
+    algebraic proof in the function's own docstring; these tests verify
+    it against the actual dense matrices, not just re-derive the proof."""
+
+    def _parity_matrix(self, mode_indices, n_qubits):
+        coeff, pauli_dict = total_parity_operator(mode_indices, n_qubits)
+        return coeff * pauli_hamiltonian_to_matrix([(1.0, pauli_dict)], n_qubits)
+
+    def test_odd_length_raises(self):
+        with pytest.raises(ValueError):
+            total_parity_operator([1, 2, 3], n_qubits=2)
+
+    def test_anticommutes_with_every_member_mode(self):
+        """The core claim: P = total_parity_operator(all modes) anticommutes
+        with each INDIVIDUAL chi_m for m in those modes -- this is what
+        makes it usable as a Klein factor to fix cross-register commutation
+        (see dense_evolution.physics.fermions module docstring)."""
+        n_qubits = 3
+        n_majorana = 2 * n_qubits
+        P = self._parity_matrix(list(range(1, n_majorana + 1)), n_qubits)
+        for m in range(1, n_majorana + 1):
+            chi = _chi_matrix(m, n_qubits)
+            anticomm = P @ chi + chi @ P
+            assert np.max(np.abs(anticomm)) == pytest.approx(0.0, abs=1e-10), f"mode {m} did not anticommute"
+
+    def test_matches_ordered_matrix_product_times_phase_correction(self):
+        """total_parity_operator's symbolic algebra must agree with
+        i**(N/2) times literally multiplying the individual chi matrices
+        in order -- the i**(N/2) phase correction is what makes the
+        result Hermitian for every even N, not just N%4==0 (see the
+        function's own docstring for why the raw product alone isn't
+        enough)."""
+        n_qubits = 3
+        modes = [1, 2, 3, 4]
+        P = self._parity_matrix(modes, n_qubits)
+        manual = np.eye(2 ** n_qubits, dtype=complex)
+        for m in modes:
+            manual = manual @ _chi_matrix(m, n_qubits)
+        manual *= 1j ** (len(modes) / 2)
+        assert np.max(np.abs(P - manual)) == pytest.approx(0.0, abs=1e-10)
+
+    @pytest.mark.parametrize("n_qubits", [1, 2, 3, 4, 5])
+    def test_hermitian_and_squares_to_identity_for_every_even_n(self, n_qubits):
+        """Regression test for the N%4==2 case (N=2, 6, 10, ...), where the
+        UNcorrected raw product is anti-Hermitian, not Hermitian -- caught
+        by this exact parametrization at n_qubits=3 (N=6) during
+        development; n_qubits=1 (N=2) and n_qubits=5 (N=10) are also in
+        the same N%4==2 family and are checked here too, alongside the
+        N%4==0 cases (n_qubits=2,4) which happened to already work even
+        before the phase correction was added."""
+        n_majorana = 2 * n_qubits
+        P = self._parity_matrix(list(range(1, n_majorana + 1)), n_qubits)
+        identity = np.eye(2 ** n_qubits, dtype=complex)
+        assert np.max(np.abs(P - P.conj().T)) == pytest.approx(0.0, abs=1e-10)
+        assert np.max(np.abs(P @ P - identity)) == pytest.approx(0.0, abs=1e-10)
+
+    def test_fixes_cross_register_commutation_end_to_end(self):
+        """The actual motivating use case: two independently-Jordan-Wigner-
+        mapped registers (L, R), tensored together (disjoint qubits) --
+        bare chi_L and chi_R COMMUTE by construction; dressing chi_R with
+        L's total parity operator makes it ANTIcommute with chi_L instead."""
+        n_qubits_per_side = 2
+        n_majorana_per_side = 2 * n_qubits_per_side
+        n_full = 2 * n_qubits_per_side
+
+        def embed(mode_index, offset):
+            coeff, pauli_dict = majorana_pauli_terms(mode_index, n_qubits_per_side)
+            shifted = {q + offset: p for q, p in pauli_dict.items()}
+            return coeff * pauli_hamiltonian_to_matrix([(1.0, shifted)], n_full)
+
+        chi_L1 = embed(1, offset=0)
+        chi_R1 = embed(1, offset=n_qubits_per_side)
+
+        # Bare tensor-product convention: commute, not anticommute.
+        bare_commutator = chi_L1 @ chi_R1 - chi_R1 @ chi_L1
+        assert np.max(np.abs(bare_commutator)) == pytest.approx(0.0, abs=1e-10)
+
+        # Dress chi_R1 with P_L (L's total parity, embedded at offset 0).
+        coeff_pl, pauli_pl = total_parity_operator(list(range(1, n_majorana_per_side + 1)), n_qubits_per_side)
+        P_L = coeff_pl * pauli_hamiltonian_to_matrix([(1.0, pauli_pl)], n_full)
+        chi_R1_dressed = P_L @ chi_R1
+
+        anticomm = chi_L1 @ chi_R1_dressed + chi_R1_dressed @ chi_L1
+        assert np.max(np.abs(anticomm)) == pytest.approx(0.0, abs=1e-10)

--- a/tests/unit/test_observables.py
+++ b/tests/unit/test_observables.py
@@ -10,6 +10,7 @@ from dense_evolution import DenseSVSimulator
 from dense_evolution.observables import (
     pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix, pauli_sum_matvec,
 )
+from dense_evolution.physics.observables import multiply_pauli_terms
 
 _PAULI_MATS = {
     'I': np.eye(2, dtype=complex),
@@ -204,3 +205,46 @@ class TestPauliSumMatvec:
     def test_qubit_out_of_range_raises(self):
         with pytest.raises(ValueError):
             pauli_sum_matvec(np.zeros(4, dtype=complex), [(1.0, {5: 'Z'})])
+
+
+class TestMultiplyPauliTerms:
+    """Cross-checked against real matrix multiplication, not just the
+    symbolic phase-tracking algebra's own self-consistency."""
+
+    @pytest.mark.parametrize("a,b,expected_phase,expected_pauli", [
+        ('X', 'X', 1.0, None), ('Y', 'Y', 1.0, None), ('Z', 'Z', 1.0, None),
+        ('X', 'Y', 1j, 'Z'), ('Y', 'X', -1j, 'Z'),
+        ('Y', 'Z', 1j, 'X'), ('Z', 'Y', -1j, 'X'),
+        ('Z', 'X', 1j, 'Y'), ('X', 'Z', -1j, 'Y'),
+    ])
+    def test_all_nine_same_qubit_products_match_real_matrices(self, a, b, expected_phase, expected_pauli):
+        A = pauli_hamiltonian_to_matrix([(1.0, a)], n_qubits=1)
+        B = pauli_hamiltonian_to_matrix([(1.0, b)], n_qubits=1)
+        coeff, merged = multiply_pauli_terms([(1.0, a), (1.0, b)])
+        assert coeff == pytest.approx(expected_phase)
+        assert merged == ({0: expected_pauli} if expected_pauli else {})
+        combined = coeff * pauli_hamiltonian_to_matrix([(1.0, merged)] if merged else [(1.0, {})], n_qubits=1)
+        assert np.allclose(A @ B, combined)
+
+    def test_disjoint_qubits_no_phase_and_coefficients_multiply(self):
+        coeff, merged = multiply_pauli_terms([(2.0, 'X'), (3.0, {1: 'Z'})])
+        assert coeff == pytest.approx(6.0)
+        assert merged == {0: 'X', 1: 'Z'}
+
+    def test_three_factor_product_matches_matrix_chain(self):
+        rng = np.random.default_rng(7)
+        letters = ['X', 'Y', 'Z']
+        for _ in range(50):
+            a, b, c = rng.choice(letters, size=3)
+            A = pauli_hamiltonian_to_matrix([(1.0, a)], n_qubits=1)
+            B = pauli_hamiltonian_to_matrix([(1.0, b)], n_qubits=1)
+            C = pauli_hamiltonian_to_matrix([(1.0, c)], n_qubits=1)
+            coeff, merged = multiply_pauli_terms([(1.0, a), (1.0, b), (1.0, c)])
+            combined = coeff * pauli_hamiltonian_to_matrix([(1.0, merged)] if merged else [(1.0, {})], n_qubits=1)
+            assert np.allclose(A @ B @ C, combined), f"{a}*{b}*{c} mismatch"
+
+    def test_order_matters(self):
+        # X*Y = iZ, Y*X = -iZ -- same qubits, different order, opposite sign.
+        coeff_xy, _ = multiply_pauli_terms([(1.0, 'X'), (1.0, 'Y')])
+        coeff_yx, _ = multiply_pauli_terms([(1.0, 'Y'), (1.0, 'X')])
+        assert coeff_xy == pytest.approx(-coeff_yx)

--- a/tests/unit/test_stabilizer_renyi_entropy.py
+++ b/tests/unit/test_stabilizer_renyi_entropy.py
@@ -1,0 +1,105 @@
+"""
+Unit tests for dense_evolution/mitigation/stabilizer_renyi_entropy.py.
+Known-value checks cross-referenced against Dense-Evolution-Discovery's
+wormhole_magic_entropy.py, where the T-state value was independently
+derived by hand from the source paper's own Eq. 5 (arXiv:2106.12587), not
+copied from anywhere else.
+"""
+import jax
+jax.config.update("jax_enable_x64", True)  # needed for the tight "exactly
+# 0 for stabilizer states" tolerances below -- float32 (the default
+# without this) was measured to accumulate ~3e-7 error on a 4-qubit GHZ
+# state through this module's O(d^3) computation, same pattern already
+# used in tests/unit/test_amplitude_damping_channel.py for the same reason.
+
+import numpy as np
+import pytest
+
+from dense_evolution.mitigation import stabilizer_renyi_entropy, stabilizer_renyi_entropy_jit
+from dense_evolution import DenseSVSimulator
+
+
+def _original_loop_reference(psi):
+    """Independent reference: the original, unvectorized Discovery
+    implementation (explicit Python loop over `a`, one (d,d)@(d,) matvec
+    per iteration) -- the promoted version replaces this loop with one
+    (d,d)@(d,d) matmul; this checks they compute the identical number."""
+    psi = np.asarray(psi, dtype=complex)
+    d = len(psi)
+    idx = np.arange(d)
+    popcount = np.array([bin(i).count("1") for i in range(d)])
+    signmat = np.array([(-1.0) ** popcount[idx & b] for b in range(d)])
+    total = 0.0
+    for a in range(d):
+        c_a = np.conj(psi) * psi[idx ^ a]
+        wht = signmat @ c_a
+        total += np.sum(np.abs(wht) ** 4)
+    return -np.log2(total / d)
+
+
+class TestKnownValues:
+
+    def test_computational_basis_state_is_a_stabilizer_state(self):
+        for n_qubits in [1, 2, 3, 4]:
+            d = 2 ** n_qubits
+            for basis_idx in [0, d - 1]:
+                psi = np.zeros(d, dtype=complex)
+                psi[basis_idx] = 1.0
+                assert stabilizer_renyi_entropy(psi) == pytest.approx(0.0, abs=1e-8)
+
+    def test_ghz_state_is_a_stabilizer_state(self):
+        for n_qubits in [2, 3, 4]:
+            d = 2 ** n_qubits
+            psi = np.zeros(d, dtype=complex)
+            psi[0] = psi[-1] = 1.0 / np.sqrt(2.0)
+            assert stabilizer_renyi_entropy(psi) == pytest.approx(0.0, abs=1e-8)
+
+    def test_bell_state_from_a_real_circuit_is_a_stabilizer_state(self):
+        sim = DenseSVSimulator(2, use_float32=False)
+        sim.run_circuit([('h', 0), ('cx', 0, 1)])
+        psi = sim.get_statevector()
+        assert stabilizer_renyi_entropy(psi) == pytest.approx(0.0, abs=1e-8)
+
+    def test_single_t_state_matches_hand_derived_value(self):
+        theta = np.pi / 8
+        t1 = np.array([np.cos(theta), np.sin(theta)], dtype=complex)
+        assert stabilizer_renyi_entropy(t1) == pytest.approx(-np.log2(0.75), abs=1e-6)
+
+
+class TestVectorizationMatchesOriginalLoop:
+    """The promoted implementation replaced an explicit Python loop with
+    one batched matmul -- these confirm that was a pure vectorization,
+    not a change in the actual computed quantity."""
+
+    @pytest.mark.parametrize("n_qubits", [1, 2, 3, 4])
+    def test_matches_original_loop_on_random_states(self, n_qubits):
+        rng = np.random.default_rng(42 + n_qubits)
+        d = 2 ** n_qubits
+        v = rng.normal(size=d) + 1j * rng.normal(size=d)
+        v /= np.linalg.norm(v)
+        assert stabilizer_renyi_entropy(v) == pytest.approx(_original_loop_reference(v), abs=1e-9)
+
+
+class TestJitAndValidation:
+
+    def test_jit_matches_eager(self):
+        theta = np.pi / 8
+        t1 = np.array([np.cos(theta), np.sin(theta)], dtype=complex)
+        eager = stabilizer_renyi_entropy(t1)
+        jitted = float(stabilizer_renyi_entropy_jit(np.asarray(t1, dtype=np.complex128)))
+        assert eager == pytest.approx(jitted, abs=1e-10)
+
+    def test_non_power_of_two_length_raises(self):
+        with pytest.raises(ValueError):
+            stabilizer_renyi_entropy(np.ones(5, dtype=complex) / np.sqrt(5))
+
+    def test_non_negative_for_random_states(self):
+        # A Renyi entropy of a valid probability-like distribution can't
+        # be negative -- sanity bound, not a known exact value.
+        rng = np.random.default_rng(0)
+        for n_qubits in [1, 2, 3]:
+            d = 2 ** n_qubits
+            for _ in range(10):
+                v = rng.normal(size=d) + 1j * rng.normal(size=d)
+                v /= np.linalg.norm(v)
+                assert stabilizer_renyi_entropy(v) >= -1e-9


### PR DESCRIPTION
Two utilities promoted from today's `wormhole_magic_entropy.py` work in Dense-Evolution-Discovery (the Klein-factor fix for wormhole L/R Majorana registers, PR merged there earlier today), both generic building blocks with no dependency on that specific use case.

**No version bump** (per standing convention: bump only at PyPI release time — this is a draft PR, not a release).

## 1. `dense_evolution.mitigation.stabilizer_renyi_entropy`

Leone, Oliviero, Hamma, [arXiv:2106.12587](https://arxiv.org/abs/2106.12587) — a multi-qubit, per-**state** magic monotone. **Not** the same quantity as the existing single-qubit `magic_entropy` (Bu-Gu-Jaffe Key-Unitary construction) or `sandwiched_renyi_divergence` (a divergence *between two* density matrices) — the shared "Renyi" in all three names is coincidental (all are α-generalizations of entropy, applied to different objects).

- Verified against known values: stabilizer states → exactly 0, a single T state → 0.415037 bits (hand-derived from the paper's Eq. 5, not copied).
- Cross-checked against the original Discovery script's unvectorized loop implementation on random states (1-4 qubits) — identical to 1e-9.
- **Vectorization**: the Discovery original had an explicit Python `for a in range(d)` loop (d sequential `(d,d)@(d,)` matvecs). This version builds all pairs at once and does ONE `(d,d)@(d,d)` matmul — same O(d³) cost, but one XLA-friendly matmul instead of d small ones, matching this package's JAX-by-default convention.

## 2. `dense_evolution.physics.observables.multiply_pauli_terms` + `dense_evolution.physics.fermions.total_parity_operator`

The "Klein factor" fix for combining two independently-Jordan-Wigner-mapped fermionic registers into one joint algebra (their Majoranas commute across registers by construction, but a genuine cross-register Dirac fermion needs them to anticommute — standard bosonization/fermionic-entanglement literature, e.g. Fidkowski-Kitaev). `multiply_pauli_terms` (promoted from `dashboard_core.wormhole`'s `_multiply_pauli_dicts`) is the generic symbolic Pauli-algebra primitive; `total_parity_operator` builds the actual parity operator from it.

### Real bug found and fixed during promotion

The Discovery original only ever tested `n_majorana=8`. A parametrized test here at `n_qubits=3` (N=6 modes) caught that the **raw** ordered Majorana product is Hermitian only when `N%4==0`, and **anti-Hermitian** when `N%4==2` (N=2, 6, 10, ...) — a real algebraic gap the narrower original never exercised. Fixed with an `i**(N/2)` phase correction, verified numerically Hermitian and squares-to-identity for N=2,4,6,8,10, and re-verified end-to-end that it still fixes cross-register anticommutation.

## Testing

- New: `tests/unit/test_stabilizer_renyi_entropy.py` (11 tests), `TestMultiplyPauliTerms`/`TestTotalParityOperator` classes added to existing `test_observables.py`/`test_fermions.py`.
- Full suite: **1058 passed, 19 skipped** (expected — multi-device-only distributed tests), **0 failed**. No regressions.
- Docs updated: `docs/api/mitigation.md`, `docs/api/fermions.md`, `docs/api/observables.md` (mkdocstrings auto-pulls the new functions' docstrings; added hand-written intro paragraphs + one runnable example each, matching this repo's existing style).

Opened as **draft** — let me know if you want anything changed before merging.