### PR TITLE
Add AO-to-MO transform tests + doc updates from external bridge.py review

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -178,9 +178,18 @@ native_hf/*               fully self-contained internal DAG (basis -> gaussians/
                            only via PennyLane's own qml.Hamiltonian return type
 ```
 
-Two facts worth being explicit about, since they contradict what the package-grouping
+Three facts worth being explicit about, since they contradict what the package-grouping
 diagram alone would suggest:
 
+- **`native_hf/` produces a fixed classical Hamiltonian, entirely in NumPy, as a
+  one-time preprocessing step *before* the JAX-differentiable pipeline begins** —
+  `bridge.build_qubit_hamiltonian` hands PennyLane's `fermionic_observable`/
+  `jordan_wigner` a converged Hartree-Fock result and gets back a plain `qml.Hamiltonian`,
+  no `jax.grad` involved anywhere in that path. It is not part of the
+  `theta -> energy(theta)` differentiable graph the "Design invariants" section below
+  describes — that invariant is about circuit *parameters*, not nuclear geometry;
+  `dE/dR` (differentiating the SCF result itself with respect to atomic positions) is
+  not something this module does.
 - **`solvers/autodiff.py` imports nothing from `backends/` or `physics/`.** The Hamiltonian
   it needs (`h_matrix`) is supplied by the *caller* — a dense matrix from
   `physics/observables.py`, or a [`PauliSumOperator`](https://tatopenn-cell.github.io/Dense-Evolution/api/observables/)

--- a/docs/api/native_hf.md
+++ b/docs/api/native_hf.md
@@ -82,10 +82,29 @@ silent wrong energy for an incomplete basis.
 [lowdanie/hartree-fock-solver](https://github.com/lowdanie/hartree-fock-solver)
 ("slaterform", Apache-2.0, studied as a reference for structuring the Obara-Saika
 recursion with `jax.lax.scan` -- no source code copied) to machine precision on
-individual integrals, and to 10 significant figures on Si2/STO-3G's full SCF energy.
-Algorithm background also drawn from PennyLane's own white paper (Delgado et al.,
-"Differentiable quantum computational chemistry with PennyLane",
-[arXiv:2111.09967](https://arxiv.org/abs/2111.09967)).
+individual integrals. The original Si2/STO-3G full-SCF-energy cross-check against
+slaterform predates the DIIS/Si2-convergence fix below and has not been re-run against
+the corrected energy -- the per-integral cross-check is unaffected (integrals don't
+depend on how the SCF loop converges), but the end-to-end Si2 number should be treated
+as not yet re-verified against this independent reference. Algorithm background also
+drawn from PennyLane's own white paper (Delgado et al., "Differentiable quantum
+computational chemistry with PennyLane", [arXiv:2111.09967](https://arxiv.org/abs/2111.09967)).
+
+**SCF convergence (`run_scf`)**: DIIS-accelerated (Pulay 1980/1982) by default, not
+plain linear damping -- see [the module's own docstring](https://github.com/tatopenn-cell/Dense-Evolution/blob/main/dense_evolution/native_hf/scf.py)
+for the real Si2 near-degenerate-orbital case that motivated this (11 DIIS iterations
+vs. 53 for damping alone, same converged energy to 12 significant figures) and requires
+both density and energy to stop changing before declaring convergence, not density
+alone.
+
+**AO-to-MO integral transformation**: `bridge._ao_to_mo`'s 4-index `einsum` +
+`swapaxes` (converting AO-basis integrals to the molecular-orbital basis, using the
+converged Hartree-Fock coefficients) is exactly the kind of operation where an
+index-ordering mistake can produce a plausible-looking but numerically wrong
+Hamiltonian -- cross-checked against two independent references: a sequential
+one-index-at-a-time transform (a different algorithm computing the same quantity, not
+a copy of the code under test) to `1e-10`, and a real physical invariant on H2 (a
+basis change alone cannot alter the total electronic energy) to `1e-10`.
 
 **Production entry point**: [`dashboard_core.hamiltonians`](dashboard_core_hamiltonians.md)
 calls this engine automatically (`bridge.build_qubit_hamiltonian`) whenever a requested

--- a/tests/unit/test_native_hf_bridge.py
+++ b/tests/unit/test_native_hf_bridge.py
@@ -1,0 +1,98 @@
+"""
+Unit tests for dense_evolution/native_hf/bridge.py's AO->MO integral
+transformation (_ao_to_mo) -- flagged by an external review as the part
+of this module with the weakest test coverage: a delicate 4-index
+einsum + swapaxes where an index-ordering mistake could produce a
+plausible-looking but numerically wrong Hamiltonian. Cross-checked
+against two independent references, not just re-run against itself:
+a plain sequential one-index-at-a-time transformation (a genuinely
+different algorithm computing the same quantity), and a real physical
+invariant (the transform must not change the total electronic energy).
+"""
+import numpy as np
+import pytest
+
+from dense_evolution.native_hf.bridge import _ao_to_mo, _apply_active_space
+from dense_evolution.native_hf.basis import build_molecule_shells
+from dense_evolution.native_hf.assembly import (
+    build_overlap_matrix, build_core_hamiltonian, build_repulsion_tensor,
+)
+from dense_evolution.native_hf.scf import run_scf
+
+_BOHR_PER_ANGSTROM = 1.8897259886
+
+
+def _sequential_ao_to_mo(repulsion: np.ndarray, C: np.ndarray) -> np.ndarray:
+    """Independent reference for the two-electron AO->MO transform: one
+    index contracted at a time (the standard textbook N^5 sequential
+    transform), instead of _ao_to_mo's single combined 5-tensor einsum
+    -- a genuinely different sequence of operations computing the same
+    quantity, not a copy of the code under test."""
+    step1 = np.einsum('ab,bdeg->adeg', C.T, repulsion)
+    step2 = np.einsum('cd,adeg->aceg', C.T, step1)
+    step3 = np.einsum('ef,aceg->acfg', C, step2)
+    step4 = np.einsum('gh,acfg->acfh', C, step3)
+    return step4
+
+
+class TestAoToMo:
+
+    def test_one_electron_matches_plain_matrix_product(self):
+        rng = np.random.default_rng(0)
+        n = 5
+        H_core = rng.standard_normal((n, n))
+        H_core = H_core + H_core.T
+        repulsion = rng.standard_normal((n, n, n, n))
+        C = rng.standard_normal((n, n))
+
+        one, _ = _ao_to_mo(H_core, repulsion, C)
+        assert np.allclose(one, C.T @ H_core @ C, atol=1e-12)
+
+    def test_two_electron_matches_independent_sequential_transform(self):
+        rng = np.random.default_rng(1)
+        n = 4
+        # A real ERI tensor has 8-fold permutational symmetry -- build one
+        # that does, rather than an arbitrary 4-index array, so this test
+        # exercises the same kind of input _ao_to_mo actually sees.
+        repulsion = rng.standard_normal((n, n, n, n))
+        repulsion = repulsion + repulsion.transpose(1, 0, 2, 3)
+        repulsion = repulsion + repulsion.transpose(0, 1, 3, 2)
+        repulsion = repulsion + repulsion.transpose(2, 3, 0, 1)
+        C = rng.standard_normal((n, n))
+        H_core = np.zeros((n, n))
+
+        _, two = _ao_to_mo(H_core, repulsion, C)
+        expected = _sequential_ao_to_mo(repulsion, C)
+        # _ao_to_mo's own swapaxes(1, 3) undone here to compare against
+        # the un-swapped sequential reference directly.
+        assert np.allclose(np.swapaxes(two, 1, 3), expected, atol=1e-10)
+
+    def test_full_space_transform_preserves_real_h2_electronic_energy(self):
+        # The real physical invariant a broken index order would violate:
+        # transforming AO integrals to the MO basis, then reducing to the
+        # SAME full space (no core frozen, every orbital active), must
+        # reproduce the identical total electronic energy the AO-basis
+        # SCF already converged to -- a basis change alone cannot alter a
+        # physical observable. Uses the real H2/STO-3G integrals build_qubit_hamiltonian
+        # itself would use, not a synthetic system.
+        geometry_bohr = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.7414]]) * _BOHR_PER_ANGSTROM
+        shells = build_molecule_shells([1, 1], geometry_bohr, "sto-3g")
+        S = build_overlap_matrix(shells)
+        H_core = build_core_hamiltonian(shells, [1.0, 1.0], geometry_bohr)
+        repulsion = build_repulsion_tensor(shells)
+        hf_result = run_scf(S, H_core, repulsion, 2, [1.0, 1.0], geometry_bohr)
+
+        one, two = _ao_to_mo(H_core, repulsion, hf_result.orbital_coefficients)
+        n_orbitals = one.shape[0]
+        core_constant, one_active, two_active = _apply_active_space(
+            0.0, one, two, [], list(range(n_orbitals))
+        )
+
+        n_occupied_pairs = 1  # H2: 2 electrons
+        E_mo = core_constant
+        for i in range(n_occupied_pairs):
+            E_mo += 2 * one_active[i, i]
+            for j in range(n_occupied_pairs):
+                E_mo += 2 * two_active[i, j, j, i] - two_active[i, j, i, j]
+
+        assert E_mo == pytest.approx(hf_result.electronic_energy, abs=1e-10)


### PR DESCRIPTION
## Summary
Addresses the concrete gap flagged in an external review (saved in `Fullwork/prog.txt`): `bridge.py`'s `_ao_to_mo` (a delicate 4-index einsum + swapaxes transforming AO-basis integrals to the MO basis) had zero direct test coverage.

- 3 new tests cross-checking `_ao_to_mo` against two independent references: a sequential one-index-at-a-time transform (a different algorithm, same quantity) to `1e-10`, and a real physical invariant on H2 (a full-space basis transform cannot change the total electronic energy) to `1e-10`.
- `docs/api/native_hf.md`: documents the new coverage, plus an honest caveat -- the existing Si2/slaterform full-SCF-energy cross-check predates the recent DIIS fix and hasn't been re-run against the corrected energy.
- `ARCHITECTURE.md`: adds the real architectural boundary the review's "not fully JAX end-to-end" point confirms -- `native_hf` produces a fixed classical Hamiltonian via NumPy, before and outside the differentiable VQE graph.

## Test plan
- [x] `pytest tests/unit/test_native_hf_bridge.py tests/integration/test_dashboard_hamiltonians.py` -- 36/36 passed.