### PR TITLE
fermions.py: generalize Hubbard hopping to 2D lattices via square_lattice_edges

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -47,7 +47,7 @@ from .solvers.harrison_tb import (ELEMENTS as HARRISON_ELEMENTS, ETA as HARRISON
                                    sp3_dimer_hamiltonian, zincblende_hamiltonian)
 from .solvers.vhd_tb import (MATERIALS as VHD_MATERIALS, sp3s_star_hamiltonian,
                               direct_gap_at_gamma, band_extrema_along_path)
-from .physics.fermions import majorana_pauli_terms, total_parity_operator, hubbard_hamiltonian_pauli_terms
+from .physics.fermions import majorana_pauli_terms, total_parity_operator, hubbard_hamiltonian_pauli_terms, square_lattice_edges
 from .physics.entropy import partial_trace, von_neumann_entropy, mutual_information, central_charge
 from .circuits.trotter import (pauli_rotation_ops, trotter_evolve_ops, continuous_pulse_evolve,
                                 continuous_dissipative_evolve)
@@ -95,7 +95,7 @@ __all__ = [
     "multiply_pauli_terms",
     "pauli_sum_matvec_jax", "pauli_sum_expectation_jax", "PauliSumOperator",
     "partial_trace", "von_neumann_entropy", "mutual_information", "central_charge",
-    "majorana_pauli_terms", "total_parity_operator", "hubbard_hamiltonian_pauli_terms",
+    "majorana_pauli_terms", "total_parity_operator", "hubbard_hamiltonian_pauli_terms", "square_lattice_edges",
     "pauli_commutes", "compute_syndrome", "erasure_aware_decode", "pymatching_decode", "blind_minimum_weight_decode",
     "decode_with_erasure_fallback", "counts_in_intervals_dimension", "nearest_coset_decode",
     # Utils -- drawing, measurement, random circuits

--- a/dense_evolution/physics/__init__.py
+++ b/dense_evolution/physics/__init__.py
@@ -4,7 +4,7 @@ from .observables import (pauli_expectation, pauli_sum_expectation, pauli_hamilt
                            pauli_sum_matvec, multiply_pauli_terms,
                            pauli_sum_matvec_jax, pauli_sum_expectation_jax, PauliSumOperator)
 from .entropy import partial_trace, von_neumann_entropy, mutual_information, central_charge
-from .fermions import majorana_pauli_terms, total_parity_operator, hubbard_hamiltonian_pauli_terms
+from .fermions import majorana_pauli_terms, total_parity_operator, hubbard_hamiltonian_pauli_terms, square_lattice_edges
 from .qec import (pauli_commutes, compute_syndrome, erasure_aware_decode, pymatching_decode,
                    blind_minimum_weight_decode, nearest_coset_decode)
 
@@ -14,7 +14,7 @@ __all__ = [
     "multiply_pauli_terms",
     "pauli_sum_matvec_jax", "pauli_sum_expectation_jax", "PauliSumOperator",
     "partial_trace", "von_neumann_entropy", "mutual_information", "central_charge",
-    "majorana_pauli_terms", "total_parity_operator", "hubbard_hamiltonian_pauli_terms",
+    "majorana_pauli_terms", "total_parity_operator", "hubbard_hamiltonian_pauli_terms", "square_lattice_edges",
     "pauli_commutes", "compute_syndrome", "erasure_aware_decode", "pymatching_decode", "blind_minimum_weight_decode",
     "nearest_coset_decode",
 ]

--- a/dense_evolution/physics/fermions.py
+++ b/dense_evolution/physics/fermions.py
@@ -46,7 +46,10 @@ machinery), not a general lattice-fermion-model builder.
 """
 from .observables import multiply_pauli_terms
 
-__all__ = ['majorana_pauli_terms', 'total_parity_operator', 'hubbard_hamiltonian_pauli_terms']
+__all__ = [
+    'majorana_pauli_terms', 'total_parity_operator',
+    'hubbard_hamiltonian_pauli_terms', 'square_lattice_edges',
+]
 
 
 def majorana_pauli_terms(mode_index, n_qubits):
@@ -154,15 +157,88 @@ def total_parity_operator(mode_indices, n_qubits):
     return coeff * (1j ** (n / 2)), pauli_dict
 
 
-def hubbard_hamiltonian_pauli_terms(n_sites, t, U, periodic=True):
-    """Jordan-Wigner mapping of the 1D Hubbard-ring Hamiltonian
+def square_lattice_edges(lx, ly, periodic=True, periodic_y=None):
+    """Nearest-neighbor site-index pairs (i, j) on an Lx by Ly square
+    lattice, site index = y*lx + x (row-major). One x-bond and one
+    y-bond generated per site; a periodic direction wraps via i ->
+    (i+1) % L, the same convention as the 1D ring below -- an L=2
+    periodic direction generates the same physical bond twice (once
+    from each end), matching that same known behavior already present
+    in the 1D n_sites=2 case, not a new quirk introduced here.
+
+    `periodic` sets the x-direction boundary; `periodic_y` sets the
+    y-direction independently (defaults to the same value as `periodic`
+    when not given, so a single `periodic=True/False` still means "both
+    directions" for the common torus/open cases). Pass periodic=True,
+    periodic_y=False for a "cylinder" -- periodic around one direction,
+    open (a finite "leg" ladder) along the other -- the same geometry
+    Arovas, Bandyopadhyay & Zhu's Hubbard-model review (arXiv:2103.12097,
+    already cited below) discusses for W-leg cylinder DMRG studies
+    ("periodic boundary conditions have been enforced around the
+    cylinder" while the leg direction stays open/finite), not an
+    invented boundary condition.
+
+    With ly=1 this reduces exactly to the 1D ring
+    hubbard_hamiltonian_pauli_terms builds internally (verified in
+    tests/unit/test_fermions.py), so passing edges=square_lattice_edges(
+    n_sites, 1, periodic) to hubbard_hamiltonian_pauli_terms reproduces
+    its own default 1D behavior; ly>1 is the actual 2D generalization,
+    cross-checked there against an independent brute-force fermionic
+    construction on a real 2x2 lattice, both fully open and
+    periodic-in-x-only -- kept small since the hopping loop keys each
+    term only on that edge's own qubit indices, so nothing about the
+    check depends on lattice size.
+
+    Parameters
+    ----------
+    lx, ly : int
+        Lattice extent along x and y.
+    periodic : bool, default True
+        Wrap the x direction. Also used for y when `periodic_y` is None.
+    periodic_y : bool, optional
+        Wrap the y direction independently of `periodic`.
+
+    Returns
+    -------
+    list of (int, int)
+        Site-index pairs, ready for hubbard_hamiltonian_pauli_terms's
+        `edges` parameter.
+    """
+    if periodic_y is None:
+        periodic_y = periodic
+    edges = []
+    for y in range(ly):
+        for x in range(lx):
+            i = y * lx + x
+            if x + 1 < lx:
+                edges.append((i, y * lx + (x + 1)))
+            elif periodic and lx > 1:
+                edges.append((i, y * lx))
+            if y + 1 < ly:
+                edges.append((i, (y + 1) * lx + x))
+            elif periodic_y and ly > 1:
+                edges.append((i, x))
+    return edges
+
+
+def hubbard_hamiltonian_pauli_terms(n_sites, t, U, periodic=True, edges=None):
+    """Jordan-Wigner mapping of the Hubbard Hamiltonian
     H = -t * sum_<ij>,sigma (c^dagger_i,sigma c_j,sigma + h.c.)
         + U * sum_i n_i,up * n_i,down
     onto n_qubits=2*n_sites qubits: qubits [0, n_sites) are the spin-up
     orbitals, qubits [n_sites, 2*n_sites) spin-down, both site-ordered.
-    <ij> runs over nearest-neighbor sites on a 1D ring (site i to site
-    (i+1) % n_sites); pass periodic=False to drop the wraparound bond
-    (site n_sites-1 to site 0) and get an open chain instead.
+    <ij> runs over nearest-neighbor sites; by default that's a 1D ring
+    (site i to site (i+1) % n_sites), with periodic=False dropping the
+    wraparound bond (site n_sites-1 to site 0) for an open chain instead.
+
+    Pass `edges` explicitly (a list of (i, j) site-index pairs, 0 <= i,
+    j < n_sites) to describe a different lattice -- e.g. a 2D square
+    lattice via square_lattice_edges(lx, ly, periodic) with n_sites=
+    lx*ly -- and `periodic` is then ignored (the wraparound choice is
+    already baked into the edges you pass). The hopping/Jordan-Wigner
+    machinery below only ever uses the qubit-index Z-string between two
+    given sites (see the wraparound-bond note below), so it was already
+    lattice-agnostic; only the default 1D edge list was ring-specific.
 
     The wraparound bond needed a self-test before being trusted: some
     Jordan-Wigner conventions need an extra fermion-parity correction for
@@ -175,7 +251,9 @@ def hubbard_hamiltonian_pauli_terms(n_sites, t, U, periodic=True):
     this was verified directly against an independent brute-force
     fermionic operator construction (not just argued from the formula):
     max diff 0.00e+00 (machine-exact) at n_sites=2,3,4, both periodic and
-    open (Dense-Evolution-Discovery's hubbard_square_arovas.py).
+    open (Dense-Evolution-Discovery's hubbard_square_arovas.py), and at a
+    2D lattice via square_lattice_edges, both open and periodic-in-x-only
+    (see tests).
 
     Parameters
     ----------
@@ -197,6 +275,10 @@ def hubbard_hamiltonian_pauli_terms(n_sites, t, U, periodic=True):
         checkable via the sign pattern of pairing correlations
         <Delta_0^dagger Delta_j> with Delta_i = c_i,up * c_i,down
         (positive for axis neighbors, negative for the diagonal).
+        Ignored when `edges` is passed explicitly.
+    edges : list of (int, int), optional
+        Explicit nearest-neighbor site pairs, overriding the default 1D
+        ring. See square_lattice_edges for a 2D square-lattice builder.
 
     Returns
     -------
@@ -209,9 +291,10 @@ def hubbard_hamiltonian_pauli_terms(n_sites, t, U, periodic=True):
     n_qubits = 2 * n_sites
     terms = []
 
-    edges = [(i, (i + 1) % n_sites) for i in range(n_sites)]
-    if not periodic:
-        edges = [(i, j) for i, j in edges if not (i == n_sites - 1 and j == 0)]
+    if edges is None:
+        edges = [(i, (i + 1) % n_sites) for i in range(n_sites)]
+        if not periodic:
+            edges = [(i, j) for i, j in edges if not (i == n_sites - 1 and j == 0)]
 
     for i, j in edges:
         for offset in (0, n_sites):

--- a/docs/api/fermions.md
+++ b/docs/api/fermions.md
@@ -126,6 +126,41 @@ applies `terms` directly to the statevector, the same differentiable path
 [`circuit_to_energy_fn`](autodiff.md) uses for `jax.grad`-based VQE, without ever
 building a dense Hamiltonian matrix.
 
+## Step 5. Beyond 1D: a 2D lattice
+
+```python
+edges = de.square_lattice_edges(2, 2, periodic=False)
+edges
+```
+
+```
+[(0, 1), (0, 2), (1, 3), (2, 3)]
+```
+
+`hubbard_hamiltonian_pauli_terms`'s hopping construction only ever needs a Jordan-Wigner
+`Z`-string between two given qubit indices -- it never assumed a 1D ring. `square_lattice_edges(lx,
+ly, periodic)` builds the site-index pairs for an `lx` by `ly` square lattice instead (site
+`index = y*lx + x`); passing them via the `edges` parameter swaps out the default ring
+for any lattice this function can describe. Above, a 2x2 open plaquette (4 sites, no
+diagonal bond) gives the 4 nearest-neighbor pairs shown.
+
+```python
+terms2d = de.hubbard_hamiltonian_pauli_terms(n_sites=4, t=1.0, U=2.0, edges=edges)
+len(terms2d)
+```
+
+```
+32
+```
+
+4 bonds, 2 spins, 2 Pauli terms (`XX` and `YY`) per bond-spin gives `4*2*2=16` hopping
+terms, plus `4*4=16` onsite-interaction terms (4 sites) -- `32` total, [`PauliSumOperator`](observables.md)-
+ready exactly like Step 4's 1D Hamiltonian. `periodic` and `periodic_y` wrap the x- and
+y-directions independently, so `periodic=True, periodic_y=False` gives a "cylinder" --
+periodic around one direction, open along the other, the finite-width-ladder geometry
+Arovas, Bandyopadhyay & Zhu's Hubbard-model review (cited below) uses for its cylinder
+DMRG results.
+
 ---
 
 ## Details

--- a/tests/unit/test_fermions.py
+++ b/tests/unit/test_fermions.py
@@ -6,7 +6,7 @@ matrices via pauli_hamiltonian_to_matrix, not just the textbook formula.
 import numpy as np
 import pytest
 
-from dense_evolution import majorana_pauli_terms, hubbard_hamiltonian_pauli_terms
+from dense_evolution import majorana_pauli_terms, hubbard_hamiltonian_pauli_terms, square_lattice_edges
 from dense_evolution.observables import pauli_hamiltonian_to_matrix
 from dense_evolution.physics.fermions import total_parity_operator
 
@@ -189,15 +189,16 @@ def _annihilation_matrix(n_qubits, q):
     return result @ kron_at(sigma_minus, q)
 
 
-def _hubbard_matrix_bruteforce(n_sites, t, U, periodic=True):
+def _hubbard_matrix_bruteforce(n_sites, t, U, periodic=True, edges=None):
     """Fermionic-operator construction, independent of the XX/YY Pauli
     decomposition hubbard_hamiltonian_pauli_terms uses."""
     n_qubits = 2 * n_sites
     c = [_annihilation_matrix(n_qubits, q) for q in range(n_qubits)]
     H = np.zeros((2 ** n_qubits, 2 ** n_qubits), dtype=complex)
-    edges = [(i, (i + 1) % n_sites) for i in range(n_sites)]
-    if not periodic:
-        edges = [(i, j) for i, j in edges if not (i == n_sites - 1 and j == 0)]
+    if edges is None:
+        edges = [(i, (i + 1) % n_sites) for i in range(n_sites)]
+        if not periodic:
+            edges = [(i, j) for i, j in edges if not (i == n_sites - 1 and j == 0)]
     for i, j in edges:
         for off in (0, n_sites):
             qi, qj = off + i, off + j
@@ -257,3 +258,56 @@ class TestHubbardHamiltonianPauliTerms:
         assert rel_diff < 1e-3, f"rel_diff={rel_diff:.2e} too large deep in the small-U regime"
         # Reproduces the exact value found in Experiment 38: -3.962753
         assert energy_exact == pytest.approx(-3.962753, abs=1e-5)
+
+
+class TestSquareLatticeEdges:
+    """square_lattice_edges generalizes hubbard_hamiltonian_pauli_terms's
+    hopping term beyond the 1D ring -- the hopping/Jordan-Wigner machinery
+    itself was already lattice-agnostic (it only ever uses the Z-string
+    between two given qubit indices), so this is purely a new edge-list
+    builder, not a change to the term construction."""
+
+    @pytest.mark.parametrize("n_sites,periodic", [(3, True), (3, False), (4, True), (5, False)])
+    def test_ly_one_reduces_exactly_to_the_1d_ring(self, n_sites, periodic):
+        """The defining consistency check: with ly=1, the 2D builder must
+        reproduce hubbard_hamiltonian_pauli_terms's own internal 1D ring
+        edge list exactly, not just an equivalent graph."""
+        ring_edges = [(i, (i + 1) % n_sites) for i in range(n_sites)]
+        if not periodic:
+            ring_edges = [(i, j) for i, j in ring_edges if not (i == n_sites - 1 and j == 0)]
+        assert square_lattice_edges(n_sites, 1, periodic=periodic) == ring_edges
+
+    def test_open_2x2_has_four_bonds_no_diagonal(self):
+        edges = square_lattice_edges(2, 2, periodic=False)
+        assert set(tuple(sorted(e)) for e in edges) == {(0, 1), (2, 3), (0, 2), (1, 3)}
+
+    def test_periodic_x_and_y_are_independent(self):
+        """periodic controls x, periodic_y controls y independently --
+        with neither given, periodic_y defaults to periodic (single-flag
+        torus/open cases stay as simple as before)."""
+        lx, ly = 3, 2
+        assert len(square_lattice_edges(lx, ly, periodic=False)) == 4 + 3
+        assert len(square_lattice_edges(lx, ly, periodic=True)) == 6 + 6
+        assert len(square_lattice_edges(lx, ly, periodic=True, periodic_y=False)) == 6 + 3
+        assert len(square_lattice_edges(lx, ly, periodic=False, periodic_y=True)) == 4 + 6
+
+    @pytest.mark.parametrize("periodic,periodic_y", [(False, False), (True, False)])
+    def test_hubbard_on_2d_lattice_matches_bruteforce_fermionic_construction(self, periodic, periodic_y):
+        """hubbard_hamiltonian_pauli_terms's hopping loop handles every
+        edge independently -- each term's JW string only depends on that
+        edge's own qubit indices, nothing depends on the overall graph
+        shape -- so a small 2x2 lattice (8 qubits) exercises the same
+        arbitrary-edges code path a bigger grid would, for a fraction of
+        the brute-force matrix cost (2**8 vs. e.g. 2**12 for a 3x2 grid).
+        Covers both a fully open plaquette and periodic=True,
+        periodic_y=False (a small 'cylinder' -- see square_lattice_edges's
+        own docstring for the L=2 double-bond note that applies here)."""
+        lx, ly, t, U = 2, 2, 1.0, 0.5
+        n_sites = lx * ly
+        edges = square_lattice_edges(lx, ly, periodic=periodic, periodic_y=periodic_y)
+
+        terms = hubbard_hamiltonian_pauli_terms(n_sites, t, U, edges=edges)
+        H_pauli = np.asarray(pauli_hamiltonian_to_matrix(terms, 2 * n_sites))
+        H_bruteforce = _hubbard_matrix_bruteforce(n_sites, t, U, edges=edges)
+        max_diff = np.max(np.abs(H_pauli - H_bruteforce))
+        assert max_diff < 1e-10, f"2D lattice periodic={periodic},{periodic_y}: diff={max_diff:.2e}"


### PR DESCRIPTION
Addresses the lowest sub-score (Generalita: 7.8/10) in the latest fermions.py review: the Hubbard model builder was hardcoded to a 1D ring.

The hopping/Jordan-Wigner machinery in \`hubbard_hamiltonian_pauli_terms\` was already lattice-agnostic (each term's Z-string only depends on that edge's own qubit indices, nothing shape-dependent) -- only the default edge-list generation was 1D-specific. Adds:

- \`edges=\` optional parameter on \`hubbard_hamiltonian_pauli_terms\`, overriding the default 1D ring with any explicit site-pair list.
- \`square_lattice_edges(lx, ly, periodic=True, periodic_y=None)\`: 2D square-lattice edge builder, with \`periodic\`/\`periodic_y\` independent so a "cylinder" (periodic one direction, open the other) is representable -- grounded in Arovas, Bandyopadhyay & Zhu's Hubbard review (arXiv:2103.12097, already cited in this file), which uses exactly that geometry for its cylinder DMRG results (checked via quantumrag, not assumed).

Verified:
- \`ly=1\` reduces \`square_lattice_edges\` exactly to the existing internal 1D ring edge list (not just an equivalent graph).
- Real 2D Hamiltonians (open + periodic-in-x-only "cylinder") cross-checked against the existing independent brute-force fermionic-operator reference in \`tests/unit/test_fermions.py\`, to 1e-10. Kept at a small 2x2/8-qubit lattice rather than a bigger one -- the term-construction loop treats every edge independently, so a larger lattice would exercise the identical code path for a much higher brute-force matrix cost with no added coverage.
- Full \`tests/unit/test_fermions.py\`: 27/27 passed in 1.3s.
- \`docs/api/fermions.md\` gets a new Step 5 with a real, verified 2x2-lattice example.

No behavior change for existing callers (edges defaults to None, same 1D ring as before).