### PR TITLE
P5: fix test collection in a clean env (pennylane/mcp not on path)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,7 +174,7 @@ local_site = "research/local_site"
 # longer siblings of _helpers.py. This adds tests/ to sys.path
 # unconditionally regardless of which subdirectory the running test file
 # lives in -- pytest's own sanctioned mechanism for exactly this case.
-pythonpath = ["tests"]
+pythonpath = ["tests", "tools"]
 
 [tool.black]
 line-length = 100

--- a/tests/unit/test_native_hf_bridge.py
+++ b/tests/unit/test_native_hf_bridge.py
@@ -12,6 +12,8 @@ invariant (the transform must not change the total electronic energy).
 import numpy as np
 import pytest
 
+pytest.importorskip("pennylane")
+
 from dense_evolution.native_hf.bridge import _ao_to_mo, _apply_active_space
 from dense_evolution.native_hf.basis import build_molecule_shells
 from dense_evolution.native_hf.assembly import (


### PR DESCRIPTION
- `tests/unit/test_native_hf_bridge.py`: guard with `pytest.importorskip("pennylane")` — the module transitively imports pennylane via `native_hf/bridge.py`, `ModuleNotFoundError` with `-x` stopped the whole suite.
- `pyproject.toml`: extend the existing `pythonpath` ini option to `["tests", "tools"]` so `test_mcp_cache.py` resolves `mcp_server` (lives under `tools/`) without external `PYTHONPATH`.

Verified: `pytest tests/unit -x --collect-only -q` collects all 795 tests clean; `test_mcp_cache.py`'s 7 tests pass.

P5 of the prog.txt audit list.