### PR TITLE
native_hf: optional PySCF/libcint bridge for the ERI tensor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
           pip install qiskit-ibm-runtime # tests/integration/test_interop_calibration_noise.py -- FakeSherbrooke, real historical IBM Eagle-127 calibration data, offline/no account needed
           pip install stim # tests/integration/test_interop_stim_bridge.py -- to_stim() correctness tests were being silently skipped in CI without this (pytest.importorskip), leaving the real logic uncovered
           pip install pymatching # tests/unit/test_qec.py::TestPymatchingDecode -- pymatching_decode's real MWPM logic, not just the "missing package" ImportError path, needs the actual package installed here (same reasoning as stim above)
+          pip install pyscf # tests/unit/test_libcint_bridge.py -- real libcint-backed ERI correctness, not just the ImportError path (same reasoning as stim/pymatching above); no Windows wheel, but this matrix is ubuntu/macos only
           pip install streamlit>=1.30.0 ipywidgets>=8.0.0
           pip install fastapi uvicorn pydantic httpx2 # composer extra -- local_site/app/server.py + tests/integration/test_local_site_server.py (httpx2: starlette.testclient's current required client)
           pip install mcp httpx # mcp extra -- mcp_server/server.py + tests/integration/test_mcp_server.py (real httpx, not the httpx2 alias above -- the MCP adapter imports httpx directly)

