### PR TITLE
Bump version to 8.1.73 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dense-evolution"
-version = "8.1.72"
+version = "8.1.73"
 description = "High-performance quantum simulation toolkit -- Statevector/MPS engines with JIT compilation, noise modeling, VQE, QEC, quantum chemistry, and agent-native tooling"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Covers everything merged since 8.1.72 (2026-09-08):

- #208 — P8: `mps_pauli_expectation`/`mps_pauli_sum_expectation` missing normalization (real bug in the 8.1.72 release, up to ~9% systematic bias on MPS observables under real truncation)
- #209 — P9: `_optimal_rank_chi_state` test-reference normalization, near-volume-law case given its own documented threshold
- #210 — CONTRIBUTING.md: approximation-parameter testing-regime rule
- #211 — `_PAULI_MATRICES` complex64 truncation (recurrence of the `GATES` bug), regression test generalized

**This is a correctness release, not a maintenance one.** 8.1.72 as published on PyPI contains the P8 bug in a public function -- anyone who installed it and used `mps_pauli_expectation`/`mps_pauli_sum_expectation` under real truncation is getting a systematically biased result (up to ~9% measured at n=14/chi=4). This needs to be stated plainly in the GitHub release notes, not left to the changelog link alone.

No other file changed -- version bump only, per this repo's convention (exactly +1 patch per release regardless of how many PRs are bundled in).

Not merging or publishing to PyPI from here -- both reserved for the user. Tag/GitHub release will follow only after PyPI upload is confirmed.