### PR TITLE
Add PauliSumOperator (JAX-native, matrix-free VQE Hamiltonian) + fix import warnings

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -36,7 +36,8 @@ from .mitigation.zne import (richardson_extrapolate, zero_noise_extrapolation, p
 from .circuits.diagram import plot_circuit
 from .circuits.topology import entangling_layer
 from .physics.observables import (pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix,
-                                   pauli_sum_matvec, multiply_pauli_terms)
+                                   pauli_sum_matvec, multiply_pauli_terms,
+                                   pauli_sum_matvec_jax, pauli_sum_expectation_jax, PauliSumOperator)
 from .physics.states import ghz_state
 from .utils.measurement import sample_counts, statevector_fidelity
 from .circuits.qft import qft
@@ -92,6 +93,7 @@ __all__ = [
     "ghz_state",
     "pauli_expectation", "pauli_sum_expectation", "pauli_hamiltonian_to_matrix", "pauli_sum_matvec",
     "multiply_pauli_terms",
+    "pauli_sum_matvec_jax", "pauli_sum_expectation_jax", "PauliSumOperator",
     "partial_trace", "von_neumann_entropy", "mutual_information", "central_charge",
     "majorana_pauli_terms", "total_parity_operator", "hubbard_hamiltonian_pauli_terms",
     "pauli_commutes", "compute_syndrome", "erasure_aware_decode", "pymatching_decode", "blind_minimum_weight_decode",

--- a/dense_evolution/mitigation/magic_entropy.py
+++ b/dense_evolution/mitigation/magic_entropy.py
@@ -40,6 +40,8 @@ promoted alongside this module in magic_entropy_shadows.py -- see that
 module for why it has its own API shape (measurement snapshots in, not a
 density matrix) rather than a function alongside this one.
 """
+import functools
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -77,7 +79,29 @@ def _build_key_unitary_k3() -> jnp.ndarray:
     return jnp.array(layer2 @ layer1, dtype=jnp.complex128)
 
 
-_KEY_UNITARY_K3 = _build_key_unitary_k3()
+@functools.lru_cache(maxsize=1)
+def _key_unitary_k3() -> jnp.ndarray:
+    """Cached, lazily-built K3 Key Unitary -- NOT a bare module-level
+    constant (that used to be `_KEY_UNITARY_K3 = _build_key_unitary_k3()`,
+    evaluated at import time). A bare module-level `jnp.array(...,
+    dtype=jnp.complex128)` runs before anything has had a chance to call
+    `dense_evolution.config.ensure_x64()` (only DenseSVSimulator,
+    QuantumHardwareRegistry and circuit_to_energy_fn do that, and only
+    the first time one of them is constructed) -- so on a bare `import
+    dense_evolution`, jax_enable_x64 is still False at this point, and
+    JAX both silently truncates the requested complex128 to complex64
+    AND raises a UserWarning about it, on every fresh interpreter
+    (verified directly: 3-4 near-identical warnings fire on a plain
+    `import dense_evolution as de`, one per such module-level constant
+    across this file and magic_entropy_shadows.py, before this fix).
+    Wrapping it in a cached lazy getter defers construction to first
+    actual use (typically after some simulator has already called
+    ensure_x64()), which both silences the spurious warning in the
+    common case and avoids permanently baking in whatever precision
+    happened to be active at import time -- exactly the "lazy, not an
+    import-time side effect" policy dense_evolution.config already
+    documents for the rest of the package, just not yet applied here."""
+    return _build_key_unitary_k3()
 
 
 def _self_convolve_3_core(rho: jnp.ndarray) -> jnp.ndarray:
@@ -86,8 +110,9 @@ def _self_convolve_3_core(rho: jnp.ndarray) -> jnp.ndarray:
     `dense_evolution.physics.entropy.partial_trace` -- that helper is
     pure-statevector-only, and this needs to trace out a general (possibly
     mixed) 3-qubit density matrix built from a possibly-mixed input."""
+    key_unitary = _key_unitary_k3()
     rho_full = jnp.kron(jnp.kron(rho, rho), rho)
-    evolved = _KEY_UNITARY_K3 @ rho_full @ jnp.conj(_KEY_UNITARY_K3).T
+    evolved = key_unitary @ rho_full @ jnp.conj(key_unitary).T
     tensor = evolved.reshape(2, 2, 2, 2, 2, 2)
     return jnp.einsum("ijkljk->il", tensor)
 

--- a/dense_evolution/mitigation/magic_entropy_shadows.py
+++ b/dense_evolution/mitigation/magic_entropy_shadows.py
@@ -29,11 +29,13 @@ snapshot, from a recorded basis+outcome).
 Restricted to SINGLE-QUBIT density matrices, matching `magic_entropy`'s
 own scope.
 """
+import functools
+
 import jax
 import jax.numpy as jnp
 import numpy as np
 
-from .magic_entropy import _KEY_UNITARY_K3
+from .magic_entropy import _key_unitary_k3
 
 __all__ = [
     "sample_classical_shadow", "magic_entropy_from_shadows",
@@ -42,9 +44,16 @@ __all__ = [
 
 # Single-qubit random-Pauli classical shadow protocol (Huang, Kueng,
 # Preskill 2020, eq. 2-3): the three diagonalizing unitaries for X, Y, Z.
-_H = jnp.array([[1.0, 1.0], [1.0, -1.0]], dtype=jnp.complex128) / jnp.sqrt(2.0)
-_SDAG = jnp.array([[1.0, 0.0], [0.0, -1j]], dtype=jnp.complex128)
-_BASIS_U = jnp.stack([_H, _H @ _SDAG, jnp.eye(2, dtype=jnp.complex128)])
+@functools.lru_cache(maxsize=1)
+def _basis_u() -> jnp.ndarray:
+    """Cached, lazily-built stack of the 3 diagonalizing unitaries -- same
+    "defer past the import-time x64 warning" fix as magic_entropy.py's
+    _key_unitary_k3(); see that function's docstring for why a bare
+    module-level `jnp.array(..., dtype=jnp.complex128)` here used to fire
+    a spurious UserWarning on every `import dense_evolution`."""
+    h = jnp.array([[1.0, 1.0], [1.0, -1.0]], dtype=jnp.complex128) / jnp.sqrt(2.0)
+    sdag = jnp.array([[1.0, 0.0], [0.0, -1j]], dtype=jnp.complex128)
+    return jnp.stack([h, h @ sdag, jnp.eye(2, dtype=jnp.complex128)])
 
 
 def sample_classical_shadow(rho: jnp.ndarray, n_snapshots: int, seed: int = 0) -> jnp.ndarray:
@@ -70,8 +79,10 @@ def sample_classical_shadow(rho: jnp.ndarray, n_snapshots: int, seed: int = 0) -
     key_basis, key_bit = jax.random.split(key)
     bases = jax.random.randint(key_basis, (n_snapshots,), 0, 3)
 
+    basis_u = _basis_u()
+
     def prob0(basis_idx):
-        u = _BASIS_U[basis_idx]
+        u = basis_u[basis_idx]
         rotated = u @ rho @ jnp.conj(u).T
         return jnp.clip(jnp.real(rotated[0, 0]), 0.0, 1.0)
 
@@ -80,7 +91,7 @@ def sample_classical_shadow(rho: jnp.ndarray, n_snapshots: int, seed: int = 0) -
     bits = (uniforms > probs0).astype(jnp.int32)
 
     def snapshot_matrix(basis_idx, bit):
-        u = _BASIS_U[basis_idx]
+        u = basis_u[basis_idx]
         b_ket = jnp.array([1.0, 0.0], dtype=jnp.complex128) * (1 - bit) + \
             jnp.array([0.0, 1.0], dtype=jnp.complex128) * bit
         proj = jnp.outer(b_ket, jnp.conj(b_ket))
@@ -89,31 +100,33 @@ def sample_classical_shadow(rho: jnp.ndarray, n_snapshots: int, seed: int = 0) -
     return jax.vmap(snapshot_matrix)(bases, bits)
 
 
+@functools.lru_cache(maxsize=1)
 def _o_operators():
     """O_ab = V^dagger (|b><a| (x) I_4) V such that R_ab = Tr[O_ab . rho^{(x)3}]
     -- the same construction `magic_entropy.py`'s `_self_convolve_3_core`
     applies to exact `rho`, here turned into fixed operators so each entry
     is a LINEAR functional of `rho^{(x)3}` (the shape a shadow-snapshot
     U-statistic estimator needs). Reuses this package's own
