### PR TITLE
Document the approximation-parameter testing gap from prog.txt's audit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,7 @@ Tests are organized one file per source module, split into `tests/unit/` (a sing
 
 - Match the existing code style — no comments explaining *what* code does (names should do that); comments only for non-obvious *why* (a workaround, an invariant, a hard-won bug fix).
 - Add tests for anything you fix or add — especially anything numerical (statevector/probability outputs). A test that would have caught the bug you just fixed is worth more than a description of the fix.
+- For any function with an approximation parameter (`max_bond`, `shots`, `screening_tol`, number of noise-extrapolation scales, ...), at least one test must run in a regime where that parameter actually bites, not only the exact/unsaturated regime — three separate bugs in this repo (MPS truncation, MPS Pauli expectation, the MPS truncation-quality reference) each passed their existing tests only because those tests never pushed the approximation hard enough to expose them.
 - Update `README.md`'s changelog section if your change is user-visible.
 - Keep PRs focused — one fix or one feature per PR is easier to review than a bundle of unrelated changes.
 


### PR DESCRIPTION
prog.txt's independent post-8.1.72 audit found the same pattern three separate times: P0 (MPS truncation), P8 (`mps_pauli_expectation`), and P9 (the MPS truncation-quality test reference) all passed their existing tests only because those tests never pushed `max_bond` hard enough to actually saturate.

Adds one bullet to `CONTRIBUTING.md`'s "Making changes" section recording this as a rule for future PRs: any function with an approximation parameter needs at least one test in the regime where that parameter actually bites.

Docs-only change, no code touched.