### PR TITLE
P2: fix build_core_hamiltonian re-jit on every call

### DIFF
--- a/dense_evolution/native_hf/assembly.py
+++ b/dense_evolution/native_hf/assembly.py
@@ -103,33 +103,20 @@ def build_overlap_matrix(shells: list[ContractedShell]) -> np.ndarray:
     return _build_two_index(shells, _overlap_primitive)
 
 
+def _core_hamiltonian_primitive(ga, gb, charges, positions):
+    T = kinetic_3d(ga, gb)
+    per_nucleus = jax.vmap(lambda z, r: -z * nuclear_attraction(ga, gb, r))(charges, positions)
+    V = jnp.sum(per_nucleus, axis=0)
+    return -0.5 * T + V
+
+
 def build_core_hamiltonian(shells: list[ContractedShell], nuclear_charges: list[float], nuclear_positions: np.ndarray) -> np.ndarray:
-    # NOTE: this closure is rebuilt (and re-jitted) on every call, which
-    # defeats cross-call jit caching for e.g. a bond-length scan -- see
-    # prog.txt task "fix cross-call JIT caching". Reverted to this
-    # simpler, independently-verified-correct form (matches slaterform
-    # to 10 significant figures on Si2/STO-3G) after a traced-args
-    # refactor (charges/positions as jax arrays via vmap over nuclei,
-    # threaded through a shared `extra` argument in _pair_block) passed
-    # every individual/aggregate check (element-wise Hc, eigenvalues,
-    # trace, sum, 5x determinism) yet still produced a different,
-    # wrong total SCF energy end-to-end for reasons not pinned down in
-    # the time available -- not worth shipping an unexplained
-    # discrepancy just for speed.
-    charges = tuple(float(z) for z in nuclear_charges)
-    positions = tuple(jnp.asarray(r) for r in nuclear_positions)
-
-    def core_primitive(ga, gb):
-        T = kinetic_3d(ga, gb)
-        V = jnp.zeros_like(T)
-        for z, r in zip(charges, positions):
-            V = V - z * nuclear_attraction(ga, gb, r)
-        return -0.5 * T + V
-
-    return _build_two_index(shells, core_primitive)
+    charges = jnp.asarray(nuclear_charges, dtype=jnp.float64)
+    positions = jnp.asarray(nuclear_positions, dtype=jnp.float64)
+    return _build_two_index(shells, _core_hamiltonian_primitive, extra=(charges, positions))
 
 
-def _build_two_index(shells: list[ContractedShell], primitive_fn) -> np.ndarray:
+def _build_two_index(shells: list[ContractedShell], primitive_fn, extra=()) -> np.ndarray:
     n = n_cartesian_functions(shells)
     offsets = _shell_offsets(shells)
     M = np.zeros((n, n))
@@ -139,7 +126,7 @@ def _build_two_index(shells: list[ContractedShell], primitive_fn) -> np.ndarray:
                 _pair_block(
                     sa.exponents, sa.coefficients, sa.center, sa.degree,
                     sb.exponents, sb.coefficients, sb.center, sb.degree,
-                    primitive_fn,
+                    primitive_fn, extra=extra,
                 )
             )
             oi, oj = offsets[i], offsets[j]


### PR DESCRIPTION
Diagnosis first, per prog.txt P2: reproduced the traced-charges/positions refactor the module's own comment described as previously rolled back for giving a "different, wrong total SCF energy end-to-end." Compared the full downstream chain against the current (closure-based) implementation on a real 3-atom molecule (H2O/STO-3G) — S, H_core, ERI tensor, SCF total/electronic energy, iteration count — isolating the first diverging quantity.

**Root cause of the earlier failure could not be pinned down** (that code was never committed, only described in a comment), but this clean reimplementation is verified correct: S and the repulsion tensor are bit-identical (0 diff); H_core differs by 4.44e-16 (2 ULP) at its largest, from summation-order non-associativity (`jax.vmap`+`jnp.sum` over nuclei vs. a sequential Python for-loop) — not a bug; total/electronic energy agree to 13 significant figures, same iteration count (10).

Aside worth flagging: a first attempt at this comparison gave a false "bit-identical to a stale answer" result, because `python <script>.py` resolves `dense_evolution` to a stale non-editable site-packages install ahead of the local checkout for that invocation style. Re-verified with `sys.path` forced to the local repo before trusting any number (same class of issue as an earlier stale-install false alarm in a different repo this session).

**Fix**: `core_primitive` was a fresh Python closure over `charges`/`positions`, rebuilt every call — since `_pair_block`'s `primitive_fn` is a static jit key (identity-hashed), a new closure object forces a fresh trace/compile every single call, defeating cross-call caching for e.g. a bond-length scan. Replaced with `_core_hamiltonian_primitive`, a stable module-level function, with charges/positions now traced arguments threaded through `_pair_block`'s existing `extra` mechanism (already built for exactly this) instead of closed over.

Verified: a 20-point H2 PEC scan traces/compiles exactly once (was: 20 separate compilations), 15.780s → 1.323s (~12x). All frozen `tests/unit/test_native_hf_engine.py` values unaffected (44 passed with `test_native_hf_bridge.py`, `JAX_ENABLE_X64=True`, matching CI).

P2 of the prog.txt audit list.