### PR TITLE
P3: ERI tensor scalability (8-fold symmetry + Cauchy-Schwarz screening)

### DIFF
--- a/dense_evolution/native_hf/assembly.py
+++ b/dense_evolution/native_hf/assembly.py
@@ -139,9 +139,15 @@ def build_repulsion_tensor(shells: list[ContractedShell]) -> np.ndarray:
     offsets = _shell_offsets(shells)
     V = np.zeros((n, n, n, n))
     for i, sa in enumerate(shells):
-        for j, sb in enumerate(shells):
+        for j in range(i + 1):
+            sb = shells[j]
+            ij_index = i * (i + 1) // 2 + j
             for k, sc in enumerate(shells):
-                for l, sd in enumerate(shells):
+                for l in range(k + 1):
+                    sd = shells[l]
+                    kl_index = k * (k + 1) // 2 + l
+                    if ij_index < kl_index:
+                        continue
                     block = np.array(
                         _quartet_block(
                             (sa.exponents, sb.exponents, sc.exponents, sd.exponents),
@@ -152,10 +158,15 @@ def build_repulsion_tensor(shells: list[ContractedShell]) -> np.ndarray:
                         )
                     )
                     oi, oj, ok, ol = offsets[i], offsets[j], offsets[k], offsets[l]
-                    V[
-                        oi : oi + block.shape[0],
-                        oj : oj + block.shape[1],
-                        ok : ok + block.shape[2],
-                        ol : ol + block.shape[3],
-                    ] = block
+                    for pi, pj, pk, pl, b in (
+                        (oi, oj, ok, ol, block),
+                        (oj, oi, ok, ol, block.transpose(1, 0, 2, 3)),
+                        (oi, oj, ol, ok, block.transpose(0, 1, 3, 2)),
+                        (oj, oi, ol, ok, block.transpose(1, 0, 3, 2)),
+                        (ok, ol, oi, oj, block.transpose(2, 3, 0, 1)),
+                        (ol, ok, oi, oj, block.transpose(3, 2, 0, 1)),
+                        (ok, ol, oj, oi, block.transpose(2, 3, 1, 0)),
+                        (ol, ok, oj, oi, block.transpose(3, 2, 1, 0)),
+                    ):
+                        V[pi : pi + b.shape[0], pj : pj + b.shape[1], pk : pk + b.shape[2], pl : pl + b.shape[3]] = b
     return V

--- a/dense_evolution/native_hf/assembly.py
+++ b/dense_evolution/native_hf/assembly.py
@@ -134,10 +134,37 @@ def _build_two_index(shells: list[ContractedShell], primitive_fn, extra=()) -> n
     return M
 
 
-def build_repulsion_tensor(shells: list[ContractedShell]) -> np.ndarray:
+def _schwarz_bound(sa: ContractedShell, sb: ContractedShell) -> float:
+    block = np.array(
+        _quartet_block(
+            (sa.exponents, sb.exponents, sa.exponents, sb.exponents),
+            (sa.coefficients, sb.coefficients, sa.coefficients, sb.coefficients),
+            (sa.center, sb.center, sa.center, sb.center),
+            (sa.degree, sb.degree, sa.degree, sb.degree),
+            electron_repulsion,
+        )
+    )
+    na, nb = block.shape[0], block.shape[1]
+    diag = np.array([[block[p, q, p, q] for q in range(nb)] for p in range(na)])
+    return float(np.sqrt(np.max(np.abs(diag))))
+
+
+def _shell_pair_schwarz_bounds(shells: list[ContractedShell]) -> dict:
+    bounds = {}
+    for i, sa in enumerate(shells):
+        for j in range(i + 1):
+            sb = shells[j]
+            q = _schwarz_bound(sa, sb)
+            bounds[(i, j)] = q
+            bounds[(j, i)] = q
+    return bounds
+
+
+def build_repulsion_tensor(shells: list[ContractedShell], screening_tol: float = 1e-12) -> np.ndarray:
     n = n_cartesian_functions(shells)
     offsets = _shell_offsets(shells)
     V = np.zeros((n, n, n, n))
+    schwarz = _shell_pair_schwarz_bounds(shells)
     for i, sa in enumerate(shells):
         for j in range(i + 1):
             sb = shells[j]
@@ -147,6 +174,8 @@ def build_repulsion_tensor(shells: list[ContractedShell]) -> np.ndarray:
                     sd = shells[l]
                     kl_index = k * (k + 1) // 2 + l
                     if ij_index < kl_index:
+                        continue
+                    if schwarz[(i, j)] * schwarz[(k, l)] < screening_tol:
                         continue
                     block = np.array(
                         _quartet_block(


### PR DESCRIPTION
Three interventions from prog.txt P3, each measured independently. Two kept, one abandoned with evidence.

## Step 1 (kept): 8-fold permutational symmetry
Only computes quartets with `i>=j, k>=l, (i,j)>=(k,l)`, replicates via axis transposes. Honest finding: NOT literally bit-identical to the original (1.665e-16 on H2, 3.920e-15 on H2O -- a few ULP, floating-point summation-order noise from deduplicating quartets vs the original's independent redundant computation, same class as this session's P0/P2 findings). All frozen SCF energies unaffected.

**This step is the real win**: on Si2 (10 shells), pre-step-1 baseline 45.60s cold / **17.77s warm** → step-1 32.81s cold / **2.26s warm** — a ~7.9x speedup at warm cache, essentially the theoretical 8x.

## Step 2 (NOT committed): shell-signature batching — measured regression
Implemented exactly as specified (group quartets by `(degree, K)` signature, one `vmap` call per group instead of per quartet) and verified correct, but benchmarked *worse* on Si2 in both dimensions: 50.07s cold / 3.98s warm, vs. step-1's 32.81s / 2.26s. Not a compile-cost-now-pays-off-later trade-off — warm is worse too.

Root-caused by measurement, not assumption: summed (isolated per-signature `_quartet_block` call time at warm cache) × (quartet count in that signature) across all 16 of Si2's post-symmetry signatures → **predicted 3.68s**, already *higher* than step-1's real 2.26s total. Since the sum-of-parts estimate already exceeds the real whole, there's no leftover per-quartet dispatch overhead left for batching to reclaim — the real cost is the Obara-Saika recursion's own XLA compute, which grouping-based batching doesn't reduce. Kept as a local stash, not pushed.

## Step 3 (kept): Cauchy-Schwarz screening
New `screening_tol` parameter (default `1e-12`): precomputes `Q_ij = sqrt(max|(pq|pq)|)` per shell pair, skips quartets with `Q_ij*Q_kl < screening_tol` (Cauchy-Schwarz: `|(pq|rs)| <= Q_pq*Q_rs`).

Verified: `screening_tol=0.0` bit-identical to unscreened on H2/H2O (0 quartets screened either way — compact molecules, nothing negligible). Default screening on Si2: max abs diff 5.170e-13 vs unscreened (well inside 1e-12), 244/1540 quartets skipped (~16%).

## Full P3 benchmark (step 1 + step 3 combined)

| system | shells | before (prog.txt) | after | target |
|---|---|---|---|---|
| H2O | 5 | 43.8s cold | **22.0s cold** | — |
| (H2O)2 | 10 | 6.3s warm | **0.957s warm** | <1s ✓ |
| (H2O)4 | 20 | — | **5.3s cold / 4.5s warm** | <10s ✓ |

`test_native_hf_engine.py` + `test_native_hf_bridge.py`: 44 passed throughout.

P3 of the prog.txt audit list.