### PR TITLE
Update README to remove Mind Map link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
   <img src="docs/assets/banner.svg" alt="Dense Evolution — NISQ quantum simulation toolkit, JAX-native" width="900">
 </p>
 
-<p align="center">
-  <a href="https://tatopenn-cell.github.io/Dense-Evolution/mindmap/"><strong>🧠 New here? Start with the interactive Mind Map</strong></a> — click any module to see what it does and how it connects.
-</p>
+
 
 <!-- mcp-name: io.github.tatopenn-cell/dense-evolution -->
 **A high-performance quantum simulation toolkit


### PR DESCRIPTION
Removed introductory link to the interactive Mind Map from the README.

## What & why

What does this change, and why is it needed — not just what it does mechanically.

## Testing

- [ ] Added/updated tests for the change (especially for anything numerical — statevector/probability outputs)
- [ ] `pytest tests/` passes locally
- [ ] Updated `README.md`'s changelog section if this is user-visible

## Notes for the reviewer

Anything that needs extra attention, or context that isn't obvious from the diff.
