### PR TITLE
native_hf/scf.py: DIIS acceleration + dual energy/density convergence

### DIFF
--- a/dense_evolution/native_hf/scf.py
+++ b/dense_evolution/native_hf/scf.py
@@ -21,18 +21,51 @@ never settles. Confirmed this is a real oscillation, not just slow
 convergence: three separate machines/runs of the undamped loop each
 hit the iteration cap at a DIFFERENT total energy (-571.63, -570.69,
 -571.02 Ha), all physically meaningless artifacts of whatever step the
-loop happened to be on. Fixed with standard linear density damping
+loop happened to be on. First fixed with plain linear density damping
 (P_next = alpha*P_new + (1-alpha)*P_old) -- textbook remedy for exactly
-this oscillation failure mode (Szabo & Ostlund ch. 3.4.9). Verified
-the damped loop converges to the SAME energy (-570.874032094871 Ha,
-agreeing to 10 significant figures) across alpha in {0.1, 0.2, 0.3,
-0.5, 0.7} -- the fix's correctness doesn't hinge on the specific alpha
-chosen, only that damping is applied at all.
+this oscillation failure mode (Szabo & Ostlund ch. 3.4.9), verified to
+converge to the SAME energy (-570.874032094871 Ha, agreeing to 10
+significant figures) across alpha in {0.1, 0.2, 0.3, 0.5, 0.7).
+
+UPGRADED to DIIS (Pulay, "Convergence acceleration of iterative
+sequences: the case of SCF iteration", Chem. Phys. Lett. 73, 393
+(1980); "Improved SCF convergence acceleration", J. Comput. Chem. 3,
+556 (1982)) -- the standard production-grade SCF accelerator plain
+linear damping is a simplified special case of. Pulay's own error
+vector, `e = X.T @ (F@P@S - S@P@F) @ X` (the Fock/density commutator in
+the orthonormal basis, exactly zero at true self-consistency), is kept
+across the last `diis_dim` iterations alongside the Fock matrices that
+produced them; each step extrapolates a new Fock matrix as the
+minimum-norm linear combination of that history (constrained to sum to
+1) instead of diagonalizing the latest F directly. Verified on the
+same Si2 near-degenerate case that motivated damping in the first
+place: DIIS converges in 11 iterations to -570.8740320948958 Ha, versus
+53 iterations for plain damped substitution alone (diis_dim=0,
+alpha=0.5) to reach the same energy, -570.8740320948963 Ha -- agreeing
+to 12 significant figures, the same true self-consistent solution
+reached ~4.8x faster, not a different answer.
+
+If the DIIS linear system is ever singular (a degenerate/duplicated
+error-vector history), that step falls back to the plain, unextrapolated
+Fock matrix rather than raising -- a transient fallback, not silent
+wrong physics, since the next iteration's fresh error vector rebuilds a
+usable history.
+
+Convergence now requires BOTH the density AND the energy to stop
+changing (`|P_new - P| < convergence_tol` AND `|E_new - E_old| <
+energy_tol`) rather than density alone -- density convergence can
+occasionally plateau one step before energy does (or vice versa) for
+a system with several nearly-degenerate iterations near the end of the
+run; requiring both is strictly more conservative than either alone
+and costs at most a couple of extra iterations on every system tested
+here.
 """
 
 import dataclasses
 
 import numpy as np
+
+_DIIS_DIM = 8
 
 
 @dataclasses.dataclass
@@ -67,6 +100,55 @@ def _density_from_coefficients(C: np.ndarray, n_occupied_pairs: int) -> np.ndarr
     return C_occ @ C_occ.T
 
 
+def _diis_error(F: np.ndarray, P: np.ndarray, S: np.ndarray, X: np.ndarray) -> np.ndarray:
+    """Pulay's DIIS error vector, `X.T @ (F@P@S - S@P@F) @ X` -- the
+    Fock/density commutator (zero at true self-consistency, since F and
+    P then commute), transformed into the same orthonormal basis the
+    Fock matrix itself is diagonalized in. F, P, S are all symmetric, so
+    this reduces to `Y - Y.T` for `Y = X.T @ F @ P @ S @ X` -- computed
+    that way to avoid forming two separate FPS/SPF products."""
+    Y = X.T @ F @ P @ S @ X
+    return Y - Y.T
+
+
+def _diis_extrapolate(fock_history: list[np.ndarray], error_history: list[np.ndarray]) -> np.ndarray:
+    """Pulay DIIS (Chem. Phys. Lett. 73, 393 (1980)): the minimum-norm
+    linear combination `sum_i c_i * F_i` of the last few Fock matrices,
+    constrained to `sum_i c_i = 1`, that makes `sum_i c_i * e_i` as
+    close to zero as possible -- solved via the standard augmented
+    linear system `[[B, -1], [-1.T, 0]] @ [c, lambda] = [0, ..., 0, -1]`
+    with `B[i,j] = e_i . e_j` (Frobenius inner product). Falls back to
+    the single latest Fock matrix (no extrapolation, equivalent to
+    plain substitution for this one step) if that system is singular --
+    a transient condition (e.g. two near-duplicate error vectors early
+    in a short history), not silently wrong physics, since the next
+    iteration's fresh error vector rebuilds a usable history from
+    scratch."""
+    n = len(fock_history)
+    B = np.empty((n, n))
+    for i in range(n):
+        for j in range(n):
+            B[i, j] = np.sum(error_history[i] * error_history[j])
+
+    A = np.zeros((n + 1, n + 1))
+    A[:n, :n] = B
+    A[:n, n] = -1.0
+    A[n, :n] = -1.0
+    b = np.zeros(n + 1)
+    b[n] = -1.0
+
+    try:
+        solution = np.linalg.solve(A, b)
+    except np.linalg.LinAlgError:
+        return fock_history[-1]
+
+    coeffs = solution[:n]
+    F_diis = np.zeros_like(fock_history[0])
+    for c, F_i in zip(coeffs, fock_history):
+        F_diis = F_diis + c * F_i
+    return F_diis
+
+
 def run_scf(
     S: np.ndarray,
     H_core: np.ndarray,
@@ -76,7 +158,9 @@ def run_scf(
     nuclear_positions: np.ndarray,
     max_iterations: int = 200,
     convergence_tol: float = 1e-10,
+    energy_tol: float = 1e-10,
     damping: float = 0.5,
+    diis_dim: int = _DIIS_DIM,
 ) -> HFResult:
     if n_electrons % 2 != 0:
         raise ValueError("Only closed-shell (even electron count) systems are supported.")
@@ -87,33 +171,60 @@ def run_scf(
     orbital_energies, C_ortho = np.linalg.eigh(X.T @ H_core @ X)
     C = X @ C_ortho
     P = _density_from_coefficients(C, n_occupied_pairs)
+    energy_prev = None
+
+    fock_history: list[np.ndarray] = []
+    error_history: list[np.ndarray] = []
 
     converged = False
     for iteration in range(1, max_iterations + 1):
         J = np.einsum("pqrs,rs->pq", repulsion, P)
         K = np.einsum("prqs,rs->pq", repulsion, P)
         F = H_core + 2.0 * J - K
+        energy = float(np.sum(P * (H_core + F)))
 
-        orbital_energies, C_ortho = np.linalg.eigh(X.T @ F @ X)
+        # DIIS (see _diis_extrapolate's docstring) supersedes plain linear
+        # damping as the default accelerator -- verified on the same Si2
+        # near-degenerate-orbital case that motivated damping in the
+        # first place (module docstring) to converge to the identical
+        # energy, faster. `damping` is kept as a fallback knob (used only
+        # once DIIS has no history yet, iteration 1) rather than removed,
+        # so an existing caller's tuned `damping` value still does
+        # something rather than being silently ignored.
+        error = _diis_error(F, P, S, X)
+        fock_history.append(F)
+        error_history.append(error)
+        if len(fock_history) > diis_dim:
+            fock_history.pop(0)
+            error_history.pop(0)
+
+        if len(fock_history) >= 2:
+            F_step = _diis_extrapolate(fock_history, error_history)
+        else:
+            F_step = F
+
+        orbital_energies, C_ortho = np.linalg.eigh(X.T @ F_step @ X)
         C = X @ C_ortho
         P_new = _density_from_coefficients(C, n_occupied_pairs)
 
-        if np.linalg.norm(P_new - P) < convergence_tol:
+        density_converged = np.linalg.norm(P_new - P) < convergence_tol
+        energy_converged = energy_prev is not None and abs(energy - energy_prev) < energy_tol
+        if density_converged and energy_converged:
             P = P_new
             converged = True
             break
-        # Linear density damping (Szabo & Ostlund ch. 3.4.9): plain
-        # substitution (damping=1.0) oscillates indefinitely for systems
-        # with near-degenerate orbitals at the occupied/virtual boundary
-        # (see module docstring, Si2) instead of converging -- mixing in
-        # a fraction of the old density every step damps that
-        # oscillation. Verified to reproduce the same converged energy
-        # to 10 significant figures across damping in [0.1, 0.7] for the
-        # system that motivated this, and to leave already-convergent
-        # systems' converged energies unchanged (just costs a handful of
-        # extra iterations, well inside max_iterations).
-        P = damping * P_new + (1.0 - damping) * P
+        energy_prev = energy
 
+        if len(fock_history) < 2:
+            # No DIIS history yet (iteration 1) -- fall back to plain
+            # linear damping for this one step, same role it always had.
+            P = damping * P_new + (1.0 - damping) * P
+        else:
+            P = P_new
+
+    J = np.einsum("pqrs,rs->pq", repulsion, P)
+    K = np.einsum("prqs,rs->pq", repulsion, P)
+    F = H_core + 2.0 * J - K
     electronic_energy = float(np.sum(P * (H_core + F)))
     e_nuc = nuclear_repulsion_energy(nuclear_charges, nuclear_positions)
 

--- a/docs/api/native_hf.md
+++ b/docs/api/native_hf.md
@@ -20,14 +20,14 @@ n_qubits, hf_result.converged, hf_result.n_iterations, hf_result.total_energy
 ```
 
 ```
-(4, True, 13, -1.1166843352600253)
+(4, True, 3, -1.116684335260025)
 ```
 
 `build_qubit_hamiltonian(atomic_numbers, geometry_angstrom, n_electrons)` runs the full
 pipeline -- Obara-Saika integrals, then Hartree-Fock self-consistent-field iteration
-(`run_scf`) -- for H2 (two protons, atomic number 1, `0.7414` Angstrom apart, the real
-equilibrium bond length) in the default STO-3G minimal basis. It converged in 13
-iterations to a mean-field energy of `-1.1167` Ha. `H` is a `qml.Hamiltonian` -- the
+(`run_scf`, DIIS-accelerated) -- for H2 (two protons, atomic number 1, `0.7414` Angstrom
+apart, the real equilibrium bond length) in the default STO-3G minimal basis. It
+converged in 3 iterations to a mean-field energy of `-1.1167` Ha. `H` is a `qml.Hamiltonian` -- the
 converged result still goes through PennyLane's own `fermionic_observable` +
 `jordan_wigner` for the qubit mapping, since that stage was already fast and
 well-tested; this module only replaces the slow integral/SCF stage.
@@ -51,7 +51,7 @@ float(np.min(np.linalg.eigvalsh(H_dense)))
 ```
 
 ```
--1.1372701878105915
+-1.1372701878105904
 ```
 
 Converting `H`'s Pauli terms to [`pauli_hamiltonian_to_matrix`](observables.md)'s format


### PR DESCRIPTION
## Summary
Addresses a real gap flagged in an external review (saved in `Fullwork/prog.txt`): plain linear density damping is a simplified special case of DIIS (Pulay 1980/1982), the standard production-grade SCF accelerator every real quantum chemistry package (PySCF included) uses.

- Implemented Pulay's own error vector (Fock/density commutator, orthonormal basis) and minimum-norm Fock extrapolation, replacing damping as the default accelerator (damping kept only as a one-iteration bootstrap before DIIS has history).
- Added an energy-based convergence criterion alongside the existing density-based one (both required now).

**Verified on the real Si2 near-degenerate-orbital case that originally motivated damping**: DIIS converges in 11 iterations to -570.8740320949 Ha, vs. 53 iterations for plain damped substitution to reach the same energy (agreement to 12 significant figures -- same self-consistent solution, ~4.8x faster). H2 converges in 3 iterations (down from 13), same energy.

## Test plan
- [x] Full existing regression suite (33 tests, `tests/integration/test_dashboard_hamiltonians.py`) passes unchanged, including the exact Si2 ground-state-energy assertion this change could most plausibly have broken.
- [x] `docs/api/native_hf.md`'s worked example numbers updated to match the new (faster) convergence.