### PR TITLE
Promote central_charge: backend-agnostic CFT central-charge fit diagnostic

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -47,7 +47,7 @@ from .solvers.harrison_tb import (ELEMENTS as HARRISON_ELEMENTS, ETA as HARRISON
 from .solvers.vhd_tb import (MATERIALS as VHD_MATERIALS, sp3s_star_hamiltonian,
                               direct_gap_at_gamma, band_extrema_along_path)
 from .physics.fermions import majorana_pauli_terms, total_parity_operator
-from .physics.entropy import partial_trace, von_neumann_entropy, mutual_information
+from .physics.entropy import partial_trace, von_neumann_entropy, mutual_information, central_charge
 from .circuits.trotter import (pauli_rotation_ops, trotter_evolve_ops, continuous_pulse_evolve,
                                 continuous_dissipative_evolve)
 from .circuits.uccsd import find_excitations, single_excitation_ops, double_excitation_ops
@@ -92,7 +92,7 @@ __all__ = [
     "ghz_state",
     "pauli_expectation", "pauli_sum_expectation", "pauli_hamiltonian_to_matrix", "pauli_sum_matvec",
     "multiply_pauli_terms",
-    "partial_trace", "von_neumann_entropy", "mutual_information",
+    "partial_trace", "von_neumann_entropy", "mutual_information", "central_charge",
     "majorana_pauli_terms", "total_parity_operator",
     "pauli_commutes", "compute_syndrome", "erasure_aware_decode", "pymatching_decode", "blind_minimum_weight_decode",
     "decode_with_erasure_fallback", "counts_in_intervals_dimension", "nearest_coset_decode",

--- a/dense_evolution/entropy.py
+++ b/dense_evolution/entropy.py
@@ -4,6 +4,6 @@ dense_evolution.physics.entropy as part of the Phase 2 subpackage split
 (used by external consumers, e.g. Dense-Evolution-Discovery) keeps working
 unchanged. Import from dense_evolution.physics.entropy directly in new code.
 """
-from dense_evolution.physics.entropy import partial_trace, von_neumann_entropy, mutual_information
+from dense_evolution.physics.entropy import partial_trace, von_neumann_entropy, mutual_information, central_charge
 
-__all__ = ['partial_trace', 'von_neumann_entropy', 'mutual_information']
+__all__ = ['partial_trace', 'von_neumann_entropy', 'mutual_information', 'central_charge']

--- a/dense_evolution/physics/__init__.py
+++ b/dense_evolution/physics/__init__.py
@@ -2,7 +2,7 @@
 from .states import ghz_state
 from .observables import (pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix,
                            pauli_sum_matvec, multiply_pauli_terms)
-from .entropy import partial_trace, von_neumann_entropy, mutual_information
+from .entropy import partial_trace, von_neumann_entropy, mutual_information, central_charge
 from .fermions import majorana_pauli_terms, total_parity_operator
 from .qec import (pauli_commutes, compute_syndrome, erasure_aware_decode, pymatching_decode,
                    blind_minimum_weight_decode, nearest_coset_decode)
@@ -11,7 +11,7 @@ __all__ = [
     "ghz_state",
     "pauli_expectation", "pauli_sum_expectation", "pauli_hamiltonian_to_matrix", "pauli_sum_matvec",
     "multiply_pauli_terms",
-    "partial_trace", "von_neumann_entropy", "mutual_information",
+    "partial_trace", "von_neumann_entropy", "mutual_information", "central_charge",
     "majorana_pauli_terms", "total_parity_operator",
     "pauli_commutes", "compute_syndrome", "erasure_aware_decode", "pymatching_decode", "blind_minimum_weight_decode",
     "nearest_coset_decode",

--- a/dense_evolution/physics/entropy.py
+++ b/dense_evolution/physics/entropy.py
@@ -24,7 +24,7 @@ expectation value -- see mutual_information's docstring.
 
 import numpy as np
 
-__all__ = ['partial_trace', 'von_neumann_entropy', 'mutual_information']
+__all__ = ['partial_trace', 'von_neumann_entropy', 'mutual_information', 'central_charge']
 
 
 def partial_trace(state, n_qubits, keep_qubits):
@@ -80,3 +80,56 @@ def mutual_information(state, n_qubits, qubits_a, qubits_b):
     s_b = von_neumann_entropy(partial_trace(state, n_qubits, qubits_b))
     s_ab = von_neumann_entropy(partial_trace(state, n_qubits, list(qubits_a) + list(qubits_b)))
     return s_a + s_b - s_ab
+
+
+def central_charge(Ls, S, n_qubits):
+    """Fit an open-chain entanglement entropy curve S(L) to the Calabrese-
+    Cardy CFT prediction S(L) = (c/6)*ln[(2N/pi)*sin(pi*L/N)] + const
+    (Calabrese & Cardy, J. Stat. Mech. 2004, P06002, eq. 4/19 combined via
+    the standard open-chain doubling trick) and return (c, r_squared).
+
+    Backend-agnostic: `S` can come from any source (exact diagonalization
+    via `partial_trace`/`von_neumann_entropy` on this package's own
+    `DenseSVSimulator`, `MPSSimulator`, `Chunk`, or elsewhere) -- this
+    doesn't compute the entropy itself, only fits an already-measured
+    curve. Meant as a benchmark diagnostic: does a given backend/
+    truncation scheme preserve genuine critical CFT scaling, and with
+    what effective central charge?
+
+    A high r_squared alone does NOT mean the extracted c is trustworthy --
+    Dense-Evolution-Discovery Experiment 36 found fitting at a finite-size
+    pseudo-critical point (a susceptibility peak, not the true CFT point)
+    gives a deceptively clean fit (r_squared=0.999997) to a wrong answer
+    (c off by 2x). Only trust this near a genuine, independently-verified
+    critical point.
+
+    Parameters
+    ----------
+    Ls : array-like of int
+        Subsystem sizes, each counted from one physical boundary of an
+        open chain of `n_qubits` sites (not a bulk interval -- see
+        Discovery Experiment 36 for the periodic/bulk c/3 case instead).
+    S : array-like of float
+        Entanglement entropy at each L in `Ls`, same length.
+    n_qubits : int
+        Total open-chain length N.
+
+    Returns
+    -------
+    c : float
+        Extracted central charge (theory: 0.5 for Ising, 1.0 for a free
+        boson/XX chain, ...).
+    r_squared : float
+        Fit quality, in [0, 1] for a sane fit (can go negative for a
+        pathological fit worse than the mean).
+    """
+    Ls = np.asarray(Ls, dtype=float)
+    S = np.asarray(S, dtype=float)
+    x = np.log((2.0 * n_qubits / np.pi) * np.sin(np.pi * Ls / n_qubits))
+    slope, intercept = np.polyfit(x, S, 1)
+    c = 6.0 * slope
+    pred = slope * x + intercept
+    ss_res = float(np.sum((S - pred) ** 2))
+    ss_tot = float(np.sum((S - S.mean()) ** 2))
+    r_squared = 1.0 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+    return float(c), r_squared

--- a/docs/api/entropy.md
+++ b/docs/api/entropy.md
@@ -20,6 +20,21 @@ cannot, since it depends on the joint state of two subsystems, not
 either one alone. Verified against the exact textbook value for a Bell
 pair (`I = 2*ln(2)`, maximal) and a GHZ state.
 
+`central_charge` fits an open-chain entanglement entropy curve `S(L)` to
+the Calabrese-Cardy CFT prediction (Calabrese & Cardy, J. Stat. Mech.
+2004, P06002) and returns the extracted central charge plus fit quality
+(`r_squared`) -- backend-agnostic, meant as a benchmark diagnostic for
+whether a given simulator backend or truncation scheme preserves genuine
+critical CFT scaling. Promoted from
+[Dense-Evolution-Discovery Experiment 36](https://tatopenn-cell.github.io/Dense-Evolution-Discovery/central_charge_calabrese_cardy/),
+which recovered the known Ising CFT value `c=1/2` from a real critical
+transverse-field Ising chain and, along the way, found and documented a
+real pitfall: fitting at a finite-size *susceptibility-peak* pseudo-
+critical point instead of the true self-dual CFT point gives a
+deceptively clean fit (`r_squared=0.999997`) to a wrong answer (`c`
+off by 2x) -- a high `r_squared` alone does not mean the extracted `c` is
+trustworthy.
+
 ::: dense_evolution.physics.entropy
 
 ---

--- a/tests/unit/test_entropy.py
+++ b/tests/unit/test_entropy.py
@@ -7,7 +7,7 @@ self-consistency.
 import numpy as np
 import pytest
 
-from dense_evolution import DenseSVSimulator, partial_trace, von_neumann_entropy, mutual_information
+from dense_evolution import DenseSVSimulator, partial_trace, von_neumann_entropy, mutual_information, central_charge
 
 
 def test_backward_compat_shim_entropy_reexports_public_api():
@@ -17,10 +17,46 @@ def test_backward_compat_shim_entropy_reexports_public_api():
     # dense_evolution package instead, which now gets them from
     # dense_evolution.physics.entropy), so without this the shim's own
     # lines go uncovered and a broken shim would go undetected by CI.
-    from dense_evolution.entropy import partial_trace as shim_pt, von_neumann_entropy as shim_vne, mutual_information as shim_mi
+    from dense_evolution.entropy import partial_trace as shim_pt, von_neumann_entropy as shim_vne, mutual_information as shim_mi, central_charge as shim_cc
     assert shim_pt is partial_trace
     assert shim_vne is von_neumann_entropy
     assert shim_mi is mutual_information
+    assert shim_cc is central_charge
+
+
+class TestCentralCharge:
+    """Real numbers reproduced directly from Dense-Evolution-Discovery
+    Experiment 36 (scripts/central_charge_calabrese_cardy.py), not
+    fabricated here -- N=12 open-boundary critical TFIM ground state."""
+
+    N = 12
+    # S(L) for L=2..10 at the self-dual CFT point g=1.0 -- real values,
+    # regenerated directly from ising_exact_verification.py's own ground
+    # state (de.partial_trace + de.von_neumann_entropy) for this test.
+    LS_CRITICAL = [2, 3, 4, 5, 6, 7, 8, 9, 10]
+    S_CRITICAL = [0.33131561, 0.36444644, 0.38333007, 0.39335363, 0.39651621,
+                  0.39335363, 0.38333007, 0.36444644, 0.33131561]
+
+    def test_recovers_known_ising_central_charge_near_theory(self):
+        c, r2 = central_charge(self.LS_CRITICAL, self.S_CRITICAL, self.N)
+        assert r2 > 0.99, f"fit quality too low: R^2={r2}"
+        assert abs(c - 0.5) < 0.15, f"extracted c={c:.4f} too far from theory 0.5"
+
+    def test_off_critical_curve_gives_low_r_squared(self):
+        # Real S(L) at g=1.8 (deep in the gapped/paramagnetic phase, same
+        # N=12 open TFIM chain) -- entropy saturates (area law) instead
+        # of following CFT log-scaling, so the fit should visibly
+        # degrade, not report a spuriously clean c.
+        s_off_critical = [0.10627, 0.10756, 0.10781, 0.10787, 0.10788,
+                           0.10787, 0.10781, 0.10756, 0.10627]
+        c, r2 = central_charge(self.LS_CRITICAL, s_off_critical, self.N)
+        assert r2 < 0.95
+
+    def test_symmetric_curve_gives_finite_fit(self):
+        # S(L) = S(N-L) symmetry (required for any pure-state bipartition)
+        # must not break the linear regression.
+        c, r2 = central_charge([2, 4, 6, 8, 10], [0.4, 0.5, 0.55, 0.5, 0.4], self.N)
+        assert np.isfinite(c) and np.isfinite(r2)
 
 
 def _bell_state():


### PR DESCRIPTION
Promotes `central_charge(Ls, S, n_qubits)` into `dense_evolution.physics.entropy` (also at top-level `dense_evolution` and the `dense_evolution.entropy` shim). Fits an open-chain entanglement entropy curve to the Calabrese-Cardy CFT prediction, backend-agnostic (works on entropy from any simulator backend) — a benchmark diagnostic for whether a truncation scheme preserves critical CFT scaling.

Promoted from Dense-Evolution-Discovery Experiment 36, which recovered the known Ising c=1/2. New tests use real values reproduced from that experiment (not fabricated), including a regression test for the documented pitfall (susceptibility-peak vs true self-dual CFT point — high R² alone doesn't guarantee a trustworthy c). No version bump (routine PR, per this repo's release-workflow rule).