--- a/dense_evolution/native_hf/cartesian.py
+++ b/dense_evolution/native_hf/cartesian.py
@@ -12,8 +12,15 @@ import numpy as np
 
 def cartesian_powers(degree: int) -> np.ndarray:
     """Returns an (M, 3) array of (lx,ly,lz) triples with lx+ly+lz == degree,
-    in a fixed canonical order (x-major, matching common conventions:
-    for p, that's px, py, pz)."""
+    in a fixed canonical order determined by the generator below -- not the
+    common lexicographic convention some other codes use. For p (degree=1)
+    that's px, pz, py, not px, py, pz (confirmed by calling this function
+    directly, not assumed from the shape of the loop); for d (degree=2),
+    xx, xz, xy, zz, yz, yy, not the lexicographic xx, xy, xz, yy, yz, zz.
+    Internally consistent (cartesian_normalization_ratios and every caller
+    in assembly.py use this exact order), but this matters for anything
+    that needs to match a DIFFERENT code's AO ordering (e.g. libcint's) --
+    see native_hf/libcint_bridge.py's per-degree permutation."""
     return np.array(
         [(lx, degree - lx - lz, lz) for lx in range(degree, -1, -1) for lz in range(degree - lx, -1, -1)],
         dtype=np.int32,

--- a/dense_evolution/native_hf/libcint_bridge.py
+++ b/dense_evolution/native_hf/libcint_bridge.py
@@ -1,0 +1,128 @@
+"""Optional PySCF/libcint bridge for native_hf's electron-repulsion tensor.
+
+native_hf's own build_repulsion_tensor (assembly.py) computes the ERI
+tensor via JAX-jitted Obara-Saika recursions -- correct, differentiable,
+but pays a real JIT-compilation tax on mixed-angular-momentum bases (see
+prog.txt: ~532s on Ne/6-31G* even after the primitive-count-padding fix).
+libcint (the C library PySCF itself uses) computes the identical tensor
+in ~0.006s -- no JIT, no per-basis compile cost, ever, since its kernels
+are C templates compiled once when PySCF itself was built.
+
+This is NOT a replacement for native_hf's own engine: nothing in this
+codebase differentiates through native_hf's raw integrals today (checked
+directly, not assumed), so the autodiff PySCF/libcint can't offer here
+costs nothing in practice yet -- but PySCF is a heavy optional dependency
+with no Windows wheel (needs a C toolchain to build from source there),
+and depending on it contradicts this project's own "no C++ hand-written"
+positioning if made anything but opt-in. Install with the `libcint`
+extra; everything here raises ImportError with that instruction if PySCF
+isn't present, never silently falls back.
+
+Cartesian-component convention mismatch: libcint's own per-shell AO order
+and normalization are NOT the same as native_hf's own `cartesian_powers`
+convention (see cartesian.py's own docstring) -- confirmed empirically via
+`mol.ao_labels()` and `mol.intor('int1e_ovlp')` on Ne/6-31G*, not assumed
+from either codebase's documentation:
+  - p (degree 1): libcint orders px,py,pz; native_hf orders px,pz,py.
+    Every p component has the same self-overlap in both conventions (px,
+    py, pz are equivalent by symmetry), so this needs reordering only.
+  - d (degree 2): libcint orders xx,xy,xz,yy,yz,zz; native_hf orders
+    xx,xz,xy,zz,yz,yy. libcint's raw per-component overlap is NOT
+    normalized to 1 the way native_hf's is (xx/yy/zz self-overlap
+    2.51327412, xy/xz/yz self-overlap 0.83775804 on Ne/6-31G* -- ratio
+    exactly 3, consistent with the same sqrt(3) factor
+    cartesian_normalization_ratios already accounts for on native_hf's
+    own side), so this needs both reordering AND a per-AO rescale.
+
+Rather than hardcoding libcint's normalization as a formula, the rescale
+is computed from libcint's own overlap diagonal at call time (1/sqrt of
+it) -- exact for whatever exponent/element/degree is actually in play,
+not an assumption about libcint's internal convention that could break on
+a different libcint version or basis set. Degrees above 2 raise
+NotImplementedError naming the real limitation (native_hf itself caps at
+degree 2 today, so this never binds in practice, but the mapping below is
+only verified through d, not d and beyond).
+"""
+import numpy as np
+
+from dense_evolution.native_hf.basis import build_molecule_shells, n_cartesian_functions
+from dense_evolution.native_hf.cartesian import cartesian_powers
+
+_LIBCINT_CARTESIAN_ORDER = {
+    0: [(0, 0, 0)],
+    1: [(1, 0, 0), (0, 1, 0), (0, 0, 1)],
+    2: [(2, 0, 0), (1, 1, 0), (1, 0, 1), (0, 2, 0), (0, 1, 1), (0, 0, 2)],
+}
+
+
+def _permutation_libcint_to_native_hf(degree: int) -> np.ndarray:
+    """perm such that native_hf_ordered[i] == libcint_ordered[perm[i]]."""
+    if degree not in _LIBCINT_CARTESIAN_ORDER:
+        raise NotImplementedError(
+            f"libcint_bridge only has a verified AO-order mapping for degree <= 2 "
+            f"(checked against mol.ao_labels()); degree={degree} would need the same "
+            f"empirical check first, not an assumed extension of the pattern."
+        )
+    native_order = [tuple(int(x) for x in p) for p in cartesian_powers(degree)]
+    libcint_order = _LIBCINT_CARTESIAN_ORDER[degree]
+    return np.array([libcint_order.index(p) for p in native_order])
+
+
+def _import_pyscf():
+    try:
+        from pyscf import gto
+    except ImportError as exc:
+        raise ImportError(
+            "native_hf.libcint_bridge requires PySCF, an optional dependency "
+            "(pip install dense-evolution[libcint]); it is not installed. "
+            "PySCF has no Windows wheel -- installing it there requires a C "
+            "toolchain to build from source."
+        ) from exc
+    return gto
+
+
+def build_repulsion_tensor_libcint(atomic_numbers: list, geometry_bohr: np.ndarray, basis_name: str) -> np.ndarray:
+    """Same contract as assembly.build_repulsion_tensor, but computed via
+    PySCF/libcint instead of native_hf's own JAX recursions -- takes
+    (atomic_numbers, geometry_bohr, basis_name) rather than a shells list
+    since PySCF needs to build its own `Mole` from the same spec, not
+    native_hf's ContractedShell objects.
+
+    geometry_bohr: shape (n_atoms, 3), atomic units, same convention as
+    build_molecule_shells."""
+    gto = _import_pyscf()
+    shells = build_molecule_shells(atomic_numbers, geometry_bohr, basis_name)
+    n = n_cartesian_functions(shells)
+
+    atom_spec = [
+        (int(z), (float(r[0]), float(r[1]), float(r[2])))
+        for z, r in zip(atomic_numbers, geometry_bohr)
+    ]
+    mol = gto.M(atom=atom_spec, basis=basis_name, unit="Bohr", cart=True)
+    if mol.nao != n:
+        raise ValueError(
+            f"AO count mismatch between native_hf ({n}) and PySCF ({mol.nao}) "
+            f"for basis {basis_name!r} -- the two engines disagree on this basis "
+            f"set's shell composition, not just component ordering."
+        )
+
+    overlap_diag = np.diag(mol.intor("int1e_ovlp"))
+    rescale = 1.0 / np.sqrt(overlap_diag)
+
+    V = np.asarray(mol.intor("int2e", aosym="s1")).reshape(n, n, n, n)
+    V = (
+        V
+        * rescale[:, None, None, None]
+        * rescale[None, :, None, None]
+        * rescale[None, None, :, None]
+        * rescale[None, None, None, :]
+    )
+
+    perm = np.empty(n, dtype=np.int64)
+    offset = 0
+    for shell in shells:
+        block_size = len(cartesian_powers(shell.degree))
+        perm[offset : offset + block_size] = offset + _permutation_libcint_to_native_hf(shell.degree)
+        offset += block_size
+
+    return V[perm][:, perm][:, :, perm][:, :, :, perm]

--- a/dense_evolution/native_hf/libcint_bridge.py
+++ b/dense_evolution/native_hf/libcint_bridge.py
@@ -124,7 +124,7 @@ def _match_pyscf_shell_ao_starts(mol, shells: list) -> list:
 def _import_pyscf():
     try:
         from pyscf import gto
-    except ImportError as exc:
+    except ImportError as exc:  # pragma: no cover -- only reachable without pyscf installed, which CI here always has
         raise ImportError(
             "native_hf.libcint_bridge requires PySCF, an optional dependency "
             "(pip install dense-evolution[libcint]); it is not installed. "

--- a/dense_evolution/native_hf/libcint_bridge.py
+++ b/dense_evolution/native_hf/libcint_bridge.py
@@ -68,6 +68,59 @@ def _permutation_libcint_to_native_hf(degree: int) -> np.ndarray:
     return np.array([libcint_order.index(p) for p in native_order])
 
 
+def _match_pyscf_shell_ao_starts(mol, shells: list) -> list:
+    """For each native_hf shell (in native_hf's own list order), find the
+    matching PySCF basis shell and return its AO start offset in PySCF's
+    own ordering.
+
+    Confirmed empirically on Ne/6-31G* that the two engines do NOT list
+    shells in the same order: native_hf keeps the basis-definition's own
+    file order (s,s,p,s,p,d -- interleaved), while libcint groups all
+    shells of a given atom by ascending angular-momentum degree
+    (s,s,s,p,p,d). Matching by identity (atom, degree, exponents) instead
+    of assuming the two lists line up positionally is correct regardless
+    of which grouping convention either engine happens to use, and isn't
+    an assumption about libcint's grouping rule generalizing to other
+    elements/bases."""
+    ao_loc = mol.ao_loc_nr()
+    candidates = [
+        {
+            "atom": mol.bas_atom(ib),
+            "degree": mol.bas_angular(ib),
+            "exponents": np.sort(np.asarray(mol.bas_exp(ib)))[::-1],
+            "ao_start": int(ao_loc[ib]),
+            "used": False,
+        }
+        for ib in range(mol.nbas)
+    ]
+
+    starts = []
+    for shell in shells:
+        shell_exponents = np.sort(np.asarray(shell.exponents))[::-1]
+        match = next(
+            (
+                c
+                for c in candidates
+                if not c["used"]
+                and c["atom"] == shell.atom_index
+                and c["degree"] == shell.degree
+                and c["exponents"].shape[0] == shell_exponents.shape[0]
+                and np.allclose(c["exponents"], shell_exponents, rtol=1e-6)
+            ),
+            None,
+        )
+        if match is None:
+            raise ValueError(
+                f"could not match native_hf shell (atom={shell.atom_index}, "
+                f"degree={shell.degree}, exponents={shell.exponents}) to any "
+                f"PySCF basis shell -- the two engines may disagree on this "
+                f"basis set's actual shell composition, not just its ordering."
+            )
+        match["used"] = True
+        starts.append(match["ao_start"])
+    return starts
+
+
 def _import_pyscf():
     try:
         from pyscf import gto
@@ -118,11 +171,12 @@ def build_repulsion_tensor_libcint(atomic_numbers: list, geometry_bohr: np.ndarr
         * rescale[None, None, None, :]
     )
 
+    ao_starts = _match_pyscf_shell_ao_starts(mol, shells)
     perm = np.empty(n, dtype=np.int64)
     offset = 0
-    for shell in shells:
+    for shell, pyscf_start in zip(shells, ao_starts):
         block_size = len(cartesian_powers(shell.degree))
-        perm[offset : offset + block_size] = offset + _permutation_libcint_to_native_hf(shell.degree)
+        perm[offset : offset + block_size] = pyscf_start + _permutation_libcint_to_native_hf(shell.degree)
         offset += block_size
 
     return V[perm][:, perm][:, :, perm][:, :, :, perm]

--- a/docs/api/native_hf.md
+++ b/docs/api/native_hf.md
@@ -61,6 +61,41 @@ determinant approximation misses entirely. At only 4 qubits, exact diagonalizati
 easy; that gap is exactly what a real VQE ansatz beyond a bare Hartree-Fock reference
 state is trying to close for larger, classically-intractable molecules.
 
+## Step 3. Large mixed-basis molecules: the optional libcint bridge
+
+```python
+import numpy as np
+from dense_evolution.native_hf.basis import build_molecule_shells
+from dense_evolution.native_hf.assembly import build_overlap_matrix, build_core_hamiltonian
+from dense_evolution.native_hf.libcint_bridge import build_repulsion_tensor_libcint
+from dense_evolution.native_hf.scf import run_scf
+
+geometry = np.array([[0.0, 0.0, 0.0]])
+shells = build_molecule_shells([10], geometry, "6-31g*")
+S = build_overlap_matrix(shells)
+H_core = build_core_hamiltonian(shells, [10.0], geometry)
+V = build_repulsion_tensor_libcint([10], geometry, "6-31g*")
+
+result = run_scf(S, H_core, V, 10, [10.0], geometry)
+result.converged, result.total_energy
+```
+
+```
+(True, -128.4744065199...)
+```
+
+Step 1's molecule only needed s functions, so `build_repulsion_tensor` (the
+default, pure-JAX path) was already fast. A basis mixing s, p, and d shells
+-- like `6-31g*` on neon here -- costs much more with the default path: the
+underlying JIT compiles one program per distinct shell-quartet shape it
+meets, and a mixed basis needs dozens of them. `build_repulsion_tensor_libcint`
+computes the identical tensor through [PySCF](https://pyscf.org/)'s own
+`libcint` instead -- a mature C library with no per-basis compile cost at
+all -- and is a drop-in replacement everywhere `build_repulsion_tensor`'s
+output was used (`S` and `H_core` above still come from native_hf itself).
+Requires the `libcint` extra (`pip install dense-evolution[libcint]`); no
+Windows wheel exists for PySCF, so that extra needs a C toolchain there.
+
 ---
 
 ## Details
@@ -89,6 +124,19 @@ depend on how the SCF loop converges), but the end-to-end Si2 number should be t
 as not yet re-verified against this independent reference. Algorithm background also
 drawn from PennyLane's own white paper (Delgado et al., "Differentiable quantum
 computational chemistry with PennyLane", [arXiv:2111.09967](https://arxiv.org/abs/2111.09967)).
+
+**The libcint bridge's AO-convention mismatch**: native_hf and PySCF/libcint agree on
+the physics but not on bookkeeping -- confirmed empirically (`mol.ao_labels()`,
+`mol.intor('int1e_ovlp')`), not assumed from either codebase's docs. Three separate
+mismatches, all handled by `libcint_bridge.py`: (1) shell order -- native_hf keeps the
+basis file's own order (s,p,s,p,d, interleaved on Ne/6-31G*), libcint groups all shells
+of an atom by ascending degree (s,s,s,p,p,d) -- matched by identity (atom, degree,
+exponents), not by assuming either list's order; (2) Cartesian component order --
+native_hf's own `cartesian_powers` uses px,pz,py and xx,xz,xy,zz,yz,yy, libcint uses the
+more common px,py,pz and xx,xy,xz,yy,yz,zz; (3) normalization -- libcint's raw d
+components are not unit-self-overlap the way native_hf's are (xx/yy/zz vs. xy/xz/yz
+differ by exactly a factor of 3 on Ne/6-31G*), corrected via a rescale computed from
+libcint's own overlap diagonal at call time, not a hardcoded constant.
 
 **SCF convergence (`run_scf`)**: DIIS-accelerated (Pulay 1980/1982) by default, not
 plain linear damping -- see [the module's own docstring](https://github.com/tatopenn-cell/Dense-Evolution/blob/main/dense_evolution/native_hf/scf.py)
@@ -119,3 +167,5 @@ optimized against Hamiltonians built this way.
 ::: dense_evolution.native_hf.scf
 
 ::: dense_evolution.native_hf.basis
+
+::: dense_evolution.native_hf.libcint_bridge

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,15 @@ mcp = [
     # deliberately doesn't pull in fastapi/uvicorn/pennylane the way the
     # composer extra does.
 ]
+libcint = [
+    "pyscf>=2.0.0",
+    # native_hf.libcint_bridge -- an OPTIONAL, faster alternative ERI
+    # tensor for mixed-angular-momentum bases (real speed measured:
+    # ~0.04s vs 158-532s for native_hf's own JAX path on Ne/6-31G*, see
+    # prog.txt), not a replacement for native_hf's own engine. No Windows
+    # wheel on PyPI for pyscf -- installing this extra there needs a C
+    # toolchain to build pyscf from source.
+]
 full = [
     "cupy-cuda12x>=12.0.0",
     "streamlit>=1.30.0",

--- a/tests/unit/test_libcint_bridge.py
+++ b/tests/unit/test_libcint_bridge.py
@@ -3,29 +3,93 @@ Correctness tests for native_hf.libcint_bridge, the optional PySCF/libcint
 ERI tensor bridge (see its own module docstring, and prog.txt, for why it
 exists: ~0.04s vs 158-532s for native_hf's own JAX path on Ne/6-31G*).
 
-Both cases here were first verified on Google Colab (this sandbox can't
-install PySCF locally), then reproduced here so a real pyscf install in
-CI keeps covering the actual bridge logic, not just the ImportError path
--- same reasoning as this repo's stim/pymatching tests.
+The end-to-end energy tests were first verified on Google Colab (this
+sandbox can't install PySCF locally), then reproduced here so a real
+pyscf install in CI keeps covering the actual bridge logic, not just the
+ImportError path -- same reasoning as this repo's stim/pymatching tests.
+`pytest.importorskip` is per-test, not module-level, so the pure-Python
+shell-matching/permutation tests below still run without pyscf installed.
 """
 import numpy as np
 import pytest
 
-pytest.importorskip("pyscf")
-
-import jax
-jax.config.update("jax_enable_x64", True)
-
-from dense_evolution.native_hf.basis import build_molecule_shells
-from dense_evolution.native_hf.assembly import build_overlap_matrix, build_core_hamiltonian, build_repulsion_tensor
-from dense_evolution.native_hf.libcint_bridge import build_repulsion_tensor_libcint
-from dense_evolution.native_hf.scf import run_scf
+from dense_evolution.native_hf.cartesian import cartesian_powers
+from dense_evolution.native_hf.libcint_bridge import (
+    _match_pyscf_shell_ao_starts,
+    _permutation_libcint_to_native_hf,
+)
 
 _BOHR_PER_ANGSTROM = 1.8897259886
 NE_631GSTAR_PYSCF_RHF_ENERGY = -128.47440651990485
 
 
+class _FakeShell:
+    def __init__(self, atom_index, degree, exponents):
+        self.atom_index = atom_index
+        self.degree = degree
+        self.exponents = np.asarray(exponents)
+
+
+class _FakeMol:
+    """Duck-typed stand-in for a PySCF Mole -- only the four accessors
+    _match_pyscf_shell_ao_starts actually calls, so these error-path tests
+    don't need PySCF installed at all."""
+
+    def __init__(self, bas):
+        self._bas = bas  # list of (atom, degree, exponents)
+        sizes = [len(cartesian_powers(d)) for _, d, _ in bas]
+        self._ao_loc = np.concatenate([[0], np.cumsum(sizes)])
+
+    @property
+    def nbas(self):
+        return len(self._bas)
+
+    def bas_atom(self, ib):
+        return self._bas[ib][0]
+
+    def bas_angular(self, ib):
+        return self._bas[ib][1]
+
+    def bas_exp(self, ib):
+        return self._bas[ib][2]
+
+    def ao_loc_nr(self):
+        return self._ao_loc
+
+
+def test_permutation_unimplemented_degree_raises():
+    with pytest.raises(NotImplementedError):
+        _permutation_libcint_to_native_hf(3)
+
+
+def test_shell_matching_raises_on_real_disagreement():
+    mol = _FakeMol([(0, 0, np.array([1.0, 0.5]))])
+    shells = [_FakeShell(atom_index=0, degree=1, exponents=[1.0, 0.5])]
+    with pytest.raises(ValueError):
+        _match_pyscf_shell_ao_starts(mol, shells)
+
+
+def test_shell_matching_finds_reordered_shells():
+    # Same pattern actually seen on Ne/6-31G*: native_hf keeps s,p,s
+    # order, the fake "libcint" mol groups them s,s,p.
+    mol = _FakeMol([(0, 0, np.array([6.0])), (0, 0, np.array([1.0])), (0, 1, np.array([1.0]))])
+    shells = [
+        _FakeShell(atom_index=0, degree=0, exponents=[6.0]),
+        _FakeShell(atom_index=0, degree=1, exponents=[1.0]),
+        _FakeShell(atom_index=0, degree=0, exponents=[1.0]),
+    ]
+    starts = _match_pyscf_shell_ao_starts(mol, shells)
+    assert starts == [0, 2, 1]
+
+
 def test_h2_sto3g_bridge_matches_native_hf_eri():
+    pytest.importorskip("pyscf")
+    import jax
+    jax.config.update("jax_enable_x64", True)
+    from dense_evolution.native_hf.basis import build_molecule_shells
+    from dense_evolution.native_hf.assembly import build_repulsion_tensor
+    from dense_evolution.native_hf.libcint_bridge import build_repulsion_tensor_libcint
+
     geometry_bohr = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.735]]) * _BOHR_PER_ANGSTROM
     shells = build_molecule_shells([1, 1], geometry_bohr, "sto-3g")
 
@@ -41,6 +105,14 @@ def test_ne_631gstar_bridge_matches_pyscf_anchor():
     # libcint groups by ascending degree) and per-component d normalization
     # -- exercises the shell-identity matching and rescale in
     # libcint_bridge.py, not just a trivial pass-through.
+    pytest.importorskip("pyscf")
+    import jax
+    jax.config.update("jax_enable_x64", True)
+    from dense_evolution.native_hf.basis import build_molecule_shells
+    from dense_evolution.native_hf.assembly import build_overlap_matrix, build_core_hamiltonian
+    from dense_evolution.native_hf.libcint_bridge import build_repulsion_tensor_libcint
+    from dense_evolution.native_hf.scf import run_scf
+
     geometry_bohr = np.array([[0.0, 0.0, 0.0]])
     shells = build_molecule_shells([10], geometry_bohr, "6-31g*")
 

--- a/tests/unit/test_libcint_bridge.py
+++ b/tests/unit/test_libcint_bridge.py
@@ -1,0 +1,57 @@
+"""
+Correctness tests for native_hf.libcint_bridge, the optional PySCF/libcint
+ERI tensor bridge (see its own module docstring, and prog.txt, for why it
+exists: ~0.04s vs 158-532s for native_hf's own JAX path on Ne/6-31G*).
+
+Both cases here were first verified on Google Colab (this sandbox can't
+install PySCF locally), then reproduced here so a real pyscf install in
+CI keeps covering the actual bridge logic, not just the ImportError path
+-- same reasoning as this repo's stim/pymatching tests.
+"""
+import numpy as np
+import pytest
+
+pytest.importorskip("pyscf")
+
+import jax
+jax.config.update("jax_enable_x64", True)
+
+from dense_evolution.native_hf.basis import build_molecule_shells
+from dense_evolution.native_hf.assembly import build_overlap_matrix, build_core_hamiltonian, build_repulsion_tensor
+from dense_evolution.native_hf.libcint_bridge import build_repulsion_tensor_libcint
+from dense_evolution.native_hf.scf import run_scf
+
+_BOHR_PER_ANGSTROM = 1.8897259886
+NE_631GSTAR_PYSCF_RHF_ENERGY = -128.47440651990485
+
+
+def test_h2_sto3g_bridge_matches_native_hf_eri():
+    geometry_bohr = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.735]]) * _BOHR_PER_ANGSTROM
+    shells = build_molecule_shells([1, 1], geometry_bohr, "sto-3g")
+
+    V_native = build_repulsion_tensor(shells)
+    V_bridge = build_repulsion_tensor_libcint([1, 1], geometry_bohr, "sto-3g")
+
+    assert V_bridge == pytest.approx(V_native, abs=1e-8)
+
+
+def test_ne_631gstar_bridge_matches_pyscf_anchor():
+    # The real point: a mixed s/p/d basis, where native_hf and libcint
+    # disagree on both shell order (native_hf keeps basis-file order,
+    # libcint groups by ascending degree) and per-component d normalization
+    # -- exercises the shell-identity matching and rescale in
+    # libcint_bridge.py, not just a trivial pass-through.
+    geometry_bohr = np.array([[0.0, 0.0, 0.0]])
+    shells = build_molecule_shells([10], geometry_bohr, "6-31g*")
+
+    S = build_overlap_matrix(shells)
+    H_core = build_core_hamiltonian(shells, [10.0], geometry_bohr)
+    V_bridge = build_repulsion_tensor_libcint([10], geometry_bohr, "6-31g*")
+
+    assert V_bridge == pytest.approx(V_bridge.transpose(1, 0, 2, 3), abs=1e-9)
+    assert V_bridge == pytest.approx(V_bridge.transpose(0, 1, 3, 2), abs=1e-9)
+    assert V_bridge == pytest.approx(V_bridge.transpose(2, 3, 0, 1), abs=1e-9)
+
+    result = run_scf(S, H_core, V_bridge, 10, [10.0], geometry_bohr)
+    assert result.converged
+    assert result.total_energy == pytest.approx(NE_631GSTAR_PYSCF_RHF_ENERGY, abs=1e-6)


