### PR TITLE
P8: fix missing normalization in mps_pauli_expectation

### DIFF
--- a/dense_evolution/backends/mps.py
+++ b/dense_evolution/backends/mps.py
@@ -905,41 +905,83 @@ _PAULI_MATRICES = {
 }
 
 
+def _mps_transfer_sweep(
+    mps: "MPSSimulator", assignment: dict, need_norm: bool = True
+) -> Tuple[complex, Optional[float]]:
+    """Left-to-right transfer-matrix sweep over the Gamma/Lambda tensors
+    computing <psi|P|psi> (unnormalized) for the per-site operator
+    assignment (site -> 'I'|'X'|'Y'|'Z', missing sites default to 'I') --
+    never materializes a (2**n,) statevector, cost O(n * chi^3). When
+    need_norm is True, <psi|psi> is accumulated in the same Python loop
+    (reusing the per-site A = Lambda*Gamma tensor and its conjugate) and
+    returned alongside the raw value, instead of a second, separate sweep
+    -- when False (used by mps_pauli_sum_expectation, which only needs
+    the norm once for the whole sum, not once per term) that accumulation
+    is skipped entirely.
+
+    Every site (not only ones in the assignment) goes through the
+    identical per-site contraction, using the identity matrix wherever the
+    assignment doesn't specify a Pauli -- this is already O(chi^3) per
+    site regardless of whether the local operator is I or a real Pauli, so
+    there is no separate "skip identity sites" fast path to get right or
+    wrong: the same sweep is correct for any placement of the operator's
+    support, including support that spans much of the chain, without
+    relying on which side of any notional orthogonality center a given
+    site falls on.
+
+    The norm is needed at all because SVD truncation (apply_gate_2q) can
+    leave the Gamma/Lambda tensors at less than exact unit norm --
+    contract_to_statevector renormalizes explicitly for the same reason.
+    If the MPS ever carried exact unit norm this division is a no-op, but
+    every reader of the state normalizes explicitly rather than assuming
+    that invariant holds.
+    """
+    dtype = mps.gammas[0].dtype
+    env_op = jnp.ones((1, 1), dtype=dtype)
+    env_norm = jnp.ones((1, 1), dtype=dtype) if need_norm else None
+    for i in range(mps.n):
+        op = _PAULI_MATRICES[assignment.get(i, 'I')].astype(dtype)
+        a = jnp.einsum('l,lpr->lpr', mps.lambdas[i].astype(dtype), mps.gammas[i])
+        a_conj = jnp.conj(a)
+        a_op = jnp.einsum('pq,lqr->lpr', op, a)
+        env_op = jnp.einsum('lk,lpr->kpr', env_op, a_conj)
+        env_op = jnp.einsum('kpr,kps->rs', env_op, a_op)
+        if need_norm:
+            env_norm = jnp.einsum('lk,lpr->kpr', env_norm, a_conj)
+            env_norm = jnp.einsum('kpr,kps->rs', env_norm, a)
+    raw = complex(env_op[0, 0])
+    norm_sq = complex(env_norm[0, 0]).real if need_norm else None
+    return raw, norm_sq
+
+
 def mps_pauli_expectation(mps: "MPSSimulator", pauli_terms) -> complex:
-    """<psi|P|psi> for a single Pauli string P, contracted directly against
-    the MPS (Gamma/Lambda tensors) via a left-to-right transfer-matrix
-    sweep -- never materializes a (2**n,) statevector, cost O(n * chi^3).
+    """<psi|P|psi> / <psi|psi> for a single Pauli string P, contracted
+    directly against the MPS (Gamma/Lambda tensors).
 
     pauli_terms accepts the same three forms as
     physics.observables.pauli_expectation (a string, e.g. 'XIZ'; a dict
     {qubit: 'X'|'Y'|'Z'}; or an iterable of (qubit, pauli) pairs) -- reuses
     that module's own `_normalize_terms` so both functions agree on
