### PR TITLE
Deprecate calculate_advanced_sigma

### DIFF
--- a/dense_evolution/mitigation/healing.py
+++ b/dense_evolution/mitigation/healing.py
@@ -22,6 +22,8 @@ naming it as such would be the overclaiming this note is trying to
 avoid, not fix.
 """
 
+import warnings
+
 import jax
 import jax.numpy as jnp
 import json
@@ -49,9 +51,35 @@ GLOBAL_CONSTANTS = {
 # =====================================================================
 
 @jax.jit
-def calculate_advanced_sigma(kappa: jnp.ndarray, H: jnp.ndarray, Psi: jnp.ndarray, Omega_sync: jnp.ndarray, tau_K: jnp.ndarray) -> jnp.ndarray:
-    """Calcola la funzione di sincronizzazione avanzata Sigma."""
+def _calculate_advanced_sigma_core(kappa: jnp.ndarray, H: jnp.ndarray, Psi: jnp.ndarray, Omega_sync: jnp.ndarray, tau_K: jnp.ndarray) -> jnp.ndarray:
     return kappa * H * Psi * Omega_sync * tau_K
+
+
+def calculate_advanced_sigma(kappa: jnp.ndarray, H: jnp.ndarray, Psi: jnp.ndarray, Omega_sync: jnp.ndarray, tau_K: jnp.ndarray) -> jnp.ndarray:
+    """Deprecated: kappa*H*Psi*Omega_sync*tau_K, intended as the source of
+    zero_noise_extrapolation's sigma_at_base_noise (see this module's own
+    docs/api/healing.md), but its 5 inputs never had a defined provenance
+    in a ZNE context -- and Dense-Evolution-Discovery Experiment 35
+    (scripts/zne_healing_sigma_provenance.py) has since shown that even a
+    fully-designed input wouldn't matter: a permutation-test negative
+    control (real sigma vs. randomly shuffled sigma) performed
+    statistically identically, meaning the healing-adapted branch's
+    coefficient perturbation doesn't discriminate real signal from noise
+    at all. Kept for backward compatibility only (no known external
+    callers found in Dense-Evolution, Dense-Evolution-Discovery, or
+    Dense-Armor); will be removed in a future major version. This wrapper
+    is intentionally NOT @jax.jit-decorated (unlike the private core it
+    delegates to) so the warning fires on every call, not just once per
+    traced input shape."""
+    warnings.warn(
+        "calculate_advanced_sigma is deprecated: its output was never wired into "
+        "any real pipeline, and Dense-Evolution-Discovery Experiment 35 found the "
+        "one place it could have been used (zero_noise_extrapolation's healing "
+        "branch) does not discriminate real sigma from random noise anyway. "
+        "Will be removed in a future release.",
+        DeprecationWarning, stacklevel=2,
+    )
+    return _calculate_advanced_sigma_core(kappa, H, Psi, Omega_sync, tau_K)
 
 @jax.jit
 def calculate_phi_ab(state_A: jnp.ndarray, state_B: jnp.ndarray, ipg_vector: jnp.ndarray) -> jnp.ndarray:

--- a/docs/api/healing.md
+++ b/docs/api/healing.md
@@ -38,8 +38,15 @@ healing-adapted branch (triggered by passing `sigma_at_base_noise`) calls
 `calculate_delta_preemp` from this module. Unlike `run_vector_healing`
 above, this branch is **not** currently reachable from the kernel or MCP:
 `dashboard_core.run_zne_mitigation` never passes `sigma_at_base_noise`,
-and the kernel's `MitigateRequest` has no field for it — deliberately
-left as a known follow-up rather than wired up speculatively, since
-`calculate_advanced_sigma` (the usual source of a real `sigma_at_base_noise`
-value) itself needs `kappa`/`H`/`Psi`/`Omega_sync`/`tau_K` inputs whose
-provenance in a ZNE context isn't yet designed.
+and the kernel's `MitigateRequest` has no field for it. This was
+originally left as a known follow-up pending `calculate_advanced_sigma`'s
+undefined input provenance — that question has since been closed, not
+completed: Dense-Evolution-Discovery Experiment 35
+(`scripts/zne_healing_sigma_provenance.py`) fed the branch a real,
+oracle-free `sigma_at_base_noise` (the empirical std of the noisy trial
+ensemble) and found, via a permutation-test negative control, that the
+branch's coefficient perturbation doesn't discriminate real sigma from
+randomly shuffled sigma at all — a confound, not a usable signal. Wiring
+this branch up would not have helped even with fully-designed inputs.
+`calculate_advanced_sigma` is now deprecated (`DeprecationWarning`,
+kept for backward compatibility only) rather than completed.

--- a/tests/unit/test_healing.py
+++ b/tests/unit/test_healing.py
@@ -27,8 +27,9 @@ from dense_evolution import DenseSVSimulator, GATES, healing
 class TestPredictiveHealingCore:
 
     def test_advanced_sigma_is_product_of_inputs(self):
-        s = healing.calculate_advanced_sigma(
-            jnp.array(2.0), jnp.array(3.0), jnp.array(1.0), jnp.array(1.0), jnp.array(1.0))
+        with pytest.warns(DeprecationWarning, match="calculate_advanced_sigma is deprecated"):
+            s = healing.calculate_advanced_sigma(
+                jnp.array(2.0), jnp.array(3.0), jnp.array(1.0), jnp.array(1.0), jnp.array(1.0))
         assert float(s) == pytest.approx(6.0)
 
     def test_phi_ab_identical_states_returns_baseline_0_7(self):


### PR DESCRIPTION
`calculate_advanced_sigma` had no real callers (only its own tautological unit test) and was meant to feed `zero_noise_extrapolation`'s healing branch. Dense-Evolution-Discovery Experiment 35 tested that branch with a real, oracle-free `sigma_at_base_noise` and found — via a permutation-test negative control — that it doesn't discriminate real signal from randomly shuffled noise at all. Adds a `DeprecationWarning` (same pattern as `run_circuit_jit_beast_mode`), updates `docs/api/healing.md`, extends the existing unit test to assert the warning. No version bump (routine PR, per this repo's release-workflow rule).