### PR TITLE
native_hf: pad primitive count to collapse ERI JIT specializations

### DIFF
--- a/dense_evolution/native_hf/assembly.py
+++ b/dense_evolution/native_hf/assembly.py
@@ -140,11 +140,32 @@ def _build_two_index(shells: list[ContractedShell], primitive_fn, extra=()) -> n
     return M
 
 
-def _schwarz_bound(sa: ContractedShell, sb: ContractedShell) -> float:
+def _pad_primitives(exponents: jax.Array, coeffs: jax.Array, target_n: int) -> tuple:
+    """Pad a shell's primitives up to target_n by repeating its last exponent
+    with coefficient 0 -- contributes exactly zero to the primitive sum (not
+    an approximation), so every shell in a molecule can share one primitive
+    count and _quartet_block's JIT cache stops keying on it. Unlike padding
+    the angular-momentum degree (measured as a regression: it forces cheap,
+    many-primitive low-degree shells through the expensive high-degree
+    recursion), padding primitive count doesn't touch the recursion at all --
+    it only lengthens an already-cheap vmap axis (measured warm-cache cost:
+    0.0001-0.005s regardless of primitive count)."""
+    n = exponents.shape[0]
+    if n == target_n:
+        return exponents, coeffs
+    pad_n = target_n - n
+    exponents = jnp.concatenate([exponents, jnp.full((pad_n,), exponents[-1])])
+    coeffs = jnp.concatenate([coeffs, jnp.zeros(pad_n)])
+    return exponents, coeffs
+
+
+def _schwarz_bound(sa: ContractedShell, sb: ContractedShell, max_primitives: int) -> float:
+    ea, ca = _pad_primitives(sa.exponents, sa.coefficients, max_primitives)
+    eb, cb = _pad_primitives(sb.exponents, sb.coefficients, max_primitives)
     block = np.array(
         _quartet_block(
-            (sa.exponents, sb.exponents, sa.exponents, sb.exponents),
-            (sa.coefficients, sb.coefficients, sa.coefficients, sb.coefficients),
+            (ea, eb, ea, eb),
+            (ca, cb, ca, cb),
             (sa.center, sb.center, sa.center, sb.center),
             (sa.degree, sb.degree, sa.degree, sb.degree),
             electron_repulsion,
@@ -155,12 +176,12 @@ def _schwarz_bound(sa: ContractedShell, sb: ContractedShell) -> float:
     return float(np.sqrt(np.max(np.abs(diag))))
 
 
-def _shell_pair_schwarz_bounds(shells: list[ContractedShell]) -> dict:
+def _shell_pair_schwarz_bounds(shells: list[ContractedShell], max_primitives: int) -> dict:
     bounds = {}
     for i, sa in enumerate(shells):
         for j in range(i + 1):
             sb = shells[j]
-            q = _schwarz_bound(sa, sb)
+            q = _schwarz_bound(sa, sb, max_primitives)
             bounds[(i, j)] = q
             bounds[(j, i)] = q
     return bounds
@@ -170,7 +191,8 @@ def build_repulsion_tensor(shells: list[ContractedShell], screening_tol: float =
     n = n_cartesian_functions(shells)
     offsets = _shell_offsets(shells)
     V = np.zeros((n, n, n, n))
-    schwarz = _shell_pair_schwarz_bounds(shells)
+    max_primitives = max(s.exponents.shape[0] for s in shells)
+    schwarz = _shell_pair_schwarz_bounds(shells, max_primitives)
     for i, sa in enumerate(shells):
         for j in range(i + 1):
             sb = shells[j]
@@ -183,10 +205,14 @@ def build_repulsion_tensor(shells: list[ContractedShell], screening_tol: float =
                         continue
                     if schwarz[(i, j)] * schwarz[(k, l)] < screening_tol:
                         continue
+                    ea, ca = _pad_primitives(sa.exponents, sa.coefficients, max_primitives)
+                    eb, cb = _pad_primitives(sb.exponents, sb.coefficients, max_primitives)
+                    ec, cc = _pad_primitives(sc.exponents, sc.coefficients, max_primitives)
+                    ed, cd = _pad_primitives(sd.exponents, sd.coefficients, max_primitives)
                     block = np.array(
                         _quartet_block(
-                            (sa.exponents, sb.exponents, sc.exponents, sd.exponents),
-                            (sa.coefficients, sb.coefficients, sc.coefficients, sd.coefficients),
+                            (ea, eb, ec, ed),
+                            (ca, cb, cc, cd),
                             (sa.center, sb.center, sc.center, sd.center),
                             (sa.degree, sb.degree, sc.degree, sd.degree),
                             electron_repulsion,

--- a/tests/unit/test_native_hf_engine.py
+++ b/tests/unit/test_native_hf_engine.py
@@ -144,6 +144,69 @@ class TestRepulsionTensorSymmetry:
         assert V == pytest.approx(V.transpose(3, 2, 1, 0), abs=1e-12)
 
 
+# ── primitive-count padding (prog.txt) ────────────────────────────────────
+# _quartet_block's JIT cache keys on primitive count per shell, not just
+# angular-momentum degree (a profiled ~623s ERI build on a mixed s/p/d
+# basis turned out to be 231 distinct JIT specializations, not the 35
+# degree-tuples alone). _pad_primitives collapses that back down by
+# padding every shell to a shared primitive count via a repeated exponent
+# with coefficient 0 -- these tests check that padding is exact (not an
+# approximation) directly, without needing the expensive full ERI build
+# that exercises it in practice.
+
+class TestPrimitiveCountPadding:
+
+    def test_padding_is_a_noop_when_already_at_target(self):
+        from dense_evolution.native_hf.assembly import _pad_primitives
+        exponents = jnp.array([3.0, 1.0, 0.3])
+        coeffs = jnp.array([0.1, 0.2, 0.3])
+        padded_e, padded_c = _pad_primitives(exponents, coeffs, 3)
+        assert np.array_equal(padded_e, exponents)
+        assert np.array_equal(padded_c, coeffs)
+
+    def test_padding_adds_zero_coefficient_dummies(self):
+        from dense_evolution.native_hf.assembly import _pad_primitives
+        exponents = jnp.array([3.0, 1.0])
+        coeffs = jnp.array([0.1, 0.2])
+        padded_e, padded_c = _pad_primitives(exponents, coeffs, 5)
+        assert padded_e.shape == (5,)
+        assert padded_c.shape == (5,)
+        assert np.array_equal(padded_c[2:], np.zeros(3))
+        assert np.all(np.isfinite(padded_e))
+
+    def test_padded_repulsion_tensor_matches_unpadded_reference(self):
+        # H2/STO-3G has uniform primitive counts across its shells, so
+        # build_repulsion_tensor's own padding (target_n == every shell's
+        # real count already) never exercises the padding branch above --
+        # this calls _pad_primitives with a target deliberately larger
+        # than the real count, then verifies the padded quartet block is
+        # numerically identical to the unpadded one.
+        from dense_evolution.native_hf.assembly import _pad_primitives, _quartet_block
+        from dense_evolution.native_hf.coulomb import electron_repulsion
+
+        geometry_bohr = _linear_two_atom_geometry_bohr(0.735)
+        shells = build_molecule_shells([1, 1], geometry_bohr, "sto-3g")
+        sa = shells[0]
+
+        unpadded = np.array(_quartet_block(
+            (sa.exponents, sa.exponents, sa.exponents, sa.exponents),
+            (sa.coefficients, sa.coefficients, sa.coefficients, sa.coefficients),
+            (sa.center, sa.center, sa.center, sa.center),
+            (sa.degree, sa.degree, sa.degree, sa.degree),
+            electron_repulsion,
+        ))
+
+        target_n = sa.exponents.shape[0] + 2
+        ea, ca = _pad_primitives(sa.exponents, sa.coefficients, target_n)
+        padded = np.array(_quartet_block(
+            (ea, ea, ea, ea), (ca, ca, ca, ca),
+            (sa.center, sa.center, sa.center, sa.center),
+            (sa.degree, sa.degree, sa.degree, sa.degree),
+            electron_repulsion,
+        ))
+        assert padded == pytest.approx(unpadded, abs=1e-12)
+
+
 # ── d-shell (angular momentum L=2) support (prog.txt) ────────────────────
 # Cartesian d shells have 6 components (dxx,dyy,dzz,dxy,dxz,dyz); unlike
 # s/p, they do NOT all share the same normalization constant (dxx and dxy


### PR DESCRIPTION
Follow-up to the d-shell support (#218) and its documented ~623s ERI cost for mixed s/p/d bases. Before this, two independent batching attempts (P3 step 2, and padding the angular-momentum degree) had both measured as regressions -- this time a real profile was taken first.

**Profile** (`_quartet_block` instrumented during a real `build_repulsion_tensor` run on Ne/6-31G*): 231 unique JIT specializations, not 35 -- JAX's jit cache keys on primitive count per shell too, not just degree (shells of the same degree can have 1, 3, or 6 primitives in 6-31G*). Warm-cache cost per call: median 0.4ms, max 5ms. **Compile overhead was ~100% of the ~360s wall time, warm execution ~0%.**

**Fix**: pad every shell's primitive count (not degree) up to the molecule-wide max, via a repeated exponent with coefficient 0 -- exact, not approximate, since it contributes exactly zero to the sum. This collapses the JIT cache key back to the 35 degree-tuples without touching the expensive degree-dependent recursion at all, avoiding the earlier degree-padding regression's exact failure mode.

**Measured** on Ne/6-31G*: 158.3s vs 361.4s profiling baseline without x64 (-56%); 532.7s vs 623s historical baseline with x64 (-14.5%, the precision mode that matters for real use). SCF still converges to the PySCF anchor at 1.05e-12 Hartree, 8-fold symmetry intact, all 53 native_hf unit tests pass with x64 enabled. The gap between the two precision regimes' relative gains is unexplained (candidates: XLA float64 compiles scaling differently, or measurement jitter on this machine) -- noted honestly in prog.txt rather than re-run repeatedly, since these benchmarks are heavy enough to have caused real memory pressure on the dev machine.

Two further avenues were tried and abandoned this session (see prog.txt for the full writeup): a persistent JAX compilation cache (caused a system memory spike on cache read, not a measured win) and multiprocessing-based parallel compilation (per-worker JAX import overhead of ~12s dominated on a cheap test case; likely explanation is XLA's own per-compile CPU threading already contending with process-level parallelism).