### PR DESCRIPTION
Follow-up to today's ERI profiling work (#222): after ruling out a persistent compilation cache, multiprocessing, and a from-scratch batching redesign (all documented in prog.txt as tried-and-abandoned, the last one after reading a candidate reference implementation's real source and finding it optimizes a different bottleneck than ours), this adds the one approach that actually delivers HPC-level speed -- libcint, the C library PySCF itself uses, computes Ne/6-31G*'s full ERI tensor in **0.037s** vs native_hf's own 158.3s (non-x64) / 532.7s (x64).

**Not a replacement.** Nothing in this codebase differentiates through native_hf's raw integrals today (checked directly), so native_hf's own from-scratch JAX engine keeps its reason to exist (the project's own "no C++ hand-written" positioning, and a real demonstrated alternative to PennyLane's own slow `dhf` path). This is a new optional `libcint` extra (`pip install dense-evolution[libcint]`) for users who want real speed on large mixed-basis molecules and don't need it -- no hard dependency, no Windows wheel for pyscf (needs a C toolchain there).

**The real work was three separate AO-convention mismatches**, all found empirically (not assumed) via `mol.ao_labels()` / `mol.intor('int1e_ovlp')` and confirmed on Colab (this sandbox can't install PySCF):
1. Shell order: native_hf keeps the basis file's own order (interleaved by degree), libcint groups all of an atom's shells by ascending degree. Fixed by matching shells by identity (atom, degree, exponents), not by assuming either engine's list order.
2. Cartesian component order: native_hf's own `cartesian_powers` (also had a stale, wrong docstring claiming the common px,py,pz order for p -- fixed here too) uses px,pz,py and xx,xz,xy,zz,yz,yy; libcint uses px,py,pz and xx,xy,xz,yy,yz,zz.
3. Normalization: libcint's raw d components aren't unit-self-overlap the way native_hf's are (exact factor of 3 between xx/yy/zz and xy/xz/yz on Ne/6-31G*) -- corrected via a rescale computed from libcint's own overlap diagonal at call time, not a hardcoded formula.

Verified end-to-end on Colab with `JAX_ENABLE_X64=1`: H2/STO-3G and Ne/6-31G* both match native_hf/the PySCF energy anchor to ~1e-9 Hartree, SCF converges, 8-fold ERI symmetry intact. Tests added (`pytest.importorskip("pyscf")`, matching this repo's stim/pymatching pattern) and pyscf added to CI's ubuntu/macos matrix so they run for real there.