### PR TITLE
Bump version to 8.1.70 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dense-evolution"
-version = "8.1.69"
+version = "8.1.70"
 description = "Micro-optimized High-Performance NISQ Statevector Quantum Circuit Simulator (Hardware-Adaptive Integration of Native NumPy and CPU/GPU/TPU JAX JIT/XLA Compilation, with Linear Kernel Fusion)"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Version bump for the upcoming PyPI release, covering: `calculate_advanced_sigma` deprecation, `central_charge` promotion (Discovery Experiment 36), and the mind-map docs removal. Per the release workflow: build happens now, PyPI upload is the user's own step, tag/GitHub release only after that succeeds.