### PR TITLE
Rewrite measurement.md and native_hf.md per doc_writing_rules.txt

### DIFF
--- a/docs/api/measurement.md
+++ b/docs/api/measurement.md
@@ -1,12 +1,77 @@
 # Measurement (shot sampling & pure-state fidelity)
 
-Turning a statevector into finite-shot counts (`sample_counts`, a Qiskit-`get_counts()`
-equivalent), and comparing two pure states directly (`statevector_fidelity`) without building a
-density matrix first.
+A real quantum device never hands back a statevector -- it hands back a stream of
+individual measurement outcomes, one per shot, that you have to run many times and
+count up to approximate the underlying distribution. `sample_counts` does that
+simulated-device step (a `DenseSVSimulator` equivalent of Qiskit's `get_counts()`).
+`statevector_fidelity` answers a different question: how close are two *known* pure
+states to each other -- useful for grading a result against an ideal target, something
+no real device measurement alone can tell you.
 
-::: dense_evolution.utils.measurement
+## Step 1. Finite-shot counts from a real statevector
+
+```python
+import numpy as np
+import dense_evolution as de
+
+qasm = 'OPENQASM 2.0; include "qelib1.inc"; qreg q[2]; h q[0]; cx q[0],q[1];'
+circuit = de.QASMParser().parse(qasm)
+sim = de.DenseSVSimulator(2)
+sim.run_circuit_jit(circuit.to_tuples())
+sv = sim.get_statevector()
+
+de.sample_counts(sv, n_shots=1000, rng=np.random.default_rng(0))
+```
+
+```
+{'00': 473, '11': 527}
+```
+
+`sv` is the same Bell state built on the [Simulator](simulator.md) page --
+`sample_counts(statevector, n_shots, rng)` draws `n_shots` independent outcomes from
+its exact Born-rule probabilities and returns a dict of bitstring counts, the same
+shape `get_probabilities()` would predict exactly (`50/50` here) but with the real
+sampling noise a finite number of shots actually has -- `473`/`527`, not `500`/`500`.
+Passing `rng` makes the draw reproducible; omit it for a fresh random draw each call.
+
+## Step 2. How close are two pure states?
+
+```python
+de.statevector_fidelity(sv, sv)
+```
+
+```
+0.9999999999999996
+```
+
+```python
+qasm2 = 'OPENQASM 2.0; include "qelib1.inc"; qreg q[2]; h q[0]; h q[1];'
+sim2 = de.DenseSVSimulator(2)
+sim2.run_circuit_jit(de.QASMParser().parse(qasm2).to_tuples())
+sv2 = sim2.get_statevector()
+
+de.statevector_fidelity(sv, sv2)
+```
+
+```
+0.4999999999999998
+```
+
+`statevector_fidelity(a, b)` is `|<a|b>|^2`, computed directly on two statevectors --
+no density matrix built first, unlike [`uhlmann_fidelity`](mitigation.md) (this
+function's mixed-state counterpart). A state compared to itself gives `1` (up to
+floating-point rounding); the Bell state against `|++>` (independent `H` on each qubit,
+no entanglement) gives exactly `0.5` -- the two states share half their overlap, not
+zero and not identical.
 
 ---
 
-**See also**: [`uhlmann_fidelity`](mitigation.md) for the density-matrix fidelity `statevector_fidelity`
-is the pure-state counterpart of.
+## Details
+
+**When to use which fidelity**: `statevector_fidelity` needs both states to be pure
+(exact statevectors, as any noiseless simulation produces) -- for a genuinely mixed
+state (a real device's noisy output, or anything already reduced via
+[`partial_trace`](entropy.md)), use [`uhlmann_fidelity`](mitigation.md) instead, which
+takes density matrices.
+
+::: dense_evolution.utils.measurement

--- a/docs/api/native_hf.md
+++ b/docs/api/native_hf.md
@@ -1,54 +1,102 @@
-# Native Hartree-Fock (`dense_evolution.native_hf`)
+# Native Hartree-Fock
 
-A from-scratch, JAX-vectorized ab-initio Hartree-Fock engine — overlap,
-kinetic, nuclear-attraction, and electron-repulsion integrals over s/p
-Cartesian Gaussian shells via the Obara-Saika recursion (Obara & Saika,
-*J. Chem. Phys.* 84, 3963, 1986), each shell-pair/quartet batched with
-`jax.lax.scan`/`jax.vmap` and compiled with `jax.jit` instead of looping
-in the Python interpreter.
+Before a molecule's electronic-structure problem can become a qubit Hamiltonian, its
+integrals (overlap, kinetic, nuclear-attraction, electron-repulsion) have to be
+computed and a Hartree-Fock mean-field calculation run to get a reference orbital
+basis. `dense_evolution.native_hf` is a from-scratch, JAX-vectorized engine for that
+step -- covers any element `basis_set_exchange` has STO-3G data for, not just the small
+H-Ne table PennyLane's own bundled solver ships.
 
-It exists because PennyLane's own differentiable Hartree-Fock solver
-(`qml.qchem`, `method="dhf"`) builds these same integrals through a
-Python-level loop wrapped in its autograd-tracing numpy layer — correct,
-but profiled directly at 482 of 483 total seconds for Si2/STO-3G, almost
-entirely per-scalar-op tracer overhead rather than real FLOPs. This
-module only replaces the integral/SCF stage; the converged result still
-goes to PennyLane's own `fermionic_observable` + `jordan_wigner` for the
-qubit mapping, since that stage is already fast (under 2 seconds) and
-well-tested. Basis-set parameters come from the
-[`basis_set_exchange`](https://github.com/MolSSI-BSE/basis_set_exchange)
-package, so any element it has STO-3G data for is reachable, not just
-PennyLane's bundled H–Ne table. An element needing d-orbitals or higher
-(e.g. Fe) fails with a clear `NotImplementedError` naming the real
-limitation, not a silent wrong energy for an incomplete basis.
+## Step 1. A real molecule's qubit Hamiltonian
 
-Design and algorithm structure were informed by studying
+```python
+import numpy as np
+from dense_evolution.native_hf.bridge import build_qubit_hamiltonian
+
+geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.7414]])
+H, n_qubits, hf_result = build_qubit_hamiltonian([1, 1], geometry, n_electrons=2)
+
+n_qubits, hf_result.converged, hf_result.n_iterations, hf_result.total_energy
+```
+
+```
+(4, True, 13, -1.1166843352600253)
+```
+
+`build_qubit_hamiltonian(atomic_numbers, geometry_angstrom, n_electrons)` runs the full
+pipeline -- Obara-Saika integrals, then Hartree-Fock self-consistent-field iteration
+(`run_scf`) -- for H2 (two protons, atomic number 1, `0.7414` Angstrom apart, the real
+equilibrium bond length) in the default STO-3G minimal basis. It converged in 13
+iterations to a mean-field energy of `-1.1167` Ha. `H` is a `qml.Hamiltonian` -- the
+converged result still goes through PennyLane's own `fermionic_observable` +
+`jordan_wigner` for the qubit mapping, since that stage was already fast and
+well-tested; this module only replaces the slow integral/SCF stage.
+
+## Step 2. Hartree-Fock is a mean-field approximation -- how far off?
+
+```python
+import dense_evolution as de
+
+coeffs, ops = H.terms()
+terms = []
+for coeff, op in zip(coeffs, ops):
+    pauli = {}
+    for factor in (op.operands if hasattr(op, 'operands') else [op]):
+        if factor.name != 'Identity':
+            pauli[int(factor.wires[0])] = factor.name[-1]
+    terms.append((float(np.real(complex(coeff))), pauli))
+
+H_dense = de.pauli_hamiltonian_to_matrix(terms, n_qubits)
+float(np.min(np.linalg.eigvalsh(H_dense)))
+```
+
+```
+-1.1372701878105915
+```
+
+Converting `H`'s Pauli terms to [`pauli_hamiltonian_to_matrix`](observables.md)'s format
+and exactly diagonalizing gives `-1.1373` Ha -- lower than Step 1's Hartree-Fock energy
+by about `0.02` Ha, the real electron-correlation energy Hartree-Fock's single-Slater-
+determinant approximation misses entirely. At only 4 qubits, exact diagonalization is
+easy; that gap is exactly what a real VQE ansatz beyond a bare Hartree-Fock reference
+state is trying to close for larger, classically-intractable molecules.
+
+---
+
+## Details
+
+**Why this module exists**: PennyLane's own differentiable Hartree-Fock solver
+(`qml.qchem`, `method="dhf"`) builds the same integrals through a Python-level loop
+wrapped in its autograd-tracing numpy layer -- correct, but profiled directly at 482 of
+483 total seconds for Si2/STO-3G, almost entirely per-scalar-op tracer overhead rather
+than real FLOPs. This module batches each shell-pair/quartet with `jax.lax.scan`/
+`jax.vmap` and compiles with `jax.jit` instead.
+
+**Elements beyond PennyLane's table**: basis-set parameters come from
+[`basis_set_exchange`](https://github.com/MolSSI-BSE/basis_set_exchange), so any
+element it has STO-3G data for is reachable -- an element needing d-orbitals or higher
+(e.g. Fe) fails with a clear `NotImplementedError` naming the real limitation, not a
+silent wrong energy for an incomplete basis.
+
+**Verified against an independent implementation**: element-wise against
 [lowdanie/hartree-fock-solver](https://github.com/lowdanie/hartree-fock-solver)
-("slaterform", Apache-2.0) as a reference for structuring the Obara-Saika
-recursion with `jax.lax.scan`, and by PennyLane's own white paper
-(Delgado et al., "Differentiable quantum computational chemistry with
-PennyLane", [arXiv:2111.09967](https://arxiv.org/abs/2111.09967)) — no
-source code from either project is copied here. Verified element-wise
-against an independent JAX Hartree-Fock implementation (slaterform) to
-machine precision on individual integrals and to 10 significant figures
-on Si2/STO-3G's full SCF energy.
+("slaterform", Apache-2.0, studied as a reference for structuring the Obara-Saika
+recursion with `jax.lax.scan` -- no source code copied) to machine precision on
+individual integrals, and to 10 significant figures on Si2/STO-3G's full SCF energy.
+Algorithm background also drawn from PennyLane's own white paper (Delgado et al.,
+"Differentiable quantum computational chemistry with PennyLane",
+[arXiv:2111.09967](https://arxiv.org/abs/2111.09967)).
 
-`dashboard_core.hamiltonians` calls this engine automatically —
-`bridge.build_qubit_hamiltonian` — whenever a requested molecule uses an
-element outside PennyLane's own STO-3G table; existing molecules
-(H2/HeH+/H3+/LiH/H2O) are unaffected and keep using PennyLane's `dhf`
-pipeline directly. See [Dashboard Core — Hamiltonians](dashboard_core_hamiltonians.md)
-for the dispatch logic and the Si2 catalog entry this engine backs.
+**Production entry point**: [`dashboard_core.hamiltonians`](dashboard_core_hamiltonians.md)
+calls this engine automatically (`bridge.build_qubit_hamiltonian`) whenever a requested
+molecule uses an element outside PennyLane's own STO-3G table -- existing catalog
+molecules (H2/HeH+/H3+/LiH/H2O) are unaffected and keep using PennyLane's `dhf`
+pipeline directly. See that page for the dispatch logic and the Si2 catalog entry this
+engine backs, and [`dashboard_core.vqe`](dashboard_core_vqe.md) for ansatz circuits
+optimized against Hamiltonians built this way.
 
 ::: dense_evolution.native_hf.bridge
 
 ::: dense_evolution.native_hf.scf
 
 ::: dense_evolution.native_hf.basis
-
----
-
-**See also**: [`Dashboard Core — Hamiltonians`](dashboard_core_hamiltonians.md)
-for the production entry point (`MOLECULE_CATALOG`'s Si2 entry), and
-[`dashboard_core.vqe`](dashboard_core_vqe.md) for the ansatz circuits
-optimized against Hamiltonians this engine can build.


### PR DESCRIPTION
## Summary
Both pages were prose/directive-only with zero runnable examples.

- **measurement.md**: `sample_counts` on a real Bell state (finite-shot sampling noise, 473/527 not exactly 500/500), `statevector_fidelity` self-comparison (1.0) and against an unentangled `|++>` state (0.5, matching the real overlap).
- **native_hf.md**: `build_qubit_hamiltonian` on a real H2 molecule (STO-3G, equilibrium bond length), converged Hartree-Fock energy -1.1167 Ha, then an exact-diagonalization cross-check via `pauli_hamiltonian_to_matrix` showing the real ~0.02 Ha correlation-energy gap Hartree-Fock's mean-field approximation misses.

## Test plan
- [x] Every printed number actually run against a fresh `dense-evolution==8.1.71` install.