### PR TITLE
native_hf/basis.py: vmap primitive normalization instead of Python loop

### DIFF
--- a/dense_evolution/native_hf/basis.py
+++ b/dense_evolution/native_hf/basis.py
@@ -58,7 +58,7 @@ def _contracted_shell_from_bse(shell: dict, center: jax.Array, atom_index: int) 
     shells = []
     for row, degree in enumerate(angular_momenta):
         coeffs = jnp.array([float(c) for c in shell["coefficients"][row]])
-        norms = jnp.array([_primitive_norm(a, degree) for a in exponents])
+        norms = jax.vmap(_primitive_norm, in_axes=(0, None))(exponents, degree)
         shells.append(
             ContractedShell(
                 atom_index=atom_index,


### PR DESCRIPTION
## Summary

Pure internal refactor in `_contracted_shell_from_bse` (dense_evolution/native_hf/basis.py): the primitive-normalization loop over Gaussian exponents is now `jax.vmap`'d instead of a Python list comprehension, matching the project's JAX-native (vmap/jit) convention used elsewhere.

```python
norms = jax.vmap(_primitive_norm, in_axes=(0, None))(exponents, degree)
```
replaces
```python
norms = jnp.array([_primitive_norm(a, degree) for a in exponents])
```

Zero behavior change: `_primitive_norm` and `overlap_3d` are vmap-safe (`GaussianShell3D` is a registered pytree with `degree` as static aux_data, so `in_axes=(0, None)` over `exponent`/`degree` works cleanly).

## Verification

- Direct H2/STO-3G shell-loading smoke test: identical coefficients/shapes before and after.
- Full local test suite: `tests/unit/test_native_hf_bridge.py` + `tests/integration/test_dashboard_hamiltonians.py`, 36/36 passed, including the exact Si2 `ground_state_energy` assertion, all unchanged.