### PR TITLE
Bump version to 8.1.75 (corrects 8.1.74's wrong runtime __version__)

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -57,7 +57,7 @@ from .physics.qec import (pauli_commutes, compute_syndrome, erasure_aware_decode
                            blind_minimum_weight_decode, decode_with_erasure_fallback,
                            counts_in_intervals_dimension, nearest_coset_decode)
 
-__version__ = "8.1.74"
+__version__ = "8.1.75"
 
 __all__ = [
     "__version__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dense-evolution"
-version = "8.1.74"
+version = "8.1.75"
 description = "High-performance quantum simulation toolkit -- Statevector/MPS engines with JIT compilation, noise modeling, VQE, QEC, quantum chemistry, and agent-native tooling"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -5,6 +5,9 @@ prog.txt). Nothing here tests the individual functions themselves (each
 has its own dedicated test file); this only guards the __all__ list
 itself against typos/staleness as the package evolves.
 """
+import pathlib
+import re
+
 import dense_evolution as de
 
 
@@ -27,3 +30,18 @@ def test_star_import_only_binds_all_names():
     exec("from dense_evolution import *", ns)
     bound = {k for k in ns if k != "__builtins__"}
     assert bound == set(de.__all__)
+
+
+def test_version_matches_pyproject():
+    """The 8.1.74 wheel published to PyPI had this exact drift: pyproject.toml
+    was bumped, __init__.py's hardcoded __version__ wasn't, in the window
+    between those two commits -- caught only by downloading the published
+    wheel and checking it by hand. This regression test catches the same
+    drift at test time, before anything ships."""
+    pyproject = pathlib.Path(__file__).resolve().parents[2] / "pyproject.toml"
+    match = re.search(r'^version = "([^"]+)"', pyproject.read_text(), re.MULTILINE)
+    assert match, "couldn't find a version line in pyproject.toml"
+    assert de.__version__ == match.group(1), (
+        f"dense_evolution.__version__ ({de.__version__!r}) doesn't match "
+        f"pyproject.toml's version ({match.group(1)!r})"
+    )


### PR DESCRIPTION
8.1.74's published PyPI wheel has correct code and correct behavior (verified: `use_float32`, the adaptive cutoff, d-shell support, the P8 Pauli-expectation normalization fix, all present and working as documented), but a wrong `__version__`: the wheel was built between the version-bump commit and the later commit that fixed `__init__.py`'s hardcoded `__version__` (which was still `"8.1.68"`, six releases stale, at build time). Confirmed by downloading the actual published wheel from PyPI and checking its METADATA (`Version: 8.1.74`) against its runtime `dense_evolution.__version__` (`"8.1.68"`) directly, not by inspecting git history.

PyPI never allows overwriting an already-published version, so the fix is a new release: 8.1.75, no behavior change, `__version__` corrected.

Also adds `test_version_matches_pyproject` in `test_public_api.py`, asserting `dense_evolution.__version__` matches `pyproject.toml`'s version -- so this exact drift fails CI instead of shipping silently a second time. This is the third time a published artifact has disagreed with the repo (stale site-packages, tracked egg-info, now this) -- worth a standing check rather than a manual one to remember.