### PR TITLE
P6: fix blind_minimum_weight_decode false negative on degenerate codes

### DIFF
--- a/dense_evolution/physics/qec.py
+++ b/dense_evolution/physics/qec.py
@@ -132,6 +132,62 @@ def _pauli_string(n_qubits: int, assignment: dict) -> str:
     return ''.join(chars)
 
 
+_PAULI_SYMPLECTIC = {'I': (0, 0), 'X': (1, 0), 'Z': (0, 1), 'Y': (1, 1)}
+
+
+def _pauli_to_symplectic(pauli_str: str) -> np.ndarray:
+    """Length-n Pauli string -> length-2n GF(2) vector (n X-bits, then n
+    Z-bits). The Pauli group modulo global phase is isomorphic to
+    GF(2)^2n under this map, with Pauli multiplication (mod phase)
+    corresponding to vector XOR -- so two Pauli strings differ by a
+    stabilizer element (same coset) iff the XOR of their symplectic
+    vectors lies in the GF(2) span of the stabilizers' own symplectic
+    vectors."""
+    n = len(pauli_str)
+    v = np.zeros(2 * n, dtype=np.uint8)
+    for i, p in enumerate(pauli_str):
+        x, z = _PAULI_SYMPLECTIC[p]
+        v[i] = x
+        v[n + i] = z
+    return v
+
+
+def _gf2_rref(matrix: np.ndarray):
+    """Reduced row-echelon form of a GF(2) matrix, plus the column index
+    of each row's pivot. Pure Gaussian elimination mod 2 -- deciding
+    stabilizer-group membership needs this, not enumeration of the
+    2**k group elements (k = number of independent generators)."""
+    m = matrix.copy() % 2
+    rows, cols = m.shape
+    pivots = []
+    pivot_row = 0
+    for col in range(cols):
+        if pivot_row >= rows:
+            break
+        pivot = next((r for r in range(pivot_row, rows) if m[r, col]), None)
+        if pivot is None:
+            continue
+        m[[pivot_row, pivot]] = m[[pivot, pivot_row]]
+        for r in range(rows):
+            if r != pivot_row and m[r, col]:
+                m[r] ^= m[pivot_row]
+        pivots.append(col)
+        pivot_row += 1
+    return m, pivots
+
+
+def _in_gf2_span(v: np.ndarray, rref: np.ndarray, pivots: list) -> bool:
+    """Whether GF(2) vector v lies in the row space of `rref` (already in
+    reduced row-echelon form, with `pivots[i]` the pivot column of row
+    i) -- reduce v against each pivot row in turn, in the span iff the
+    residual is all-zero."""
+    v = v.copy() % 2
+    for row, col in enumerate(pivots):
+        if v[col]:
+            v ^= rref[row]
+    return not v.any()
+
+
 def erasure_aware_decode(
     observed_syndrome: tuple,
     heralded_qubits: Sequence[int],
@@ -334,14 +390,18 @@ def blind_minimum_weight_decode(
 
     Searches every possible Pauli error in increasing WEIGHT order (0
     non-identity qubits, then 1, then 2, ...), stopping at the first
-    weight with at least one match: returns that match if it's the ONLY
-    one at that weight, `None` if more than one full-length Pauli string
-    at the minimum matching weight reproduces `observed_syndrome`
-    (ambiguous -- not guessed) or if nothing matches by `max_weight`.
-    Minimum-weight selection, not "only one match across every possible
-    weight" -- the latter essentially never holds for a blind search,
-    since any correction plus a stabilizer element reproduces the same
-    syndrome (see module docstring). This IS the same principle
+    weight with at least one match. Multiple matches at that weight are
+    NOT automatically ambiguous: in a degenerate code (e.g. Shor
+    [[9,1,3]]), two lowest-weight corrections that differ by a
+    stabilizer-group element are the SAME physical correction (applying
+    either one restores the code space identically), not two competing
+    guesses. This checks that directly -- via the corrections' symplectic
+    (GF(2)) representation, not by re-deriving it from scratch each call
+    -- and returns the (deterministic, first-found) representative when
+    every match is in the same stabilizer coset. Returns `None` only when
+    two matches at the minimum weight differ by an actual LOGICAL
+    operator (not in the stabilizer group), which is genuine ambiguity, or
+    when nothing matches by `max_weight`. This IS the same principle
     `pymatching_decode`'s MWPM implements, via brute force instead of a
     matching graph -- deliberately much slower, in exchange for working
     on ANY stabilizer code, graph-like or not.
@@ -403,6 +463,9 @@ def blind_minimum_weight_decode(
             raise ValueError(f"stabilizers[{i}] has length {len(s)}, expected n_qubits={n_qubits}")
 
     target = tuple(observed_syndrome)
+    stab_rref, stab_pivots = _gf2_rref(
+        np.array([_pauli_to_symplectic(s) for s in stabilizers], dtype=np.uint8)
+    )
 
     for weight in range(max_weight + 1):
         matches = []
@@ -412,10 +475,18 @@ def blind_minimum_weight_decode(
                 candidate = _pauli_string(n_qubits, assignment)
                 if compute_syndrome(candidate, stabilizers) == target:
                     matches.append(candidate)
+        if not matches:
+            continue
         if len(matches) == 1:
             return matches[0]
-        if len(matches) > 1:
-            return None
+
+        reference = matches[0]
+        reference_symplectic = _pauli_to_symplectic(reference)
+        same_coset = all(
+            _in_gf2_span(reference_symplectic ^ _pauli_to_symplectic(m), stab_rref, stab_pivots)
+            for m in matches[1:]
+        )
+        return reference if same_coset else None
 
     return None
 

--- a/tests/unit/test_qec.py
+++ b/tests/unit/test_qec.py
@@ -30,6 +30,20 @@ STEANE_X_STABILIZERS = ['IIIXXXX', 'IXXIIXX', 'XIXIXIX']
 STEANE_Z_STABILIZERS = ['IIIZZZZ', 'IZZIIZZ', 'ZIZIZIZ']
 N_STEANE = 7
 
+# Shor [[9,1,3]] stabilizer generators: 3 blocks of 3 qubits (0-2, 3-5,
+# 6-8), Z-type pairs detecting a bit flip within each block (degenerate:
+# any single Z error inside a block is invisible to the OTHER Z stabilizer
+# of that block and shares its syndrome with the other two single-Z
+# errors in the same block), X-type generators spanning two blocks at a
+# time detecting a phase flip across blocks.
+SHOR_STABILIZERS = [
+    'ZZIIIIIII', 'IZZIIIIII',
+    'IIIZZIIII', 'IIIIZZIII',
+    'IIIIIIZZI', 'IIIIIIIZZ',
+    'XXXXXXIII', 'IIIXXXXXX',
+]
+N_SHOR = 9
+
 
 class TestPauliCommutes:
 
@@ -457,6 +471,36 @@ class TestBlindMinimumWeightDecode:
 
         assert blind_minimum_weight_decode(syndrome, N_STEANE, all_stabilizers, max_weight=0) is None
         assert blind_minimum_weight_decode(syndrome, N_STEANE, all_stabilizers, max_weight=1) == error
+
+    def test_shor_code_degenerate_z_errors_all_decode(self):
+        """prog.txt P6: Shor [[9,1,3]] is a real degenerate code -- any two
+        single-Z errors inside the same 3-qubit block are invisible to
+        that block's own Z-type stabilizer and so share a syndrome (their
+        product IS that very stabilizer generator, e.g. Z0*Z1 = 'ZZIIIIIII'
+        = the first generator itself), meaning applying either one is the
+        same physical correction. The old ambiguity criterion (more than
+        one match -> None) returned None for all 9 Z errors; this decodes
+        every one of the 18 weight-1 X/Z errors to a correction with the
+        matching syndrome."""
+        for q in range(N_SHOR):
+            for pauli in ('X', 'Z'):
+                error = qec_module._pauli_string(N_SHOR, {q: pauli})
+                syndrome = compute_syndrome(error, SHOR_STABILIZERS)
+                correction = blind_minimum_weight_decode(syndrome, N_SHOR, SHOR_STABILIZERS)
+                assert correction is not None, f"{pauli} error on qubit {q} incorrectly returned None"
+                assert compute_syndrome(correction, SHOR_STABILIZERS) == syndrome
+
+    def test_shor_code_z_stabilizers_alone_cannot_distinguish_x_from_y(self):
+        """Contrast case for the same fix: Shor's 6 Z-type generators alone
+        (bit-flip detection within each block) span only even-weight
+        combinations confined to one block -- never a single bare Z --
+        so an X vs Y error at the same qubit (whose product is a lone Z
+        there) is a genuine LOGICAL difference, not a stabilizer one, and
+        must still return None."""
+        z_only = SHOR_STABILIZERS[:6]
+        error = qec_module._pauli_string(N_SHOR, {4: 'X'})
+        syndrome = compute_syndrome(error, z_only)
+        assert blind_minimum_weight_decode(syndrome, N_SHOR, z_only) is None
 
     def test_invalid_max_weight_raises(self):
         with pytest.raises(ValueError, match="max_weight"):


### PR DESCRIPTION
Real false negative (prog.txt P6): `blind_minimum_weight_decode` returned `None` whenever more than one minimum-weight correction matched the syndrome, treating every multi-match as ambiguous. On a degenerate code (Shor [[9,1,3]]), two lowest-weight corrections differing by a stabilizer-group element are the SAME physical correction — verified: 9 of 18 weight-1 errors on Shor (all the Z errors) returned `None`.

Fixed by checking stabilizer-coset membership directly via GF(2) symplectic representation + Gaussian elimination (`_pauli_to_symplectic`, `_gf2_rref`, `_in_gf2_span`), not enumeration of the `2**k` group elements. Returns the first-found deterministic representative when every match is in the same coset; `None` only for genuine logical ambiguity.

New tests: all 18 weight-1 Shor errors now decode; a genuine-ambiguity contrast case (Shor's Z-only stabilizers can't distinguish X from Y) still correctly returns `None`. All 3 existing Steane ambiguity tests verified unaffected by hand before writing the fix (their products are logical, not stabilizer, operators) and confirmed green after.

`test_qec.py`: 49 passed, 0 failed.

P6 of the prog.txt audit list.