-    `_KEY_UNITARY_K3` directly rather than duplicating it (unlike
+    `_key_unitary_k3()` directly rather than duplicating it (unlike
     Dense-Evolution-Discovery's per-script self-containment convention,
     this library's internal modules import from each other freely). The
     `|b><a|` (not `|a><b|`) projector is deliberate: a direct index-expansion
     check (not just the cyclic-trace derivation, which looks right on paper
     but hides the swap) showed `Tr[(|a><b| (x) I) M] = R_ba`, not `R_ab` --
     caught in Discovery Experiment 31 by a unit test checking matrix
-    entries directly, not just the downstream entropy."""
+    entries directly, not just the downstream entropy.
+
+    Cached/lazy (functools.lru_cache), not a bare module-level constant
+    -- same "defer past the import-time x64 warning" fix as
+    magic_entropy.py's _key_unitary_k3() and this module's _basis_u()."""
     i4 = jnp.eye(4, dtype=jnp.complex128)
-    v = _KEY_UNITARY_K3
+    v = _key_unitary_k3()
     ops = {}
     for a in range(2):
         for b in range(2):
             proj_ba = jnp.zeros((2, 2), dtype=jnp.complex128).at[b, a].set(1.0)
             ops[(a, b)] = jnp.conj(v).T @ jnp.kron(proj_ba, i4) @ v
     return ops
-
-
-_O_AB = _o_operators()
 
 
 def _median_of_means(values: np.ndarray, n_groups: int) -> float:
@@ -172,7 +185,7 @@ def magic_entropy_from_shadows(shadow_snapshots: jnp.ndarray, n_groups: int = 20
     rho3_batch = jax.vmap(triple_kron)(triples)
 
     r_hat = jnp.zeros((2, 2), dtype=jnp.complex128)
-    for (a, b), o_ab in _O_AB.items():
+    for (a, b), o_ab in _o_operators().items():
         vals = np.array(jnp.einsum("ij,tji->t", o_ab, rho3_batch))
         real_part = _median_of_means(vals.real, n_groups)
         imag_part = _median_of_means(vals.imag, n_groups)

--- a/dense_evolution/physics/__init__.py
+++ b/dense_evolution/physics/__init__.py
@@ -1,7 +1,8 @@
 """Physics subpackage: state preparation, observables, entropy, fermions, QEC."""
 from .states import ghz_state
 from .observables import (pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix,
-                           pauli_sum_matvec, multiply_pauli_terms)
+                           pauli_sum_matvec, multiply_pauli_terms,
+                           pauli_sum_matvec_jax, pauli_sum_expectation_jax, PauliSumOperator)
 from .entropy import partial_trace, von_neumann_entropy, mutual_information, central_charge
 from .fermions import majorana_pauli_terms, total_parity_operator, hubbard_hamiltonian_pauli_terms
 from .qec import (pauli_commutes, compute_syndrome, erasure_aware_decode, pymatching_decode,
@@ -11,6 +12,7 @@ __all__ = [
     "ghz_state",
     "pauli_expectation", "pauli_sum_expectation", "pauli_hamiltonian_to_matrix", "pauli_sum_matvec",
     "multiply_pauli_terms",
+    "pauli_sum_matvec_jax", "pauli_sum_expectation_jax", "PauliSumOperator",
     "partial_trace", "von_neumann_entropy", "mutual_information", "central_charge",
     "majorana_pauli_terms", "total_parity_operator", "hubbard_hamiltonian_pauli_terms",
     "pauli_commutes", "compute_syndrome", "erasure_aware_decode", "pymatching_decode", "blind_minimum_weight_decode",

--- a/dense_evolution/physics/observables.py
+++ b/dense_evolution/physics/observables.py
@@ -19,10 +19,12 @@ qubit 0 upward (`pauli_terms[q]` is the operator on qubit q), independent
 of this internal bit-position detail.
 """
 import numpy as np
+import jax.numpy as jnp
 
 __all__ = [
     'pauli_expectation', 'pauli_sum_expectation', 'pauli_hamiltonian_to_matrix',
     'pauli_sum_matvec', 'multiply_pauli_terms',
+    'pauli_sum_matvec_jax', 'pauli_sum_expectation_jax', 'PauliSumOperator',
 ]
 
 _PAULI_MATRICES = {
@@ -304,6 +306,148 @@ def pauli_sum_matvec(vector, terms, n_qubits=None):
         result += coeff * _apply_pauli_term(vector, normalized, inferred_n_qubits)
 
     return result
+
+
+def _apply_pauli_term_jax(statevector, terms, inferred_n_qubits):
+    """JAX-native counterpart of _apply_pauli_term -- pure jnp ops, no
+    np.asarray/float() cast on `statevector`, so this stays valid under
+    jax.grad/jax.jit tracing (same split as _jsd_vectors/_jsd_vectors_jax
+    in dense_evolution.backends.mps). `terms` (already-normalized dict)
+    and `inferred_n_qubits` are always plain Python objects, never traced
+    -- only `statevector` is ever a tracer here."""
+    if not terms:
+        return statevector
+
+    def bit_pos(q):
+        return inferred_n_qubits - 1 - q
+
+    flip_mask = 0
+    for q, p in terms.items():
+        if p in ('X', 'Y'):
+            flip_mask |= (1 << bit_pos(q))
+
+    dim = statevector.shape[0]
+    indices = jnp.arange(dim)
+    source_idx = indices ^ flip_mask
+
+    coeff = jnp.ones(dim, dtype=jnp.complex128)
+    for q, p in terms.items():
+        bit = (source_idx >> bit_pos(q)) & 1
+        if p == 'Y':
+            coeff = coeff * jnp.where(bit == 0, 1j, -1j)
+        elif p == 'Z':
+            coeff = coeff * jnp.where(bit == 0, 1.0, -1.0)
+
+    return statevector[source_idx] * coeff
+
+
+def pauli_sum_matvec_jax(vector, terms, n_qubits=None):
+    """JAX-native counterpart of pauli_sum_matvec: H @ vector for a
+    Hamiltonian given as a weighted sum of Pauli strings, never building
+    the 2**n_qubits matrix -- but pure jnp internally (no np.asarray/
+    float() on `vector`), so unlike pauli_sum_matvec itself this stays
+    valid under jax.grad/jax.jit tracing. Verified to agree with
+    pauli_sum_matvec to floating-point precision, and to give correct
+    gradients (matching a dense pauli_hamiltonian_to_matrix reference)
+    -- see test_pauli_sum_jax_matches_numpy_and_is_differentiable.
+
+    `terms`/`n_qubits` must stay plain Python objects (never traced) --
+    only `vector` may be a JAX tracer.
+
+    PRECISION GOTCHA: this function never calls dense_evolution.config's
+    ensure_x64() itself (it's a pure math function, no opinion on global
+    JAX state) -- if nothing else in the process has constructed a
+    DenseSVSimulator/QuantumHardwareRegistry/circuit_to_energy_fn yet
+    (the only things that call ensure_x64() lazily), JAX is still at its
+    float32 default, and this silently runs at complex64 precision with
+    no error, just ~1e-7 relative accuracy instead of ~1e-16 -- verified
+    directly (a standalone correctness selftest run before constructing
+    anything else failed at max_diff=7.10e-07, exactly float32 relative
+    precision, until dense_evolution.set_precision(True) was called
+    first). Call dense_evolution.set_precision(True) yourself up front
+    if you're using this standalone, before anything else has a chance
+    to enable x64 for you.
+
+    This is what lets a differentiable VQE loop reach 20+ qubits at all.
+    circuit_to_energy_fn's own h_matrix @ statevector path needs a dense
+    (2**n_qubits, 2**n_qubits) matrix -- physically impossible to hold
+    much past ~14 qubits (2**28 complex128 entries = 4GB, x4 per extra
+    qubit) -- while the statevector itself stays linear in dim (2**20
+    complex128 = 16MB at 20 qubits, no problem at all). Drop this in as
+    circuit_to_energy_fn's `h_matrix` argument via PauliSumOperator
+    (below), whose only job is wrapping this behind `__matmul__` since
+    that's the only operation energy_fn performs on h_matrix:
+
+        from dense_evolution import circuit_to_energy_fn, PauliSumOperator
+        energy_fn, n_params = circuit_to_energy_fn(circuit, n_qubits=20)
+        h_op = PauliSumOperator(terms, n_qubits=20)
+        energy, sv = energy_fn(theta, h_op)
+        grad = jax.grad(lambda th: energy_fn(th, h_op)[0])(theta)
+    """
+    dim = vector.shape[0]
+    inferred_n_qubits = dim.bit_length() - 1
+    if 1 << inferred_n_qubits != dim:
+        raise ValueError(f"vector length {dim} is not a power of 2")
+
+    vector = jnp.asarray(vector, dtype=jnp.complex128)
+    result = jnp.zeros(dim, dtype=jnp.complex128)
+    for coeff, pauli_terms in terms:
+        normalized = _normalize_terms(pauli_terms, n_qubits)
+        if normalized and max(normalized) >= inferred_n_qubits:
+            raise ValueError(
+                f"term references qubit {max(normalized)}, but vector only "
+                f"spans {inferred_n_qubits} qubits")
+        result = result + coeff * _apply_pauli_term_jax(vector, normalized, inferred_n_qubits)
+
+    return result
+
+
+def pauli_sum_expectation_jax(statevector, terms, n_qubits=None):
+    """JAX-native counterpart of pauli_sum_expectation -- same
+    sum_i coeff_i * <psi|P_i|psi>, pure jnp internally so it stays valid
+    under jax.grad/jax.jit (unlike pauli_sum_expectation, whose
+    np.asarray(statevector) forces concretization). Returns a jnp float
+    scalar, not a Python float -- call float(...) yourself outside a
+    traced context if you need one. `terms`/`n_qubits` must stay plain
+    Python objects; only `statevector` may be a tracer."""
+    dim = statevector.shape[0]
+    inferred_n_qubits = dim.bit_length() - 1
+    if 1 << inferred_n_qubits != dim:
+        raise ValueError(f"statevector length {dim} is not a power of 2")
+
+    statevector = jnp.asarray(statevector, dtype=jnp.complex128)
+    total = jnp.zeros((), dtype=jnp.float64)
+    for coeff, pauli_terms in terms:
+        normalized = _normalize_terms(pauli_terms, n_qubits)
+        if normalized and max(normalized) >= inferred_n_qubits:
+            raise ValueError(
+                f"term references qubit {max(normalized)}, but statevector only "
+                f"spans {inferred_n_qubits} qubits")
+        p_psi = _apply_pauli_term_jax(statevector, normalized, inferred_n_qubits)
+        total = total + coeff * jnp.real(jnp.vdot(statevector, p_psi))
+
+    return total
+
+
+class PauliSumOperator:
+    """Matrix-free Hamiltonian wrapper: presents a Pauli-sum Hamiltonian
+    (the same `terms` format pauli_sum_expectation/pauli_sum_matvec_jax
+    accept) as an object supporting `@`, so it can be dropped in wherever
+    a dense h_matrix is expected without ever materializing one.
+
+    Written specifically for circuit_to_energy_fn(circuit, n_qubits)'s
+    energy_fn(theta, h_matrix, ...), whose only use of h_matrix is
+    `h_matrix @ statevector` -- see pauli_sum_matvec_jax's docstring for
+    the full worked example. `terms`/`n_qubits` are fixed at construction
+    (plain Python objects, never traced); only the vector passed to
+    `@` may be a JAX tracer, keeping the whole thing jax.grad-safe."""
+
+    def __init__(self, terms, n_qubits):
+        self.terms = terms
+        self.n_qubits = n_qubits
+
+    def __matmul__(self, vector):
+        return pauli_sum_matvec_jax(vector, self.terms, n_qubits=self.n_qubits)
 
 
 _SAME_QUBIT_PAULI_PRODUCT = {

--- a/tests/unit/test_magic_entropy.py
+++ b/tests/unit/test_magic_entropy.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 
 from dense_evolution.mitigation import magic_entropy, magic_entropy_jit
-from dense_evolution.mitigation.magic_entropy import _KEY_UNITARY_K3, _self_convolve_3_core
+from dense_evolution.mitigation.magic_entropy import _key_unitary_k3, _self_convolve_3_core
 
 
 def _sv_to_rho(sv):
@@ -42,7 +42,7 @@ def test_key_unitary_matches_paper_lemma_9_identity():
             for x3 in (0, 1):
                 idx_in = (x1 << 2) | (x2 << 1) | x3
                 sv_in = jnp.zeros(8, dtype=jnp.complex128).at[idx_in].set(1.0)
-                sv_out = _KEY_UNITARY_K3 @ sv_in
+                sv_out = _key_unitary_k3() @ sv_in
                 y1, y2, y3 = x1 ^ x2 ^ x3, x2 ^ x1, x3 ^ x1
                 idx_expected = (y1 << 2) | (y2 << 1) | y3
                 out_idx = int(jnp.argmax(jnp.abs(sv_out)))
@@ -51,7 +51,7 @@ def test_key_unitary_matches_paper_lemma_9_identity():
 
 
 def test_key_unitary_is_unitary():
-    v = _KEY_UNITARY_K3
+    v = _key_unitary_k3()
     identity = jnp.eye(8, dtype=jnp.complex128)
     assert np.allclose(np.array(v @ jnp.conj(v).T), np.array(identity), atol=1e-10)
 

--- a/tests/unit/test_observables.py
+++ b/tests/unit/test_observables.py
@@ -3,6 +3,8 @@ Unit tests for dense_evolution/observables.py -- pauli_expectation and
 pauli_sum_expectation, cross-checked against brute-force dense Pauli
 matrices (kron products), not just against their own derivation.
 """
+import jax
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
@@ -10,7 +12,11 @@ from dense_evolution import DenseSVSimulator
 from dense_evolution.observables import (
     pauli_expectation, pauli_sum_expectation, pauli_hamiltonian_to_matrix, pauli_sum_matvec,
 )
-from dense_evolution.physics.observables import multiply_pauli_terms
+from dense_evolution.physics.observables import (
+    multiply_pauli_terms, pauli_sum_matvec_jax, pauli_sum_expectation_jax, PauliSumOperator,
+)
+from dense_evolution.solvers.autodiff import circuit_to_energy_fn
+from dense_evolution.circuits.parser import QASMParser
 
 _PAULI_MATS = {
     'I': np.eye(2, dtype=complex),
@@ -205,6 +211,116 @@ class TestPauliSumMatvec:
     def test_qubit_out_of_range_raises(self):
         with pytest.raises(ValueError):
             pauli_sum_matvec(np.zeros(4, dtype=complex), [(1.0, {5: 'Z'})])
+
+
+class TestPauliSumJax:
+    """pauli_sum_matvec_jax/pauli_sum_expectation_jax -- the JAX-native
+    (jax.grad/jax.jit-traceable) counterparts needed to run a
+    differentiable VQE past the ~14-qubit ceiling of circuit_to_energy_fn's
+    dense h_matrix @ statevector path. Cross-checked against the numpy
+    originals for correctness, and against a dense pauli_hamiltonian_to_matrix
+    reference for gradient correctness -- not just that they run under
+    jax.grad, but that the gradient they produce is the right one."""
+
+    def test_matvec_matches_numpy_version(self):
+        rng = np.random.default_rng(21)
+        n_qubits, dim = 4, 16
+        letters = ['I', 'X', 'Y', 'Z']
+        for _ in range(50):
+            n_terms = rng.integers(1, 6)
+            terms = [
+                (float(rng.normal()), ''.join(rng.choice(letters) for _ in range(n_qubits)))
+                for _ in range(n_terms)
+            ]
+            v = rng.normal(size=dim) + 1j * rng.normal(size=dim)
+            expected = pauli_sum_matvec(v, terms, n_qubits=n_qubits)
+            actual = pauli_sum_matvec_jax(jnp.asarray(v), terms, n_qubits=n_qubits)
+            assert np.allclose(np.asarray(actual), expected, atol=1e-9)
+
+    def test_expectation_matches_numpy_version(self):
+        rng = np.random.default_rng(22)
+        n_qubits, dim = 4, 16
+        letters = ['I', 'X', 'Y', 'Z']
+        for _ in range(50):
+            n_terms = rng.integers(1, 6)
+            terms = [
+                (float(rng.normal()), ''.join(rng.choice(letters) for _ in range(n_qubits)))
+                for _ in range(n_terms)
+            ]
+            psi = rng.normal(size=dim) + 1j * rng.normal(size=dim)
+            psi = psi / np.linalg.norm(psi)
+            expected = pauli_sum_expectation(psi, terms, n_qubits=n_qubits)
+            actual = pauli_sum_expectation_jax(jnp.asarray(psi), terms, n_qubits=n_qubits)
+            assert float(actual) == pytest.approx(expected, abs=1e-9)
+
+    def test_pauli_sum_operator_matmul_matches_matvec_jax(self):
+        terms = [(1.0, 'ZZ'), (0.5, {0: 'X'})]
+        op = PauliSumOperator(terms, n_qubits=2)
+        v = jnp.array([1.0, 0.0, 0.0, 0.0], dtype=jnp.complex128)
+        assert np.allclose(np.asarray(op @ v), np.asarray(pauli_sum_matvec_jax(v, terms, n_qubits=2)))
+
+    def test_circuit_to_energy_fn_via_pauli_sum_operator_matches_dense_h_matrix(self):
+        # The real point of PauliSumOperator: it must be a drop-in for
+        # circuit_to_energy_fn's h_matrix argument, giving the identical
+        # energy AND the identical jax.grad gradient as the dense
+        # pauli_hamiltonian_to_matrix path -- not just "runs without
+        # erroring under jax.grad".
+        n_qubits = 4
+        qasm = (
+            "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[4];\n"
+            "rx(0.0) q[0];\nrx(0.0) q[1];\nrx(0.0) q[2];\nrx(0.0) q[3];\n"
+            "cx q[0],q[1];\ncx q[1],q[2];\ncx q[2],q[3];\n"
+        )
+        circuit = QASMParser().parse(qasm)
+        energy_fn, n_params = circuit_to_energy_fn(circuit, n_qubits)
+        terms = [(1.0, {0: 'Z', 1: 'Z'}), (0.5, {2: 'X'}), (-0.3, {3: 'Y', 1: 'Y'})]
+        h_op = PauliSumOperator(terms, n_qubits)
+        h_dense = pauli_hamiltonian_to_matrix(terms, n_qubits)
+
+        theta = jnp.array([0.3, 0.5, 0.2, 0.1])
+
+        def loss_sparse(th):
+            e, _ = energy_fn(th, h_op)
+            return e
+
+        def loss_dense(th):
+            e, _ = energy_fn(th, h_dense)
+            return e
+
+        val_sparse, grad_sparse = jax.value_and_grad(loss_sparse)(theta)
+        val_dense, grad_dense = jax.value_and_grad(loss_dense)(theta)
+
+        assert float(val_sparse) == pytest.approx(float(val_dense), abs=1e-9)
+        assert np.allclose(np.asarray(grad_sparse), np.asarray(grad_dense), atol=1e-8)
+
+    def test_matvec_jax_qubit_out_of_range_raises(self):
+        with pytest.raises(ValueError):
+            pauli_sum_matvec_jax(jnp.zeros(4, dtype=jnp.complex128), [(1.0, {5: 'Z'})])
+
+    def test_matvec_jax_vector_length_not_a_power_of_two_raises(self):
+        with pytest.raises(ValueError):
+            pauli_sum_matvec_jax(jnp.zeros(5, dtype=jnp.complex128), [(1.0, {0: 'Z'})])
+
+    def test_matches_dense_matrix_at_whatever_precision_x64_is_set_to(self):
+        # Real gap found building the H10 VQE demo (Dense-Evolution-Discovery
+        # scripts/vqe_pauli_sum_zne_autodiff.py): pauli_sum_matvec_jax never
+        # calls dense_evolution.config.ensure_x64() itself, so a caller using
+        # it before anything else in the process has constructed a
+        # DenseSVSimulator/circuit_to_energy_fn silently runs at JAX's
+        # float32 default -- no error, just ~1e-7 relative accuracy instead
+        # of ~1e-16. This test only asserts the (weaker) float32-consistent
+        # tolerance, since it must pass regardless of whichever precision an
+        # earlier test in the same pytest process happened to leave x64 in
+        # -- the real fix is the docstring warning callers to opt in
+        # themselves via set_precision(True), not a global test-order
+        # assumption here.
+        rng = np.random.default_rng(23)
+        n_qubits, dim = 4, 16
+        terms = [(float(rng.normal()), 'ZZXY')]
+        v = rng.normal(size=dim) + 1j * rng.normal(size=dim)
+        expected = pauli_sum_matvec(v, terms, n_qubits=n_qubits)
+        actual = pauli_sum_matvec_jax(jnp.asarray(v), terms, n_qubits=n_qubits)
+        assert np.allclose(np.asarray(actual), expected, atol=1e-6)
 
 
 class TestMultiplyPauliTerms:


### PR DESCRIPTION
## Summary
- New `pauli_sum_matvec_jax`/`pauli_sum_expectation_jax` (JAX-native, `jax.grad`/`jax.jit`-traceable counterparts of the existing numpy-based `pauli_sum_matvec`/`pauli_sum_expectation`) and `PauliSumOperator` (wraps a Pauli-sum Hamiltonian behind `__matmul__`, drop-in for `circuit_to_energy_fn`'s `h_matrix` argument).
- Lets a differentiable VQE loop scale well past the ~14-qubit ceiling of the dense `h_matrix @ statevector` path (a dense Hamiltonian is O(4**n) memory; the statevector alone stays O(2**n)). Verified to match a dense reference to machine precision, in both value and gradient.
- Fixes 3-4 redundant JAX `UserWarning`s on every bare `import dense_evolution`, caused by `magic_entropy.py`/`magic_entropy_shadows.py` building `complex128` constants at module import time, before `ensure_x64()` has run. Made lazy (`functools.lru_cache`) instead.
- Built and validated in Dense-Evolution-Discovery's `vqe_pauli_sum_zne_autodiff.py` experiment (VQE + ZNE on a real 12-qubit H10 active-space Hamiltonian).

## Test plan
- [x] `pytest tests/unit/test_observables.py` -- 47/47 passed (6 new tests, including a gradient-correctness check against the dense reference).
- [x] `pytest tests/unit/test_magic_entropy.py` -- passed after updating the renamed private constant.
- [x] Full suite: 1063/1063 passed (2 earlier RESOURCE_EXHAUSTED failures were memory contention from concurrent background jobs on this machine, confirmed environmental by re-running in isolation).
- [x] `python -W error::UserWarning -c "import dense_evolution"` -- clean, no warnings.