### PR TITLE
Final touches: anti-stale-package test guard + golden-test docstring clarity

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,21 @@ test_registry.py, test_compiler.py, test_parser.py, test_chunk.py,
 test_healing.py, test_integration.py).
 """
 import os
+import pathlib
 import sys
 
 import pytest
 
+import dense_evolution
 from dense_evolution import DenseSVSimulator
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+assert _REPO_ROOT in pathlib.Path(dense_evolution.__file__).resolve().parents, (
+    f"dense_evolution imported from {dense_evolution.__file__}, not from this repo "
+    f"checkout ({_REPO_ROOT}) -- a stale installed copy (e.g. a leftover 'pip install .' "
+    f"or a twine build) is shadowing the local source; every test below would silently "
+    f"run against the wrong code."
+)
 
 
 @pytest.hookimpl(trylast=True)

--- a/tests/unit/test_native_hf_engine.py
+++ b/tests/unit/test_native_hf_engine.py
@@ -4,6 +4,26 @@
 kinetic, coulomb, assembly) and the SCF loop itself had no direct
 numerical test at all. Values below were verified correct on the current
 code before being frozen here (see prog.txt), not invented.
+
+Two different kinds of assertion live in this file, worth telling apart:
+4 are anchored against something external to this codebase --
+boys(n,x) vs scipy's own hyp1f1, the H2/STO-3G and H2O/STO-3G SCF
+energies against real literature reference values (see prog.txt's own
+evidence table), and the ERI tensor's 8-fold permutational symmetry
+(a physical invariant true of any correct implementation, not a
+property of this one). These 4 verify correctness: a wrong answer here
+means a wrong answer, full stop.
+
+The other 37 assertions (the frozen overlap-matrix entry, the frozen
+Si2 iteration-count bound, etc.) are auto-generated -- frozen from
+whatever this code currently outputs, without independent verification
+against a known-correct external reference. These block regressions
+(a future change that shifts the number gets caught), but a systematic
+error already present when a value was frozen would be locked in, not
+revealed. If a future audit finds one of the 37 wrong, that is real
+information about a real bug -- it does not mean this test suite lied,
+it means this suite was never able to catch that particular error in
+the first place.
 """
 import numpy as np
 import pytest


### PR DESCRIPTION
Two of the four non-blocking loose ends from prog.txt's post-audit review ("Code aperte, non bloccanti", items 1 and 2). The other two (a line in PR #202 about diagnosis-open-but-protection-active, and the P3 step 2 negative-result caveat about the untried K_max-padding variant) were added as follow-up comments on the already-merged #202 and #203 instead of new commits.

## `tests/conftest.py`: anti-stale-package guard
Asserts `dense_evolution.__file__` resolves inside this repo checkout, not a stale installed copy elsewhere (e.g. a leftover `pip install .` or a twine build's working directory). This exact failure mode produced two real false alarms this session (P0's `mps.py` verification, P2's `dump_hcore.py` comparison) — `python <script>.py` resolves the package differently than `python -m pytest` for the identical environment, and both looked like passing runs until checked directly. Verified the assert's logic against the actual stale path found this session; collection unaffected (857 tests, same as before).

## `tests/unit/test_native_hf_engine.py`: docstring clarity
Distinguishes the 4 externally-anchored assertions (`boys` vs scipy's `hyp1f1`, H2/H2O SCF energies vs literature, ERI 8-fold symmetry — a physical invariant, not a property of this implementation) from the other 37, which are frozen from whatever the code currently outputs and only catch a *future* regression, not a systematic error already present when frozen. 41 passed, unaffected (docstring-only change).