### PR TITLE
Fix stale version bookkeeping (__version__, README Zenodo DOI, CITATION.cff)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,12 +12,12 @@ authors:
 repository-code: "https://github.com/tatopenn-cell/Dense-Evolution"
 url: "https://github.com/tatopenn-cell/Dense-Evolution"
 license: "BUSL-1.1"
-version: "8.1.68"
-doi: "10.5281/zenodo.22116621"
+version: "8.1.74"
+doi: "10.5281/zenodo.22669081"
 identifiers:
   - type: doi
     value: "10.5281/zenodo.21855643"
     description: "The concept DOI for all versions of this software."
   - type: doi
-    value: "10.5281/zenodo.22116621"
-    description: "The version-specific DOI for v8.1.68."
+    value: "10.5281/zenodo.22669081"
+    description: "The version-specific DOI for v8.1.74."

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ If Dense-Evolution is useful in academic work, please cite it via the metadata i
 Archived on [Zenodo](https://zenodo.org/):
 
 - **Concept DOI** (always resolves to the latest version): [10.5281/zenodo.21855643](https://doi.org/10.5281/zenodo.21855643)
-- **This release (v8.1.61)**: [10.5281/zenodo.22009005](https://doi.org/10.5281/zenodo.22009005)
+- **This release (v8.1.74)**: [10.5281/zenodo.22669081](https://doi.org/10.5281/zenodo.22669081)
 
 ---
 

--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -57,7 +57,7 @@ from .physics.qec import (pauli_commutes, compute_syndrome, erasure_aware_decode
                            blind_minimum_weight_decode, decode_with_erasure_fallback,
                            counts_in_intervals_dimension, nearest_coset_decode)
 
-__version__ = "8.1.68"
+__version__ = "8.1.74"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
`dense_evolution.__version__` was hardcoded at `8.1.68`, six releases behind `pyproject.toml`'s `8.1.74` -- no release step ever kept it in sync (last touched incidentally in an unrelated commit, not a version bump). Found while checking the actually-installed pip package against this checkout.

Also stale, same root cause (nothing in the release process updates them):
- README.md's "This release" Zenodo DOI still named v8.1.61.
- CITATION.cff's `version`/`doi` fields still named v8.1.68.

Verified against Zenodo's own API (`https://zenodo.org/api/records/21855643`) that `10.5281/zenodo.22669081` is the real, already-archived DOI for v8.1.74 (GitHub-Zenodo integration auto-archived it) before writing it down -- not fabricated.