### PR TITLE
P9: normalize _optimal_rank_chi_state, separate the near-volume-law case

### DIFF
--- a/tests/unit/test_mps.py
+++ b/tests/unit/test_mps.py
@@ -816,7 +816,8 @@ def _optimal_rank_chi_state(psi, n_qubits, chi):
         l, d, r = core.shape
         vec = vec @ core.reshape(l, d * r)
         vec = vec.reshape(-1, r)
-    return vec.reshape(-1)
+    vec = vec.reshape(-1)
+    return vec / np.linalg.norm(vec)
 
 
 def _brick_wall_ry_ops(n_qubits, seed, layers, lo=0.1, hi=1.5):
@@ -835,7 +836,7 @@ def _brick_wall_ry_ops(n_qubits, seed, layers, lo=0.1, hi=1.5):
     return ops
 
 
-@pytest.mark.parametrize("n_qubits, layers, chi", [(8, 6, 8), (10, 8, 8), (12, 6, 16)])
+@pytest.mark.parametrize("n_qubits, layers, chi", [(8, 6, 8), (12, 6, 16)])
 def test_mps_truncation_quality_vs_optimal_rank_chi(n_qubits, layers, chi):
     ops = _brick_wall_ry_ops(n_qubits, seed=42, layers=layers)
 
@@ -853,6 +854,39 @@ def test_mps_truncation_quality_vs_optimal_rank_chi(n_qubits, layers, chi):
     fid_optimal = np.abs(np.vdot(psi_exact, psi_optimal)) ** 2
 
     assert fid_mps >= 0.95 * fid_optimal
+
+
+def test_mps_truncation_quality_vs_optimal_rank_chi_near_volume_law():
+    """(10, 8, 8) measured at ratio 0.83 (fid_mps / fid_optimal), well
+    below the 0.95 the other two parametrized cases clear. This is not
+    the MPS backend being broken: the TT-SVD reference is a global
+    optimum over the whole statevector, computed once with full knowledge
+    of the final state, while the MPS truncates sequentially gate by
+    gate, committing to each cut before later gates reveal how the state
+    entangles further. With 8 layers on 10 qubits the circuit is deep
+    enough relative to its width to approach the volume-law regime, where
+    that gap between a global and a sequential local optimum widens. A
+    single shared 0.95 threshold across all three cases was silently
+    weaker than it looked, because the pre-fix _optimal_rank_chi_state
+    returned an unnormalized vector that deflated fid_optimal enough to
+    mask this gap."""
+    n_qubits, layers, chi = 10, 8, 8
+    ops = _brick_wall_ry_ops(n_qubits, seed=42, layers=layers)
+
+    dense = de.DenseSVSimulator(n_qubits=n_qubits, use_float32=False)
+    dense.run_circuit_jit(ops)
+    psi_exact = dense.get_statevector()
+
+    mps = MPSSimulator(n_qubits=n_qubits, max_bond=chi)
+    mps.run_circuit_jit(ops)
+    sv_mps = np.asarray(mps.contract_to_statevector())
+
+    psi_optimal = _optimal_rank_chi_state(psi_exact, n_qubits, chi)
+
+    fid_mps = np.abs(np.vdot(psi_exact, sv_mps)) ** 2
+    fid_optimal = np.abs(np.vdot(psi_exact, psi_optimal)) ** 2
+
+    assert fid_mps >= 0.80 * fid_optimal
 
 
 # ── P4: Pauli expectation values via tensor contraction (prog.txt) ──────


### PR DESCRIPTION
Independent post-8.1.72 audit (prog.txt, Prompt 11) found `_optimal_rank_chi_state` in `tests/unit/test_mps.py` returns the recontracted TT-SVD vector without normalizing it. Truncation reduces its norm, so `fid_optimal` was deflated and `fid_mps >= 0.95 * fid_optimal` was a weaker assertion than its own docstring implied.

Measured after normalizing (matches prog.txt's own numbers exactly): (8,6,8) -> 0.979, (10,8,8) -> 0.830, (12,6,16) -> 0.995. (10,8,8) no longer clears 0.95.

Per the prompt's explicit instruction, not lowered silently for all three cases: (10,8,8) is split into its own test (`test_mps_truncation_quality_vs_optimal_rank_chi_near_volume_law`) with a 0.80 threshold and a docstring explaining why -- the TT-SVD reference is a global optimum computed with full knowledge of the final state, while the MPS truncates sequentially gate by gate; 8 layers on 10 qubits is deep enough relative to width to approach the volume-law regime where that gap between global and sequential-local optimum widens. The other two cases keep the original 0.95 threshold unchanged.

Branched off #208 (touches the same file, same test suite) rather than main, following this session's own convention (P4 branched off a main that already had P0 merged).

File scope: `tests/unit/test_mps.py` only. Full `test_mps.py` run: 65 passed (2 deselected -- `test_dashboard_engine_mps_matches_dense_bell`/`_entangling`, a pre-existing RAM-pressure flake on this machine unrelated to this change, confirmed to pass in isolation).