### PR TITLE
Polish mind map: docs nav entry, README guide link, README-only CI skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
               - '**'
               - '!docs/**'
               - '!mkdocs.yml'
+              - '!README.md'
 
   docs-examples:
     name: Docs examples (docs-only change)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
   <img src="docs/assets/banner.svg" alt="Dense Evolution — NISQ quantum simulation toolkit, JAX-native" width="900">
 </p>
 
+<p align="center">
+  <a href="https://tatopenn-cell.github.io/Dense-Evolution/mindmap/"><strong>🧠 New here? Start with the interactive Mind Map</strong></a> — click any module to see what it does and how it connects.
+</p>
+
 <!-- mcp-name: io.github.tatopenn-cell/dense-evolution -->
 **A high-performance quantum simulation toolkit
 Statevector/MPS engines with compilation, noise, VQE, QEC, chemistry, and agent-native tooling.**

--- a/docs/mindmap.md
+++ b/docs/mindmap.md
@@ -1,0 +1,5 @@
+# Interactive Mind Map
+
+Click any node to see what it does and how it connects to the rest of the package.
+
+<iframe src="mindmap.html" style="width:100%; height:82vh; border:1px solid var(--md-default-fg-color--lightest); border-radius:8px;"></iframe>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ plugins:
 
 nav:
   - Home: index.md
+  - Mind Map: mindmap.md
   - Composer: composer.md
   - MCP Server: mcp.md
   - Getting Started: getting-started.md


### PR DESCRIPTION
Follow-up to the mind map added in #168 (already merged). Adds:
- `docs/mindmap.md`: iframe wrapper so the mind map shows up as a real, indexed docs page
- `mkdocs.yml`: nav entry near the top ("Mind Map")
- `README.md`: guide link right under the banner
- `.github/workflows/ci.yml`: excludes `README.md`-only changes from the full 6-way test matrix (same fast-path as `docs/**`/`mkdocs.yml`), avoiding wasted CI compute on doc-only edits