### PR TITLE
native_hf: add d-shell (angular momentum L=2) support

### DIFF
--- a/dense_evolution/native_hf/assembly.py
+++ b/dense_evolution/native_hf/assembly.py
@@ -22,7 +22,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from dense_evolution.native_hf.basis import ContractedShell, n_cartesian_functions
-from dense_evolution.native_hf.cartesian import cartesian_powers
+from dense_evolution.native_hf.cartesian import cartesian_powers, cartesian_normalization_ratios
 from dense_evolution.native_hf.gaussians import GaussianShell3D
 from dense_evolution.native_hf.overlap import overlap_3d
 from dense_evolution.native_hf.kinetic import kinetic_3d
@@ -39,6 +39,8 @@ def _pair_block(exponents_a, coeffs_a, center_a, degree_a, exponents_b, coeffs_b
     it IS a static jit key."""
     powers_a = jnp.asarray(cartesian_powers(degree_a))
     powers_b = jnp.asarray(cartesian_powers(degree_b))
+    ratio_a = jnp.asarray(cartesian_normalization_ratios(degree_a))
+    ratio_b = jnp.asarray(cartesian_normalization_ratios(degree_b))
 
     def one_primitive_pair(ea, ca, eb, cb):
         ga = GaussianShell3D(degree=degree_a, exponent=ea, center=center_a)
@@ -51,7 +53,7 @@ def _pair_block(exponents_a, coeffs_a, center_a, degree_a, exponents_b, coeffs_b
         jax.vmap(one_primitive_pair, in_axes=(None, None, 0, 0)),
         in_axes=(0, 0, None, None),
     )(exponents_a, coeffs_a, exponents_b, coeffs_b)
-    return jnp.sum(batched, axis=(0, 1))
+    return ratio_a[:, None] * ratio_b[None, :] * jnp.sum(batched, axis=(0, 1))
 
 
 @functools.partial(jax.jit, static_argnames=("degrees", "primitive_fn"))
@@ -59,6 +61,7 @@ def _quartet_block(exponents, coeffs, centers, degrees, primitive_fn):
     """exponents/coeffs: tuples of 4 arrays (one per shell), centers: tuple
     of 4 (3,) arrays, degrees: tuple of 4 static ints."""
     powers = [jnp.asarray(cartesian_powers(d)) for d in degrees]
+    ratios = [jnp.asarray(cartesian_normalization_ratios(d)) for d in degrees]
 
     def one_quartet(ea, ca, eb, cb, ec, cc, ed, cd):
         ga = GaussianShell3D(degree=degrees[0], exponent=ea, center=centers[0])
@@ -84,7 +87,10 @@ def _quartet_block(exponents, coeffs, centers, degrees, primitive_fn):
         exponents[2], coeffs[2], exponents[3], coeffs[3],
     )
     batched = vmapped(ea, ca, eb, cb, ec, cc, ed, cd)
-    return jnp.sum(batched, axis=(0, 1, 2, 3))
+    summed = jnp.sum(batched, axis=(0, 1, 2, 3))
+    ratio_outer = ratios[0][:, None, None, None] * ratios[1][None, :, None, None] \
+        * ratios[2][None, None, :, None] * ratios[3][None, None, None, :]
+    return ratio_outer * summed
 
 
 def _shell_offsets(shells: list[ContractedShell]) -> list[int]:

--- a/dense_evolution/native_hf/basis.py
+++ b/dense_evolution/native_hf/basis.py
@@ -22,6 +22,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from dense_evolution.native_hf.cartesian import cartesian_powers
 from dense_evolution.native_hf.gaussians import GaussianShell3D
 from dense_evolution.native_hf.overlap import overlap_3d
 
@@ -38,10 +39,14 @@ class ContractedShell:
 
 
 def _primitive_norm(exponent: jax.Array, degree: int) -> jax.Array:
-    """1/sqrt(self-overlap) for the (degree,0,0) Cartesian component --
-    for a shell of pure angular momentum `degree` every Cartesian
-    component (e.g. px, py, pz) has the same norm by symmetry, so one
-    component is enough."""
+    """1/sqrt(self-overlap) for the (degree,0,0) Cartesian component,
+    used as the shared reference normalization for every Cartesian
+    component of this shell. For degree<=1 that's already each
+    component's own norm (px, py, pz are equivalent by symmetry). For
+    degree>=2 it is not (dxx and dxy have different norms) --
+    cartesian_normalization_ratios supplies the per-component correction
+    relative to this same (degree,0,0) reference, applied at assembly
+    time in assembly.py rather than here."""
     g = GaussianShell3D(degree=degree, exponent=exponent, center=jnp.zeros(3))
     self_overlap = overlap_3d(g, g)[degree, 0, 0, degree, 0, 0]
     return 1.0 / jnp.sqrt(self_overlap)
@@ -81,14 +86,14 @@ def load_element_shells(basis_name: str, atomic_number: int, center: jax.Array, 
     max_degree = max(
         degree for shell in electron_shells for degree in shell["angular_momentum"]
     )
-    if max_degree > 1:
+    if max_degree > 2:
         from basis_set_exchange.lut import element_sym_from_Z
 
         sym = element_sym_from_Z(atomic_number).capitalize()
         raise NotImplementedError(
-            f"native_hf's overlap/kinetic/Coulomb integrals only implement s and p "
-            f"shells (degree <= 1); {sym} (Z={atomic_number}) needs a degree-{max_degree} "
-            f"shell (d-orbitals or higher) in {basis_name}. Not a silent approximation -- "
+            f"native_hf's overlap/kinetic/Coulomb integrals only implement s, p and d "
+            f"shells (degree <= 2); {sym} (Z={atomic_number}) needs a degree-{max_degree} "
+            f"shell (f-orbitals or higher) in {basis_name}. Not a silent approximation -- "
             f"this element genuinely isn't supported by this engine yet."
         )
 
@@ -106,8 +111,5 @@ def build_molecule_shells(atomic_numbers: list[int], geometry_bohr: np.ndarray, 
     return shells
 
 
-_DEGREE_TO_N_CARTESIAN = {0: 1, 1: 3}  # s: 1 component, p: 3 (x,y,z)
-
-
 def n_cartesian_functions(shells: list[ContractedShell]) -> int:
-    return sum(_DEGREE_TO_N_CARTESIAN[s.degree] for s in shells)
+    return sum(len(cartesian_powers(s.degree)) for s in shells)

--- a/dense_evolution/native_hf/cartesian.py
+++ b/dense_evolution/native_hf/cartesian.py
@@ -18,3 +18,40 @@ def cartesian_powers(degree: int) -> np.ndarray:
         [(lx, degree - lx - lz, lz) for lx in range(degree, -1, -1) for lz in range(degree - lx, -1, -1)],
         dtype=np.int32,
     )
+
+
+def _double_factorial_odd(n: int) -> float:
+    """(2n-1)!! for n >= 0, with the (2*0-1)!! = (-1)!! = 1 convention."""
+    result = 1.0
+    k = 2 * n - 1
+    while k > 1:
+        result *= k
+        k -= 2
+    return result
+
+
+def cartesian_normalization_ratios(degree: int) -> np.ndarray:
+    """Relative normalization of each Cartesian component of a shell of
+    the given degree, relative to the (degree,0,0) component -- 1.0 for
+    every component when degree<=1 (px, py, pz are equivalent by
+    symmetry), but genuinely different starting at degree=2 (e.g. dxy
+    needs a larger normalization constant than dxx, since <dxx|dxx> =
+    3*<dxy|dxy> for the same exponent).
+
+    Standard result for an unnormalized Cartesian Gaussian primitive
+    (x-Rx)^lx (y-Ry)^ly (z-Rz)^lz exp(-a|r-R|^2): its normalization
+    constant is proportional to 1/sqrt((2lx-1)!!(2ly-1)!!(2lz-1)!!), so
+    this ratio -- independent of the exponent, verified numerically
+    against overlap_3d's own self-overlap at several exponents -- is
+    sqrt((2*degree-1)!! / ((2lx-1)!!(2ly-1)!!(2lz-1)!!)).
+
+    Order matches cartesian_powers(degree) exactly, so callers can zip
+    or elementwise-multiply the two directly."""
+    powers = cartesian_powers(degree)
+    reference = _double_factorial_odd(degree)
+    return np.array(
+        [
+            np.sqrt(reference / (_double_factorial_odd(lx) * _double_factorial_odd(ly) * _double_factorial_odd(lz)))
+            for lx, ly, lz in powers
+        ]
+    )

--- a/tests/unit/test_native_hf_engine.py
+++ b/tests/unit/test_native_hf_engine.py
@@ -6,13 +6,18 @@ numerical test at all. Values below were verified correct on the current
 code before being frozen here (see prog.txt), not invented.
 
 Two different kinds of assertion live in this file, worth telling apart:
-4 are anchored against something external to this codebase --
+several are anchored against something external to this codebase --
 boys(n,x) vs scipy's own hyp1f1, the H2/STO-3G and H2O/STO-3G SCF
 energies against real literature reference values (see prog.txt's own
-evidence table), and the ERI tensor's 8-fold permutational symmetry
+evidence table), the ERI tensor's 8-fold permutational symmetry
 (a physical invariant true of any correct implementation, not a
-property of this one). These 4 verify correctness: a wrong answer here
-means a wrong answer, full stop.
+property of this one), and -- added for d-shell (angular momentum L=2)
+support -- the d-orbital overlap integral against independent scipy
+quadrature, the d-orbital kinetic integral against an exact sympy
+symbolic Laplacian, and the dxy/dxx normalization ratio against the
+closed-form sqrt(3) result every Cartesian-Gaussian implementation has
+to get right. These verify correctness: a wrong answer here means a
+wrong answer, full stop.
 
 The other 37 assertions (the frozen overlap-matrix entry, the frozen
 Si2 iteration-count bound, etc.) are auto-generated -- frozen from
@@ -25,6 +30,7 @@ information about a real bug -- it does not mean this test suite lied,
 it means this suite was never able to catch that particular error in
 the first place.
 """
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
@@ -33,11 +39,15 @@ pytest.importorskip("basis_set_exchange")
 from scipy.special import hyp1f1
 
 from dense_evolution.native_hf.boys import boys
-from dense_evolution.native_hf.basis import build_molecule_shells
+from dense_evolution.native_hf.basis import build_molecule_shells, n_cartesian_functions
 from dense_evolution.native_hf.assembly import (
     build_overlap_matrix, build_core_hamiltonian, build_repulsion_tensor,
 )
 from dense_evolution.native_hf.scf import run_scf
+from dense_evolution.native_hf.gaussians import GaussianShell3D
+from dense_evolution.native_hf.overlap import overlap_3d
+from dense_evolution.native_hf.kinetic import kinetic_3d
+from dense_evolution.native_hf.cartesian import cartesian_powers, cartesian_normalization_ratios
 
 _BOHR_PER_ANGSTROM = 1.8897259886
 
@@ -132,3 +142,112 @@ class TestRepulsionTensorSymmetry:
         assert V == pytest.approx(V.transpose(0, 1, 3, 2), abs=1e-12)
         assert V == pytest.approx(V.transpose(2, 3, 0, 1), abs=1e-12)
         assert V == pytest.approx(V.transpose(3, 2, 1, 0), abs=1e-12)
+
+
+# ── d-shell (angular momentum L=2) support (prog.txt) ────────────────────
+# Cartesian d shells have 6 components (dxx,dyy,dzz,dxy,dxz,dyz); unlike
+# s/p, they do NOT all share the same normalization constant (dxx and dxy
+# have different self-overlap). These tests check the new per-component
+# normalization ratio, and the underlying overlap/kinetic recursions
+# themselves, against sources external to native_hf entirely (scipy
+# quadrature, sympy exact symbolic integration) -- not just self-
+# consistency within the library. A full molecular SCF run on a real
+# d-containing basis (RHF/6-31G* on neon) is too slow to run on every
+# push (~10 minutes, see prog.txt) and lives instead as an experiment in
+# Dense-Evolution-Discovery.
+
+class TestDShellNormalization:
+
+    def test_cartesian_powers_count_matches_degree_formula(self):
+        for degree in range(4):
+            assert len(cartesian_powers(degree)) == (degree + 1) * (degree + 2) // 2
+
+    @pytest.mark.parametrize("exponent", [0.3, 0.9, 5.7])
+    def test_d_shell_normalization_ratio_matches_overlap_self_consistency(self, exponent):
+        g = GaussianShell3D(degree=2, exponent=jnp.asarray(exponent), center=jnp.zeros(3))
+        S = overlap_3d(g, g)
+        powers = cartesian_powers(2)
+        ref_self_overlap = float(S[tuple(powers[0]) + tuple(powers[0])])
+        measured = np.array([
+            np.sqrt(ref_self_overlap / float(S[lx, ly, lz, lx, ly, lz]))
+            for lx, ly, lz in powers
+        ])
+        assert measured == pytest.approx(cartesian_normalization_ratios(2), abs=1e-12)
+
+    def test_dxy_over_dxx_normalization_ratio_is_sqrt3(self):
+        # The one number every Cartesian-Gaussian implementation gets
+        # asked about: dxy needs a sqrt(3) larger normalization constant
+        # than dxx, because <dxx|dxx> = 3*<dxy|dxy> for the same exponent.
+        ratios = cartesian_normalization_ratios(2)
+        powers = cartesian_powers(2).tolist()
+        dxx_ratio = ratios[powers.index([2, 0, 0])]
+        dxy_ratio = ratios[powers.index([1, 1, 0])]
+        assert dxy_ratio / dxx_ratio == pytest.approx(np.sqrt(3.0), abs=1e-12)
+
+
+class TestDShellIntegralsAgainstExternalReferences:
+
+    def test_d_overlap_matches_independent_scipy_quadrature(self):
+        from scipy import integrate
+
+        a = 0.9
+        g = GaussianShell3D(degree=2, exponent=jnp.asarray(a), center=jnp.zeros(3))
+        S = overlap_3d(g, g)
+
+        Ix4, _ = integrate.quad(lambda x: x**4 * np.exp(-2 * a * x * x), -np.inf, np.inf)
+        Ix2, _ = integrate.quad(lambda x: x**2 * np.exp(-2 * a * x * x), -np.inf, np.inf)
+        I0, _ = integrate.quad(lambda x: np.exp(-2 * a * x * x), -np.inf, np.inf)
+
+        dxx_quad = Ix4 * I0 * I0
+        dxy_quad = Ix2 * Ix2 * I0
+
+        assert float(S[2, 0, 0, 2, 0, 0]) == pytest.approx(dxx_quad, rel=1e-10)
+        assert float(S[1, 1, 0, 1, 1, 0]) == pytest.approx(dxy_quad, rel=1e-10)
+
+    def test_d_kinetic_matches_independent_sympy_exact_integration(self):
+        sp = pytest.importorskip("sympy")
+
+        x, y, z, a_sym = sp.symbols("x y z a", positive=True, real=True)
+        gaussian = sp.exp(-a_sym * (x**2 + y**2 + z**2))
+        dxx_expr = x**2 * gaussian
+        dxy_expr = x * y * gaussian
+
+        def laplacian_expectation(f_expr):
+            lap = sp.diff(f_expr, x, 2) + sp.diff(f_expr, y, 2) + sp.diff(f_expr, z, 2)
+            val = sp.integrate(f_expr * lap, (x, -sp.oo, sp.oo))
+            val = sp.integrate(val, (y, -sp.oo, sp.oo))
+            return sp.integrate(val, (z, -sp.oo, sp.oo))
+
+        a_val = 0.9
+        dxx_exact = float(laplacian_expectation(dxx_expr).subs(a_sym, a_val))
+        dxy_exact = float(laplacian_expectation(dxy_expr).subs(a_sym, a_val))
+
+        g = GaussianShell3D(degree=2, exponent=jnp.asarray(a_val), center=jnp.zeros(3))
+        T = kinetic_3d(g, g)
+
+        assert float(T[2, 0, 0, 2, 0, 0]) == pytest.approx(dxx_exact, rel=1e-10)
+        assert float(T[1, 1, 0, 1, 1, 0]) == pytest.approx(dxy_exact, rel=1e-10)
+
+
+class TestDShellBasisLoading:
+
+    def test_631gstar_oxygen_yields_a_real_d_shell(self):
+        geometry_bohr = np.array([[0.0, 0.0, 0.0]])
+        shells = build_molecule_shells([8], geometry_bohr, "6-31g*")
+        degrees = sorted({s.degree for s in shells})
+        assert 2 in degrees
+        assert n_cartesian_functions(shells) == sum(len(cartesian_powers(s.degree)) for s in shells)
+
+    def test_core_hamiltonian_symmetric_with_a_real_d_shell(self):
+        # Fast (no ERI): overlap + core Hamiltonian only, on the smallest
+        # real d-containing basis available -- the full electron-repulsion
+        # tensor for a mixed s/p/d basis is a separate, slow check (see
+        # the Dense-Evolution-Discovery experiment referenced above).
+        geometry_bohr = np.array([[0.0, 0.0, 0.0]])
+        shells = build_molecule_shells([10], geometry_bohr, "6-31g*")
+        S = build_overlap_matrix(shells)
+        H_core = build_core_hamiltonian(shells, [10.0], geometry_bohr)
+
+        assert S == pytest.approx(S.T, abs=1e-9)
+        assert np.allclose(np.diag(S), 1.0, atol=1e-8)
+        assert H_core == pytest.approx(H_core.T, abs=1e-9)


### PR DESCRIPTION
`native_hf` raised `NotImplementedError` for any shell beyond s/p (degree>1). Investigated before writing any code: the Obara-Saika recursions in `overlap.py`/`kinetic.py`/`coulomb.py` were already general in angular momentum (verified by direct inspection -- no hardcoded degree anywhere), and `cartesian.py`'s `cartesian_powers` already enumerated a d shell's 6 Cartesian components correctly. The real gaps were narrower than the guard suggested:

1. `basis.py`'s `_DEGREE_TO_N_CARTESIAN = {0: 1, 1: 3}` was hardcoded to s/p; `n_cartesian_functions` now uses `len(cartesian_powers(degree))` generally.
2. Per-Cartesian-component normalization was missing. s and p shells have one normalization constant per shell (px/py/pz are equivalent by symmetry) -- d shells don't (dxx and dxy have different self-overlap). Verified: the ratio is exactly `sqrt(3)` via `overlap_3d`'s own self-overlap, independent of exponent (checked at 0.3/0.9/5.7), matching the standard closed-form `sqrt((2L-1)!!/((2lx-1)!!(2ly-1)!!(2lz-1)!!))` result. Applied at assembly time (`_pair_block`/`_quartet_block`, new `cartesian_normalization_ratios` helper) rather than folded into the shared per-primitive contraction coefficients, which are a genuine physical fact about the basis set shared across a shell's Cartesian components, not something to overload with a per-component correction.

Guard raised from `degree>1` to `degree>2` (f and higher still rejected, not silently wrong).

**New tests** verify the actual new capability against sources external to this codebase, not just self-consistency: the d-orbital overlap integral against independent scipy quadrature, the d-orbital kinetic integral against an exact sympy symbolic Laplacian, and the dxy/dxx normalization ratio against the closed-form sqrt(3) result. Plus a real 6-31G*-on-oxygen/neon basis-loading and core-Hamiltonian-symmetry check (fast -- no ERI).

**Deliberately not included**: a full molecular SCF run on a real d-containing basis -- too slow to run on every push (~10 minutes, see below). Ran RHF/6-31G* on neon locally and cross-checked against an independent PySCF run on Colab: **-128.4744065199038** (this implementation) vs PySCF's **-128.47440651990485** with `cart=True` (forcing PySCF's Cartesian d-function mode to match this implementation's only supported convention) -- agreement to ~1e-12 Hartree, machine precision. PySCF's *default* (spherical d functions) gave a ~5e-4 Hartree discrepancy first, which looked like a real subtle bug until the spherical/Cartesian convention mismatch was identified and resolved -- see the full writeup in [Dense-Evolution-Discovery#155](https://github.com/tatopenn-cell/Dense-Evolution-Discovery/pull/155).

Building the ERI tensor for this run took ~10 minutes on the machine this was verified on -- a real scaling cost of the existing per-shell-quartet JIT-caching architecture once 3 distinct angular momenta (s,p,d) mix instead of 2 (35 distinct JIT specializations needed for this specific system vs a handful for pure s/p). Not a regression from this change, and optimizing it is separate, not-yet-started work with its own before/after benchmark (same precedent as the earlier ERI-scaling work in this repo's history). That full run and its PySCF cross-check live as a documented experiment in Dense-Evolution-Discovery instead of adding ~10 minutes to every push here.

File scope: `dense_evolution/native_hf/{cartesian,basis,assembly}.py`, `tests/unit/test_native_hf_engine.py`. Full `test_native_hf_engine.py`: 50 passed (41 pre-existing + 9 new), no regressions.