### PR TITLE
Rewrite fermions/observables/healing docs per doc_writing_rules.txt

### DIFF
--- a/docs/api/fermions.md
+++ b/docs/api/fermions.md
@@ -1,54 +1,165 @@
-# Fermions (Majorana Jordan-Wigner mapping)
+# Fermions (Jordan-Wigner mapping)
 
-Majorana-fermion → qubit (Jordan-Wigner) mapping, one qubit per two
-Majorana modes: `chi_{2j-1} = (prod_{k<j} Z_k) X_j`,
-`chi_{2j} = (prod_{k<j} Z_k) Y_j`. Each `chi_i` is Hermitian and unit-
-normalized (`chi_i^2 = I`), and the anticommutation relation
-`{chi_a, chi_b} = 2*delta_ab*I` holds exactly — verified against the
-actual matrices, not assumed from the textbook formula alone.
+A fermion (an electron, say) obeys the Pauli exclusion principle -- two of them can
+never occupy the same state -- which shows up mathematically as *anticommutation*:
+swapping two fermionic operators flips a sign, `a*b = -b*a`, unlike ordinary qubit
+operators, which mostly commute. The Jordan-Wigner mapping is the standard recipe for
+building qubit operators that reproduce this anticommuting behavior exactly, by
+attaching a string of `Z` gates that tracks the "which fermions come before this one"
+bookkeeping. This module builds two different flavors of that mapping: Majorana
+operators (this page's main guide) and, for a specific Hubbard-model use case, ordinary
+fermion creation/annihilation operators (Step 4).
 
-Combine the returned Pauli term with
-[`pauli_hamiltonian_to_matrix`](observables.md) to build any
-Majorana-operator Hamiltonian as a dense matrix, e.g. a sparse
-Sachdev-Ye-Kitaev (SYK) model: `H = sum_{ijkl} J_ijkl * chi_i*chi_j*chi_k*chi_l`.
+## Step 1. A Majorana operator, and what makes it special
 
-`total_parity_operator` builds the "Klein factor" for a set of Majorana
-modes — the tool needed when TWO independently-Jordan-Wigner-mapped
-registers (e.g. the two sides of a thermofield-double/wormhole
-construction) must be combined into one joint fermionic algebra: their
-Majoranas commute across registers by construction (disjoint qubits),
-but a genuine cross-register Dirac fermion needs them to anticommute.
-Dressing one register's operators with its own `total_parity_operator`
-before combining fixes this — see the function's own docstring for the
-full derivation, and
-[Dense-Evolution-Discovery's wormhole_magic_entropy.py](https://tatopenn-cell.github.io/Dense-Evolution-Discovery/)
-for the real construction this was promoted from.
+```python
+import dense_evolution as de
 
-`hubbard_hamiltonian_pauli_terms` uses the OTHER standard Jordan-Wigner
-convention — ordinary spin-orbital creation/annihilation operators
-(`c_q = sigma+_q * Z-string`, not Majoranas) — to map the 1D Hubbard-ring
-Hamiltonian `H = -t*sum_<ij>,sigma (c^dagger_i c_j + h.c.) + U*sum_i
-n_i,up*n_i,down` onto Pauli terms. With `n_sites=4` and `periodic=True`
-this is the "Hubbard square" studied in Arovas, Bandyopadhyay & Zhu,
-"The Hubbard Model" (Annual Review of Condensed Matter Physics 2022,
-arXiv:2103.12097) — Table 2 (p.6) gives a closed-form small-`U/t`
-perturbative ground-state energy for this exact model, and identifies
-its ground state's orbital symmetry as `x^2-y^2` (B1g/d-wave). See
-[Dense-Evolution-Discovery's hubbard_square_arovas.py](https://tatopenn-cell.github.io/Dense-Evolution-Discovery/)
-(Experiment 38) for the full verification: the perturbative formula
-checked directly against the paper's own text, and the periodic
-wraparound bond (the one place a naive Jordan-Wigner implementation
-could plausibly need an extra parity correction) checked against an
-independent brute-force fermionic construction — machine-exact
-agreement, not assumed from the formula alone.
+de.majorana_pauli_terms(1, 2)
+```
+
+```
+(1.0, {0: 'X'})
+```
+
+`majorana_pauli_terms(mode_index, n_qubits)` returns one Majorana fermion operator as
+a `(coeff, {qubit: pauli})` term -- the same format
+[`pauli_hamiltonian_to_matrix`](observables.md) and
+[`pauli_sum_expectation`](observables.md) accept. `mode_index` runs from `1` to
+`2*n_qubits` (two Majorana modes share every qubit); mode `1` on a 2-qubit register is
+just `X` on qubit 0. Every Majorana operator is Hermitian and squares to the identity
+(`chi_i^2 = I`) -- it behaves like a real, physical observable, not an abstract
+placeholder.
+
+## Step 2. Anticommutation, checked on a real state
+
+```python
+qasm = 'OPENQASM 2.0; include "qelib1.inc"; qreg q[2]; h q[0]; cx q[0],q[1];'
+circuit = de.QASMParser().parse(qasm)
+sim = de.DenseSVSimulator(2)
+sim.run_circuit_jit(circuit.to_tuples())
+sv = sim.get_statevector()
+
+from dense_evolution.physics.observables import pauli_sum_matvec
+
+chi1 = de.majorana_pauli_terms(1, 2)
+chi3 = de.majorana_pauli_terms(3, 2)
+
+def apply(term, v):
+    coeff, pauli = term
+    return coeff * pauli_sum_matvec(v, [(1.0, pauli)], n_qubits=2)
+
+anticommutator = apply(chi1, apply(chi3, sv)) + apply(chi3, apply(chi1, sv))
+anticommutator
+```
+
+```
+array([0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j])
+```
+
+`sv` is the same Bell state built on the [Simulator](simulator.md) page. `chi1` lives
+entirely on qubit 0 (mode 1); `chi3` is mode 1 of the *second* Majorana pair, which
+lands on qubit 1 but carries a leading `Z` on qubit 0 -- the Jordan-Wigner string. That
+`Z` is exactly what makes `chi1` and `chi3` anticommute even though they act on
+different qubits: applying both operators in either order to the Bell state gives the
+exact zero vector, `{chi1, chi3}|psi> = 0` for every `|psi>`, the defining property of
+two independent Majorana modes.
+
+## Step 3. Combining two separate registers: the Klein factor
+
+```python
+de.total_parity_operator([1, 2, 3, 4], 2)
+```
+
+```
+((1+0j), {0: 'Z', 1: 'Z'})
+```
+
+`total_parity_operator` multiplies every Majorana in a register together, which
+collapses to the register's total-parity operator -- `Z` on every qubit in that
+register (all 4 modes of a 2-qubit register, above, give `Z0 Z1`). It anticommutes with
+every individual Majorana *in that same register*, the same way `chi1`/`chi3` did in
+Step 2. That property is the tool needed when two *independently* Jordan-Wigner-mapped
+registers (e.g. the two sides of a wormhole-teleportation construction) have to be
+combined into one joint fermionic algebra: two Majoranas from different registers act
+on disjoint qubits with no shared `Z`-string, so they naively *commute* -- wrong for a
+genuine cross-register fermion. Dressing one register's operators with its own
+`total_parity_operator` first restores the correct anticommutation across the join.
+
+## Step 4. A different mapping, for the Hubbard model
+
+```python
+terms = de.hubbard_hamiltonian_pauli_terms(n_sites=2, t=1.0, U=2.0, periodic=False)
+len(terms)
+```
+
+```
+12
+```
+
+The Hubbard model (electrons hopping between sites, paying an energy penalty `U` for
+two electrons sharing a site) needs ordinary creation/annihilation operators, not
+Majoranas -- `hubbard_hamiltonian_pauli_terms` uses the *other* standard Jordan-Wigner
+convention for that (`c_q = sigma+_q * Z-string`). `n_sites=2, periodic=False` is the
+smallest non-trivial case: 2 lattice sites, 4 qubits (spin-up and spin-down per site).
+
+```python
+qasm4 = 'OPENQASM 2.0; include "qelib1.inc"; qreg q[4]; x q[0]; x q[2];'
+circuit4 = de.QASMParser().parse(qasm4)
+energy_fn, n_params = de.circuit_to_energy_fn(circuit4, n_qubits=4)
+
+h_op = de.PauliSumOperator(terms, n_qubits=4)
+theta = []
+energy, sv = energy_fn(theta, h_op)
+energy
+```
+
+```
+2.0
+```
+
+`x q[0]; x q[2];` prepares both spin-up and spin-down electrons on site 0 -- one
+doubly-occupied site, no electron anywhere else. No hopping is possible from a state
+this localized (`t` never contributes), so the energy is exactly the interaction
+penalty `U=2.0` for that one double occupancy -- [`PauliSumOperator`](observables.md)
+applies `terms` directly to the statevector, the same differentiable path
+[`circuit_to_energy_fn`](autodiff.md) uses for `jax.grad`-based VQE, without ever
+building a dense Hamiltonian matrix.
+
+---
+
+## Details
+
+**Indexing convention**: `mode_index` is 1-indexed (`1` to `2*n_qubits`), matching the
+physics literature's `chi_1, chi_2, ...` convention -- `mode_index=0` raises
+`ValueError`. Qubit assignment follows this package's usual most-significant-bit
+convention throughout.
+
+**Building a Hamiltonian from Majoranas**: combine several `majorana_pauli_terms`
+results with [`multiply_pauli_terms`](observables.md) (e.g. a 4-Majorana product
+`chi_i*chi_j*chi_k*chi_l` for a Sachdev-Ye-Kitaev-style term) and pass the resulting
+terms list to [`pauli_hamiltonian_to_matrix`](observables.md) or
+[`PauliSumOperator`](observables.md).
+
+**Provenance**: `majorana_pauli_terms`/`total_parity_operator` were promoted from a
+real traversable-wormhole-inspired quantum teleportation reproduction (Gao-Jafferis-Wall
+theory, arXiv:2604.10090) -- see
+[Dense-Evolution-Discovery](https://tatopenn-cell.github.io/Dense-Evolution-Discovery/wormhole_syk_teleportation/)
+for that experiment. `hubbard_hamiltonian_pauli_terms` was promoted from Dense-Evolution-Discovery
+Experiment 39 (the "Hubbard square", Arovas, Bandyopadhyay & Zhu, "The Hubbard Model",
+Annual Review of Condensed Matter Physics 2022, arXiv:2103.12097), which checked the
+paper's own Table 2 perturbative ground-state formula against exact diagonalization and
+its predicted `x^2-y^2` (B1g/d-wave) ground-state symmetry against a real pairing-correlation
+sign pattern -- see
+[Dense-Evolution-Discovery's hubbard_square_arovas.py](https://tatopenn-cell.github.io/Dense-Evolution-Discovery/hubbard_square_arovas/)
+for the full writeup, including the independent brute-force check that the periodic
+wraparound bond (the one place a naive Jordan-Wigner implementation could plausibly
+need an extra parity correction) needs none.
 
 ::: dense_evolution.physics.fermions
 
 ---
 
-**See also**: [`entropy`](entropy.md) and [`trotter`](trotter.md), the
-other two modules promoted alongside this one from a real traversable-
-wormhole-inspired quantum teleportation reproduction (Gao-Jafferis-Wall
-theory, arXiv:2604.10090) — see the [MCP Server](../composer.md) section
-and [Dense-Evolution-Discovery](https://tatopenn-cell.github.io/Dense-Evolution-Discovery/wormhole_syk_teleportation/)
-for the real experiments built on top of these three modules.
+**See also**: [`entropy`](entropy.md) and [`trotter`](trotter.md), the other two
+modules promoted alongside `majorana_pauli_terms`/`total_parity_operator` from the same
+wormhole-teleportation reproduction.

--- a/docs/api/healing.md
+++ b/docs/api/healing.md
@@ -1,52 +1,105 @@
 # Healing (predictive primitives)
 
 > The shared decision primitive [Mitigation](mitigation.md) and
-> [Vector Healing](ia_utils_vector_healing.md) both call into — see
+> [Vector Healing](ia_utils_vector_healing.md) both call into -- see
 > [Concepts](../concepts.md) for which of those two you actually want.
 
-Predictive-healing primitives for noisy vector sequences (VQE/MD
-telemetry, quantum state trajectories): a "Phi-Trigger" that, given a
-state and a local baseline, decides whether an observed change looks
-like genuine dynamics or static noise, plus supporting sync/reflection
-functions. Built empirically, one formula at a time — see the module's
-own docstring for which parts carry a real information-theoretic reading
-(`calculate_vettore_dinamico`'s core term is a log-likelihood ratio) and
-which are a geometric construction instead (`calculate_phi_ab`), so as
-not to overclaim either way.
+Given one step of a noisy telemetry sequence (a VQE energy, an MD trajectory value), is
+this a genuine change worth keeping, or a spike worth smoothing away? This module's
+primitives answer that question one number at a time -- the "Phi-Trigger" -- and are
+what [`ia_utils.vector_healing.enhanced_dense_healing_hybrid`](ia_utils_vector_healing.md)
+calls internally on a whole sequence. Reach for this page directly when you want that
+same decision on raw values of your own, without going through the full sequence-healing
+wrapper.
 
-**Applied layer**: [`ia_utils.vector_healing.enhanced_dense_healing_hybrid`](https://github.com/tatopenn-cell/Dense-Evolution/blob/main/tools/ia_utils/vector_healing.py)
-is what actually calls these primitives on a real `(n_steps, dim)`
-sequence — per step, runs the Phi-Trigger against a local baseline
-window and either keeps the value (genuine dynamics) or replaces it with
-the local median (static noise), after sanitizing any NaN/Inf first
-regardless of that decision. This shipped with the pre-rebuild
-dashboard_core's Streamlit "AI healing shield" middleware (VQE/MD
-telemetry routed through it before any panel was built from it), and
-was left behind — not removed — when dashboard_core was rebuilt around
-the Composer kernel.
+## Step 1. The trigger: real change or noise?
 
-**Reintegrated end to end**: `dashboard_core.run_vector_healing` (a thin
-wrapper, mirroring `mitigation.py`'s shape) → the kernel's
-`POST /api/vector_healing` → the MCP tool `dense_evolution_vector_healing`
-(see `mcp_server/README.md`). All three call the same real primitives on
-this page — no separate reimplementation.
+```python
+import jax.numpy as jnp
+import dense_evolution.healing as h
+
+dq_dt = jnp.array([0.001, 0.002, 0.5, 0.001])
+h.evaluate_phi_trigger(dq_dt)
+```
+
+```
+(Array([0., 0., 1., 0.], dtype=float32, weak_type=True),
+ Array([0.15, 0.15, 0.05, 0.15], dtype=float32, weak_type=True),
+ Array([0.11, 0.11, 0.01, 0.11], dtype=float32, weak_type=True))
+```
+
+`dq_dt` is one rate-of-change value per step -- how much a quantity moved since the
+previous step. `evaluate_phi_trigger` returns three arrays: the trigger itself (`1.0`
+where a step's rate crosses the "this is real dynamics" threshold, `0.0` otherwise --
+only the third step here, `0.5`, is large enough), and two damping coefficients that
+drop when the trigger fires (`0.15` -> `0.05` and `0.11` -> `0.01`) -- a genuine change
+gets less aggressive smoothing applied around it than a static step would.
+
+## Step 2. Where `dq_dt` comes from: comparing two real states
+
+```python
+ipg_vector = jnp.array([1.0, 0.0])
+phi_ab = h.calculate_phi_ab(jnp.array([1.0, 0.0]), jnp.array([1.0, 0.0]), ipg_vector)
+
+v_stable = h.calculate_vettore_dinamico(jnp.array(1.0), jnp.array(1.001), phi_ab)
+v_jump = h.calculate_vettore_dinamico(jnp.array(1.0), jnp.array(1.5), phi_ab)
+
+h.evaluate_phi_trigger(jnp.array([v_stable, v_jump]))[0]
+```
+
+```
+Array([0., 1.], dtype=float32, weak_type=True)
+```
+
+Step 1's `dq_dt` isn't usually handed to you directly -- it's built from two states
+`E_A`/`E_B` (a scalar energy or observable at consecutive steps) plus `Phi_AB`, an
+alignment/coherence factor between them (`calculate_phi_ab`, here computed once for two
+identical direction vectors and reused for both comparisons).
+`calculate_vettore_dinamico(E_A, E_B, Phi_AB)` is `log(E_B/E_A)` scaled by that
+alignment -- a log-likelihood-ratio-flavored measure of how much `E_A` moved to become
+`E_B`. `1.0 -> 1.001` (`v_stable = 0.0035`) doesn't trigger; `1.0 -> 1.5` (`v_jump =
+1.42`) does -- exactly the same 0/1 split Step 1 showed directly, now built from two
+real states instead of a rate-of-change handed in already computed.
 
 ---
 
-**See also**: [`dense_evolution.mitigation`](mitigation.md) — `zero_noise_extrapolation`'s
-healing-adapted branch (triggered by passing `sigma_at_base_noise`) calls
-`calculate_delta_preemp` from this module. Unlike `run_vector_healing`
-above, this branch is **not** currently reachable from the kernel or MCP:
-`dashboard_core.run_zne_mitigation` never passes `sigma_at_base_noise`,
-and the kernel's `MitigateRequest` has no field for it. This was
-originally left as a known follow-up pending `calculate_advanced_sigma`'s
-undefined input provenance — that question has since been closed, not
-completed: Dense-Evolution-Discovery Experiment 35
-(`scripts/zne_healing_sigma_provenance.py`) fed the branch a real,
-oracle-free `sigma_at_base_noise` (the empirical std of the noisy trial
-ensemble) and found, via a permutation-test negative control, that the
-branch's coefficient perturbation doesn't discriminate real sigma from
-randomly shuffled sigma at all — a confound, not a usable signal. Wiring
-this branch up would not have helped even with fully-designed inputs.
-`calculate_advanced_sigma` is now deprecated (`DeprecationWarning`,
-kept for backward compatibility only) rather than completed.
+## Details
+
+**What's principled vs. empirical here**: `calculate_vettore_dinamico`'s core term is a
+genuine log-likelihood ratio (the same elementary quantity Kullback-Leibler divergence
+is built from -- see [`kl_divergence`](https://tatopenn-cell.github.io/Dense-Evolution-Discovery/kullback_leibler_divergence/)
+for the distinction between this one un-weighted scalar ratio and a full KL divergence
+over a probability distribution). `calculate_phi_ab` is a geometric construction instead,
+built empirically rather than derived from an information-theoretic quantity -- worth
+knowing before leaning on either reading too heavily.
+
+**Applied layer**: [`ia_utils.vector_healing.enhanced_dense_healing_hybrid`](https://github.com/tatopenn-cell/Dense-Evolution/blob/main/tools/ia_utils/vector_healing.py)
+is what actually calls these primitives on a real `(n_steps, dim)` sequence -- see
+[Vector Healing](ia_utils_vector_healing.md) for that page's own worked examples. This
+shipped with the pre-rebuild dashboard_core's Streamlit "AI healing shield" middleware
+(VQE/MD telemetry routed through it before any panel was built from it), and was left
+behind -- not removed -- when dashboard_core was rebuilt around the Composer kernel.
+
+**Reintegrated end to end**: `dashboard_core.run_vector_healing` (a thin wrapper,
+mirroring `mitigation.py`'s shape) -> the kernel's `POST /api/vector_healing` -> the
+MCP tool `dense_evolution_vector_healing` (see `mcp_server/README.md`). All three call
+the same real primitives on this page -- no separate reimplementation.
+
+**The other branch, not wired up**: [`dense_evolution.mitigation`](mitigation.md)'s
+`zero_noise_extrapolation` has a healing-adapted branch (triggered by passing
+`sigma_at_base_noise`) that calls `calculate_delta_preemp` from this module. Unlike
+`run_vector_healing` above, this branch is **not** currently reachable from the kernel
+or MCP: `dashboard_core.run_zne_mitigation` never passes `sigma_at_base_noise`, and the
+kernel's `MitigateRequest` has no field for it. This was originally left as a known
+follow-up pending `calculate_advanced_sigma`'s undefined input provenance -- that
+question has since been closed, not completed: Dense-Evolution-Discovery Experiment 35
+(`scripts/zne_healing_sigma_provenance.py`) fed the branch a real, oracle-free
+`sigma_at_base_noise` (the empirical std of the noisy trial ensemble) and found, via a
+permutation-test negative control, that the branch's coefficient perturbation doesn't
+discriminate real sigma from randomly shuffled sigma at all -- a confound, not a usable
+signal. Wiring this branch up would not have helped even with fully-designed inputs.
+`calculate_advanced_sigma` is now deprecated (`DeprecationWarning`, kept for backward
+compatibility only) rather than completed -- excluded from the guide above for that
+reason.
+
+::: dense_evolution.healing

--- a/docs/api/observables.md
+++ b/docs/api/observables.md
@@ -1,22 +1,153 @@
 # Observables (Pauli-string expectation values)
 
-Exact expectation values of Pauli strings, computed directly from a statevector in O(dim) via
-bit manipulation -- the 2^n_qubits Hamiltonian matrix is never built. `pauli_sum_matvec` uses
-the same technique for `H @ vector` (not reduced to a scalar) -- the matrix-free primitive
-behind [`ground_state_energy_sparse`](dashboard_core_hamiltonians.md)'s
-`scipy.sparse.linalg.eigsh` path for molecules too large to diagonalize densely.
+A Hamiltonian for a real molecule or spin model is almost never handed to you as one
+big matrix -- it comes as a weighted sum of Pauli strings, `H = sum_i coeff_i * P_i`
+(e.g. `1.0 * ZZ + 0.5 * X0`). This module works with that sum directly: expectation
+values, matrix-vector products, and even the full dense matrix when one is genuinely
+needed, all without requiring a full `2**n x 2**n` matrix to exist first unless you ask
+for one.
 
-`multiply_pauli_terms` multiplies several Pauli-string OPERATORS together (order matters --
-unlike every function above, which sums independent terms), tracking the `i^k` phase from
-same-qubit collisions (`X*Y=iZ`, etc.) -- the manual Pauli-algebra primitive behind
-[`total_parity_operator`](fermions.md)'s Klein-factor construction, or any other by-hand
-Pauli-operator product.
+## Step 1. Expectation value of one Pauli string
+
+```python
+import dense_evolution as de
+
+qasm = 'OPENQASM 2.0; include "qelib1.inc"; qreg q[2]; h q[0]; cx q[0],q[1];'
+circuit = de.QASMParser().parse(qasm)
+sim = de.DenseSVSimulator(2)
+sim.run_circuit_jit(circuit.to_tuples())
+sv = sim.get_statevector()
+
+de.pauli_expectation(sv, 'ZZ')
+```
+
+```
+0.9999999999999998
+```
+
+`sv` is the Bell state from the [Simulator](simulator.md) page. `pauli_expectation`
+reads `'ZZ'` left to right as qubit 0, qubit 1 -- `Z` on both qubits gives `+1` on
+`|00>` and on `|11>` (the only two basis states a Bell state has any amplitude on), so
+the expectation value is `1`, up to floating-point rounding. A dict form
+(`{0: 'Z', 1: 'Z'}`) works identically -- convenient when only a few qubits are
+non-identity.
+
+## Step 2. A weighted sum of several Pauli strings
+
+```python
+terms = [(1.0, 'ZZ'), (0.5, {0: 'Z'})]
+de.pauli_sum_expectation(sv, terms)
+```
+
+```
+1.4999999999999998
+```
+
+`terms` is a list of `(coeff, pauli_string)` pairs -- this is the Hamiltonian
+representation the rest of this module (and [`fermions`](fermions.md),
+[`hamiltonians.md`](dashboard_core_hamiltonians.md)) build. `pauli_sum_expectation`
+is `pauli_expectation` applied to each term and summed with its coefficient: `1.0*<ZZ>
++ 0.5*<Z0> = 1.0*1.0 + 0.5*1.0 = 1.5`, matching the printed value.
+
+## Step 3. The same Hamiltonian, as a dense matrix
+
+```python
+import numpy as np
+
+H = de.pauli_hamiltonian_to_matrix(terms, n_qubits=2)
+np.real(np.conj(sv) @ H @ sv)
+```
+
+```
+1.4999999999999998
+```
+
+`pauli_hamiltonian_to_matrix` builds the real `(4, 4)` Hermitian matrix for the same
+`terms` -- `<psi|H|psi>` computed this way agrees with Step 2's `pauli_sum_expectation`
+exactly. Use this when something downstream genuinely needs the explicit matrix (exact
+diagonalization for a ground-state energy, say); everything else on this page avoids
+building it.
+
+## Step 4. `H @ vector`, without the matrix
+
+```python
+from dense_evolution.physics.observables import pauli_sum_matvec
+
+Hv = pauli_sum_matvec(sv, terms, n_qubits=2)
+np.allclose(H @ sv, Hv)
+```
+
+```
+True
+```
+
+`pauli_sum_matvec` computes the same `H @ vector` Step 3's dense `H` would, in
+`O(dim * n_terms)` instead of ever materializing the `(2**n, 2**n)` matrix -- the
+matrix-free primitive behind an iterative eigensolver (`scipy.sparse.linalg.eigsh` via
+a `LinearOperator` wrapping this function) for a system too large to diagonalize
+densely.
+
+## Step 5. Differentiable: the same Hamiltonian inside `jax.grad`
+
+```python
+import jax
+import jax.numpy as jnp
+
+qasm_rx = 'OPENQASM 2.0; include "qelib1.inc"; qreg q[2]; rx(0.0) q[0]; cx q[0],q[1];'
+circuit_rx = de.QASMParser().parse(qasm_rx)
+energy_fn, n_params = de.circuit_to_energy_fn(circuit_rx, n_qubits=2)
+
+h_op = de.PauliSumOperator(terms, n_qubits=2)
+
+def loss(theta):
+    energy, sv = energy_fn(theta, h_op)
+    return energy
+
+theta = jnp.array([0.8])
+jax.value_and_grad(loss)(theta)
+```
+
+```
+(Array(1.34835335, dtype=float64), Array([-0.35867805], dtype=float64))
+```
+
+`pauli_sum_matvec` (Step 4) is `numpy`-based -- fine called directly, but it breaks
+under `jax.grad` tracing. `PauliSumOperator` wraps the same `terms` behind `__matmul__`,
+backed by a pure-`jnp` rewrite (`pauli_sum_matvec_jax`), so it drops straight into
+[`circuit_to_energy_fn`](autodiff.md)'s `h_matrix` argument (the only thing `energy_fn`
+does with `h_matrix` is `h_matrix @ statevector`) and stays differentiable end to end.
+This is what a real VQE gradient step looks like -- `jax.grad` here needs no dense
+Hamiltonian at any point, which matters once a system is too large for one to fit in
+memory at all (`pauli_hamiltonian_to_matrix`'s `(2**n, 2**n)` matrix is already 4GB at
+14 qubits; `PauliSumOperator` is unaffected).
+
+---
+
+## Details
+
+**Indexing convention**: qubit 0 is the *most* significant bit of the basis-state
+index throughout this module (`pauli_terms[0]` in a string is qubit 0) -- matches
+[`DenseSVSimulator`](simulator.md) and [`entropy`](entropy.md), not the little-endian
+convention some other libraries use.
+
+**`multiply_pauli_terms`** multiplies several Pauli-string *operators* together (order
+matters -- unlike every function above, which sums independent terms), tracking the
+`i^k` phase from same-qubit collisions (`X*Y = iZ`, etc.) -- the manual Pauli-algebra
+primitive behind [`total_parity_operator`](fermions.md)'s Klein-factor construction, or
+any other by-hand Pauli-operator product.
+
+**Precision**: `pauli_sum_matvec_jax`/`pauli_sum_expectation_jax`/`PauliSumOperator`
+never call `dense_evolution.set_precision(True)` themselves -- if nothing else in the
+process has constructed a `DenseSVSimulator`/`circuit_to_energy_fn` yet, JAX is still at
+its `float32` default, and Step 5's numbers above would come out at `~1e-7` relative
+precision instead of `~1e-16`. Call `de.set_precision(True)` yourself first if using
+`PauliSumOperator` standalone, before anything else has a chance to enable `x64` for
+you.
 
 ::: dense_evolution.physics.observables
 
 ---
 
-**See also**: [`circuit_to_energy_fn`](autodiff.md) for the differentiable, `h_matrix @ statevector`
-approach to expectation values (needed for `jax.grad`-based VQE, at the cost of an explicit
-dense Hamiltonian matrix) -- use `pauli_expectation`/`pauli_sum_expectation` instead whenever a
-dense Hamiltonian isn't otherwise needed, or the system is too large for one to be practical.
+**See also**: [`circuit_to_energy_fn`](autodiff.md) for the full differentiable-VQE
+picture Step 5 is part of; [`fermions`](fermions.md) for Pauli terms built from
+Majorana/Jordan-Wigner-mapped fermionic operators instead of by hand.


### PR DESCRIPTION
## Summary
All three pages were pure prose plus a bare mkdocstrings directive -- no runnable examples, violating doc_writing_rules.txt's guide-first convention every other API page already follows.

- **fermions.md**: Majorana basics, anticommutation verified on a real Bell state, the Klein-factor/`total_parity_operator` cross-register property, and `hubbard_hamiltonian_pauli_terms`'s energy computed via `PauliSumOperator` + `circuit_to_energy_fn`.
- **observables.md**: `pauli_expectation` through `pauli_sum_matvec`, ending with `PauliSumOperator`/`pauli_sum_matvec_jax` inside `jax.grad` -- the differentiable-VQE path added earlier today but never documented on this page.
- **healing.md**: the low-level Phi-Trigger primitives (`evaluate_phi_trigger`, `calculate_phi_ab`, `calculate_vettore_dinamico`) the applied layer (`ia_utils.vector_healing`) calls internally.

Provenance/history/bug-fix narrative that used to sit inline moved to each page's "Details" section.

## Test plan
- [x] Every printed code-block output actually run against a fresh `dense-evolution==8.1.71` install and copied verbatim (including the fixed float32-vs-float64 output on observables.md's Step 5, caught by actually running it rather than assuming).