### PR TITLE
Bump version to 8.1.74 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dense-evolution"
-version = "8.1.73"
+version = "8.1.74"
 description = "High-performance quantum simulation toolkit -- Statevector/MPS engines with JIT compilation, noise modeling, VQE, QEC, quantum chemistry, and agent-native tooling"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Covers everything merged since 8.1.73: #216 (MPS precision-adaptive `svd_cutoff`/`use_float32`), #217 (`_PAULI_MATRICES` complex64 fix + codecov/comment cleanup), #218 (native_hf d-shell support). Version bump only, per convention (+1 patch regardless of PR count).

**Verified before writing this**: 8.1.73 as published on PyPI (downloaded the real wheel, not just checked git history) already contains the P8 fix (`mps_pauli_expectation` normalization) -- confirmed both by reading the extracted wheel's source and by running it live (real truncation, 35 budget violations, `mps_pauli_expectation('I'*14)` returns exactly `1+0j`). Tag and published artifact agree; nothing to disclose there.

---

## Release notes for 8.1.74

**Behavior change in `MPSSimulator`: `svd_cutoff` is no longer fixed at `1e-12`.**

Affects only code that constructs `MPSSimulator` with `jax_enable_x64` **not** active, i.e. in complex64. Code running in complex128 (the default once anything else in the process has already enabled x64) sees no change at all.

For affected code: `svd_cutoff` now resolves automatically from the active dtype (~1e-6 in complex64, unchanged at ~1e-12 in complex128), instead of the old fixed `1e-12` used in both cases. In complex64, `1e-12` sat below that dtype's own numerical noise floor: singular values that were pure noise got counted as real Schmidt weight, inflating `chi` up to `max_bond` even when the real entanglement didn't need it. Measured example: same circuit, `chi` goes from 64 to 2.

**Practical effect**: the same unmodified scripts now produce a lower `chi` in complex64 -- less memory, faster execution, and numerically more correct results (noise is no longer counted as signal). But it's a silent behavior change: anyone with a saved state or a past comparison run in complex64 will see `chi` shift.

**Remedy**: pass `svd_cutoff=1e-12` explicitly to `MPSSimulator` to restore the previous behavior -- an explicitly passed value is never rescaled, regardless of the active dtype.

---

**New capability: `native_hf` supports d shells (angular momentum L=2).**

Bases containing d orbitals (e.g. 6-31G*) no longer raise `NotImplementedError`. Verified against external references: overlap/kinetic integrals against independent scipy quadrature and sympy symbolic integration; the full SCF energy (RHF/6-31G* on neon) against an independent PySCF calculation, agreeing to ~1e-12 Hartree.

**What doesn't change**: bases with only s and p shells (e.g. STO-3G, the majority of existing usage) are numerically unchanged -- the existing 50 tests pass unmodified.

**Real cost on mixed s/p/d bases**: building the ERI tensor for a basis mixing multiple angular momenta is currently expensive. Measured on CPU, no GPU: RHF/6-31G* on isolated neon (6 shells, one of them d), ERI tensor build **~623 seconds**. The cause is known (up to 35 distinct JIT specializations for this one system) and one fix attempt was tried and discarded after measurement (a real ~68% regression, not an improvement) -- this remains open, unresolved work.

**Where the wall still is**: f orbitals and beyond (angular momentum L>2) still raise an explicit `NotImplementedError` -- not a silent approximation.