-    parsing by construction, not by parallel reimplementation.
-
-    Every site (not only ones in pauli_terms) goes through the identical
-    per-site contraction, using the identity matrix wherever pauli_terms
-    doesn't specify a Pauli -- this is already O(chi^3) per site regardless
-    of whether the local operator is I or a real Pauli, so there is no
-    separate "skip identity sites" fast path to get right or wrong: the
-    same sweep is correct for any placement of the operator's support,
-    including support that spans much of the chain, without relying on
-    which side of any notional orthogonality center a given site falls on.
+    parsing by construction, not by parallel reimplementation. See
+    _mps_transfer_sweep for why the division is needed.
     """
     assignment = _normalize_terms(pauli_terms, mps.n)
-    dtype = mps.gammas[0].dtype
-    env = jnp.ones((1, 1), dtype=dtype)
-    for i in range(mps.n):
-        op = _PAULI_MATRICES[assignment.get(i, 'I')].astype(dtype)
-        a = jnp.einsum('l,lpr->lpr', mps.lambdas[i].astype(dtype), mps.gammas[i])
-        a_op = jnp.einsum('pq,lqr->lpr', op, a)
-        env = jnp.einsum('lk,lpr->kpr', env, jnp.conj(a))
-        env = jnp.einsum('kpr,kps->rs', env, a_op)
-    return complex(env[0, 0])
+    raw, norm_sq = _mps_transfer_sweep(mps, assignment, need_norm=True)
+    return raw / norm_sq
 
 
 def mps_pauli_sum_expectation(mps: "MPSSimulator", terms) -> complex:
-    """sum_i coeff_i * <psi|P_i|psi>, each term contracted via
-    mps_pauli_expectation -- same terms format as
+    """sum_i coeff_i * <psi|P_i|psi> / <psi|psi> -- same terms format as
     physics.observables.pauli_sum_expectation: an iterable of
-    (coeff, pauli_terms) pairs."""
-    return sum(coeff * mps_pauli_expectation(mps, pauli_terms) for coeff, pauli_terms in terms)
+    (coeff, pauli_terms) pairs. <psi|psi> does not depend on which Pauli
+    string is being measured, so it is computed once via its own sweep
+    and applied to the whole sum, instead of once per term."""
+    terms = list(terms)
+    if not terms:
+        return 0j
+    _, norm_sq = _mps_transfer_sweep(mps, {}, need_norm=True)
+    raw_sum = sum(
+        coeff * _mps_transfer_sweep(mps, _normalize_terms(pauli_terms, mps.n), need_norm=False)[0]
+        for coeff, pauli_terms in terms
+    )
+    return raw_sum / norm_sq

--- a/tests/unit/test_mps.py
+++ b/tests/unit/test_mps.py
@@ -914,3 +914,53 @@ def test_mps_pauli_expectation_n30_low_chi_runs_without_memory_error():
     got = mps_pauli_expectation(mps, {0: "Z", 15: "X", 29: "Y"})
     assert np.isfinite(got.real) and np.isfinite(got.imag)
 
+
+# ── P8: mps_pauli_expectation normalization (prog.txt) ──────────────────
+# _entangled_dense_and_mps's default max_bond=32 never saturates on the
+# n_qubits<=12 cases above, so the state stays at norm 1 and a missing
+# normalization is invisible there -- these cases use a bond dimension
+# small enough (n=14, 8 layers, max_bond=8 and 4) that truncation is real
+# (35 and 54 budget violations respectively at seed=11) -- prog.txt's own
+# measurement on a different circuit found the un-normalized function
+# drifting off 1.0 by up to ~9% under exactly this kind of real saturation.
+
+@pytest.mark.parametrize("max_bond", [8, 4])
+def test_mps_pauli_expectation_identity_is_one_under_real_truncation(max_bond):
+    ops = _brick_wall_ry_ops(14, seed=11, layers=8)
+    mps = MPSSimulator(n_qubits=14, max_bond=max_bond)
+    with pytest.warns(UserWarning, match="jsd_budget"):
+        mps.run_circuit_jit(ops)
+    assert mps.budget_violations > 0
+    got = mps_pauli_expectation(mps, "I" * 14)
+    assert got == pytest.approx(1.0, abs=1e-12)
+
+
+@pytest.mark.parametrize("pauli_terms", [
+    {2: "Z", 9: "Z"},
+    {0: "X", 13: "Y"},
+    "XYZXIXYZXIXYZX",
+])
+@pytest.mark.parametrize("max_bond", [8, 4])
+def test_mps_pauli_expectation_matches_renormalized_statevector_under_truncation(max_bond, pauli_terms):
+    ops = _brick_wall_ry_ops(14, seed=11, layers=8)
+    mps = MPSSimulator(n_qubits=14, max_bond=max_bond)
+    with pytest.warns(UserWarning, match="jsd_budget"):
+        mps.run_circuit_jit(ops)
+    sv = np.asarray(mps.contract_to_statevector())
+    assert np.linalg.norm(sv) == pytest.approx(1.0, abs=1e-10)
+    expected = de.pauli_expectation(sv, pauli_terms)
+    got = mps_pauli_expectation(mps, pauli_terms)
+    assert got == pytest.approx(expected, abs=1e-10)
+
+
+def test_mps_pauli_sum_expectation_matches_renormalized_statevector_under_truncation():
+    ops = _brick_wall_ry_ops(14, seed=11, layers=8)
+    mps = MPSSimulator(n_qubits=14, max_bond=8)
+    with pytest.warns(UserWarning, match="jsd_budget"):
+        mps.run_circuit_jit(ops)
+    sv = np.asarray(mps.contract_to_statevector())
+    terms = [(0.5, {1: "Z"}), (-1.5, {3: "X", 10: "X"}), (2.0, {0: "Y", 13: "Z"})]
+    expected = sum(coeff * de.pauli_expectation(sv, term) for coeff, term in terms)
+    got = mps_pauli_sum_expectation(mps, terms)
+    assert got == pytest.approx(expected, abs=1e-10)
+


### PR DESCRIPTION
Independent post-8.1.72 audit (prog.txt, Prompt 10) found `mps_pauli_expectation` returns the raw `<psi|P|psi>` transfer-matrix contraction, while `contract_to_statevector` explicitly renormalizes -- SVD truncation can leave the Gamma/Lambda tensors below exact unit norm, and the two APIs disagreed on the same state whenever truncation was real.

Verified before fixing: `mps_pauli_expectation(m, 'I'*n)` returned exactly `1.0` whenever `max_bond` never saturated, and drifted otherwise -- confirming the bug is invisible in the exact regime and only appears under real truncation (which `_entangled_dense_and_mps`'s `max_bond=32` never reaches, same blind spot as P0).

Design decision (discussed before implementing): normalize at read time (in the observable functions), not at the source (`apply_gate_2q`/truncation). Fixing at the source would require an O(n) global-norm sweep per gate (not per observable call) or re-orthogonalizing Gamma tensors in both the eager and JIT-compiled paths independently, risking exactly the kind of eager/JIT divergence this session's earlier audit (P0) had to fix. Read-time normalization is also the convention the codebase already uses (`contract_to_statevector` normalizes explicitly for the same reason) -- this is a second application of that convention, not a third one.

Cost: normalizing on every call would double the sweep cost. `_mps_transfer_sweep` computes the raw contraction and `<psi|psi>` together in one Python loop (`need_norm=True`) reusing the per-site tensors, so `mps_pauli_expectation` costs one sweep, not two. `mps_pauli_sum_expectation` computes `<psi|psi>` once for the whole sum (it doesn't depend on which Pauli string is measured) instead of once per term.

New tests use n=14, 8 layers, max_bond=8 and 4 (35 and 54 real budget violations respectively) -- a regime where truncation genuinely bites, not the max_bond=32 default that stays exact.

File scope: `dense_evolution/backends/mps.py`, `tests/unit/test_mps.py` only.