### PR TITLE
Bump version to 8.1.72 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "dense-evolution"
 version = "8.1.72"
-description = "Micro-optimized High-Performance NISQ Statevector Quantum Circuit Simulator (Hardware-Adaptive Integration of Native NumPy and CPU/GPU/TPU JAX JIT/XLA Compilation, with Linear Kernel Fusion)"
+description = "High-performance quantum simulation toolkit -- Statevector/MPS engines with JIT compilation, noise modeling, VQE, QEC, quantum chemistry, and agent-native tooling"
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "Business Source License 1.1" }
@@ -16,15 +16,17 @@ keywords = [
     "quantum-computing",
     "quantum-simulation",
     "statevector",
+    "mps",
     "jax",
-    "cupy",
-    "cuda-acceleration",
+    "vqe",
+    "qec",
+    "quantum-chemistry",
+    "mcp",
     "openqasm",
     "nisq-noise",
     "hpc",
-    "linear-kernel-fusion",
-    "dashboard",
-    "visualization"
+    "cuda-acceleration",
+    "dashboard"
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dense-evolution"
-version = "8.1.71"
+version = "8.1.72"
 description = "Micro-optimized High-Performance NISQ Statevector Quantum Circuit Simulator (Hardware-Adaptive Integration of Native NumPy and CPU/GPU/TPU JAX JIT/XLA Compilation, with Linear Kernel Fusion)"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Covers the full prog.txt audit merged this session:

- P5 — test collection hygiene (#198)
- P0 — MPS canonical-truncation fix (#199)
- P6 — QEC degenerate-code false-negative fix (#200)
- P1 — native_hf golden tests (#201)
- P2 — build_core_hamiltonian re-jit fix (#202)
- P3 — ERI tensor scalability, 8-fold symmetry + Cauchy-Schwarz screening (#203)
- P7 — ZNE conditioning guardrails (#204)
- P4 — MPS Pauli expectation values (#205)
- Final touches — anti-stale-package guard + golden-test docstring clarity (#206)

No prior bump since 8.1.71 (2026-09-01).