### PR TITLE
P4: Pauli expectation values for MPS via tensor contraction

### DIFF
--- a/dense_evolution/backends/mps.py
+++ b/dense_evolution/backends/mps.py
@@ -57,6 +57,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from ..physics.observables import _normalize_terms
+
 
 def _jsd_vectors_jax(p: jnp.ndarray, q: jnp.ndarray) -> jnp.ndarray:
     """Same Jensen-Shannon Distance as _jsd_vectors, but returns a jnp
@@ -893,3 +895,51 @@ class MPSSimulator:
                             stacklevel=2,
                         )
                     self.budget_violations += 1
+
+
+_PAULI_MATRICES = {
+    'I': jnp.eye(2, dtype=jnp.complex128),
+    'X': jnp.array([[0, 1], [1, 0]], dtype=jnp.complex128),
+    'Y': jnp.array([[0, -1j], [1j, 0]], dtype=jnp.complex128),
+    'Z': jnp.array([[1, 0], [0, -1]], dtype=jnp.complex128),
+}
+
+
+def mps_pauli_expectation(mps: "MPSSimulator", pauli_terms) -> complex:
+    """<psi|P|psi> for a single Pauli string P, contracted directly against
+    the MPS (Gamma/Lambda tensors) via a left-to-right transfer-matrix
+    sweep -- never materializes a (2**n,) statevector, cost O(n * chi^3).
+
+    pauli_terms accepts the same three forms as
+    physics.observables.pauli_expectation (a string, e.g. 'XIZ'; a dict
+    {qubit: 'X'|'Y'|'Z'}; or an iterable of (qubit, pauli) pairs) -- reuses
+    that module's own `_normalize_terms` so both functions agree on
+    parsing by construction, not by parallel reimplementation.
+
+    Every site (not only ones in pauli_terms) goes through the identical
+    per-site contraction, using the identity matrix wherever pauli_terms
+    doesn't specify a Pauli -- this is already O(chi^3) per site regardless
+    of whether the local operator is I or a real Pauli, so there is no
+    separate "skip identity sites" fast path to get right or wrong: the
+    same sweep is correct for any placement of the operator's support,
+    including support that spans much of the chain, without relying on
+    which side of any notional orthogonality center a given site falls on.
+    """
+    assignment = _normalize_terms(pauli_terms, mps.n)
+    dtype = mps.gammas[0].dtype
+    env = jnp.ones((1, 1), dtype=dtype)
+    for i in range(mps.n):
+        op = _PAULI_MATRICES[assignment.get(i, 'I')].astype(dtype)
+        a = jnp.einsum('l,lpr->lpr', mps.lambdas[i].astype(dtype), mps.gammas[i])
+        a_op = jnp.einsum('pq,lqr->lpr', op, a)
+        env = jnp.einsum('lk,lpr->kpr', env, jnp.conj(a))
+        env = jnp.einsum('kpr,kps->rs', env, a_op)
+    return complex(env[0, 0])
+
+
+def mps_pauli_sum_expectation(mps: "MPSSimulator", terms) -> complex:
+    """sum_i coeff_i * <psi|P_i|psi>, each term contracted via
+    mps_pauli_expectation -- same terms format as
+    physics.observables.pauli_sum_expectation: an iterable of
+    (coeff, pauli_terms) pairs."""
+    return sum(coeff * mps_pauli_expectation(mps, pauli_terms) for coeff, pauli_terms in terms)

--- a/tests/unit/test_mps.py
+++ b/tests/unit/test_mps.py
@@ -18,6 +18,7 @@ import jax.numpy as jnp
 import dense_evolution as de
 from dense_evolution.backends.mps import (
     MPSSimulator, _jsd_vectors, _vectorized_chi_search, _expand_nonlocal_2q_positions,
+    mps_pauli_expectation, mps_pauli_sum_expectation,
 )
 
 def test_backward_compat_shim_mps_reexports_mpssimulator():
@@ -852,4 +853,64 @@ def test_mps_truncation_quality_vs_optimal_rank_chi(n_qubits, layers, chi):
     fid_optimal = np.abs(np.vdot(psi_exact, psi_optimal)) ** 2
 
     assert fid_mps >= 0.95 * fid_optimal
+
+
+# ── P4: Pauli expectation values via tensor contraction (prog.txt) ──────
+# Every case below is deliberately chosen to stress the one thing an
+# incorrect "skip sites outside the operator's support" shortcut could
+# get silently wrong: support placed in the middle of a chain with real,
+# non-trivial entanglement built up on BOTH sides of it (not just at the
+# edges, where such a bug would be invisible on a product-like tail).
+
+def _entangled_dense_and_mps(n_qubits, seed, layers, max_bond=32):
+    ops = _brick_wall_ry_ops(n_qubits, seed=seed, layers=layers)
+    dense = de.DenseSVSimulator(n_qubits=n_qubits, use_float32=False)
+    dense.run_circuit_jit(ops)
+    psi = dense.get_statevector()
+    mps = MPSSimulator(n_qubits=n_qubits, max_bond=max_bond)
+    mps.run_circuit_jit(ops)
+    return psi, mps
+
+
+@pytest.mark.parametrize("n_qubits,layers,pauli_terms", [
+    (8, 4, "XIIIIIII"),
+    (8, 4, "IIIIIIIZ"),
+    (9, 4, {2: "Z", 6: "Z"}),
+    (9, 4, {0: "X", 8: "Y"}),
+    (10, 5, "XYZXIXYZXI"),
+    (10, 5, {4: "X", 5: "Y"}),
+    (12, 5, [(1, "X"), (5, "Y"), (6, "Z"), (10, "X")]),
+])
+def test_mps_pauli_expectation_matches_dense_various_supports(n_qubits, layers, pauli_terms):
+    psi, mps = _entangled_dense_and_mps(n_qubits, seed=3, layers=layers)
+    expected = de.pauli_expectation(psi, pauli_terms)
+    got = mps_pauli_expectation(mps, pauli_terms)
+    assert got == pytest.approx(expected, abs=1e-10)
+
+
+def test_mps_pauli_expectation_accepts_all_three_term_formats():
+    psi, mps = _entangled_dense_and_mps(9, seed=5, layers=4)
+    from_string = mps_pauli_expectation(mps, "IIXIIYIII")
+    from_dict = mps_pauli_expectation(mps, {2: "X", 5: "Y"})
+    from_pairs = mps_pauli_expectation(mps, [(2, "X"), (5, "Y")])
+    expected = de.pauli_expectation(psi, "IIXIIYIII")
+    assert from_string == pytest.approx(expected, abs=1e-10)
+    assert from_dict == pytest.approx(expected, abs=1e-10)
+    assert from_pairs == pytest.approx(expected, abs=1e-10)
+
+
+def test_mps_pauli_sum_expectation_matches_dense():
+    psi, mps = _entangled_dense_and_mps(9, seed=7, layers=5)
+    terms = [(0.5, {1: "Z"}), (-1.5, {3: "X", 4: "X"}), (2.0, {0: "Y", 7: "Z"})]
+    expected = sum(coeff * de.pauli_expectation(psi, term) for coeff, term in terms)
+    got = mps_pauli_sum_expectation(mps, terms)
+    assert got == pytest.approx(expected, abs=1e-10)
+
+
+def test_mps_pauli_expectation_n30_low_chi_runs_without_memory_error():
+    ops = _brick_wall_ry_ops(30, seed=1, layers=2)
+    mps = MPSSimulator(n_qubits=30, max_bond=8)
+    mps.run_circuit_jit(ops)
+    got = mps_pauli_expectation(mps, {0: "Z", 15: "X", 29: "Y"})
+    assert np.isfinite(got.real) and np.isfinite(got.imag)
 


### PR DESCRIPTION
`mps_pauli_expectation(mps, pauli_terms)` and `mps_pauli_sum_expectation(mps, terms)`: `<psi|P|psi>` and weighted sums thereof, contracted directly against the MPS's own Gamma/Lambda tensors — never materializes a `(2**n,)` statevector, so this works past `contract_to_statevector`'s n<=24 ceiling. Same three term formats as `physics.observables.pauli_expectation` (string / dict / (qubit, pauli) pairs), reusing that module's own `_normalize_terms`.

Depends on P0 (already merged): an expectation computed against the pre-P0 non-canonical truncation would have been silently wrong.

## Design departure from prog.txt Prompt 6, flagged by external review before implementation
"Sites outside the operator's support contract to identity and can be skipped" is only generally true on the side of a site matching its own canonical form (left-canonical to the left of an orthogonality center, right-canonical to the right) — blindly skipping both sides when the support straddles the center is a real bug in the general single-center MPS convention. This module's Vidal Gamma-Lambda form (restored to true bicanonicity by P0) would likely make the literal shortcut safe here — but rather than lean on that subtle fact, the implementation sidesteps the question entirely: **every site goes through the identical per-site transfer-matrix contraction**, using the identity matrix wherever no Pauli is specified. No extra asymptotic cost (each site is already O(chi^3) regardless of which operator sits there) — removes the failure mode by construction instead of by argument.

## Verified empirically, not just reasoned about
New tests specifically choose supports that straddle the middle of an entangled chain (9-qubit `{2:Z,6:Z}` and `{0:X,8:Y}`; a 12-qubit 4-term case spanning positions 1,5,6,10) against real brick-wall-entangled circuits — all match dense `pauli_expectation` to 1e-10. Plus: all three term formats agree; a weighted-sum case; and the required n=30/max_bond=8 case runs to a finite result with no `MemoryError`.

`test_mps.py`: 58 passed, 0 failed (`JAX_ENABLE_X64=True`, matching CI). Package import verified clean (no circular import from the new `physics.observables` dependency).

**Last item of the prog.txt audit** — P5, P0, P6, P1, P2, P3, P7, P4 all complete after this merges.