### PR TITLE
Fix: memoize gate-matrix construction in _fuse_compiled_rows

### DIFF
--- a/dense_evolution/backends/mps.py
+++ b/dense_evolution/backends/mps.py
@@ -404,17 +404,37 @@ def _fuse_compiled_rows(rows: List[List[float]], dtype) -> List[tuple]:
 
     Returns a list of ('1q', q, matrix_2x2) / ('2q', q1, q2, matrix_4x4)
     entries. transpose_flag is resolved into the matrix itself here, so
-    the fused representation never needs it downstream."""
+    the fused representation never needs it downstream.
+
+    Memoizes row_matrix by (g_id, param, transpose_flag) -- most rows in
+    a real circuit share the same small set of distinct gate/parameter
+    combinations (e.g. one N=50 TFIM circuit has 985 rows but only 3
+    distinct ones), and each cache miss dispatches a real JAX call
+    (_mps_1q_matrix/_mps_2q_matrix) that is not free to skip. Without
+    this, a real (not tiny-example) circuit pays a full eager JAX
+    dispatch per row on every single run_circuit_jit(fuse_gates=True)
+    call, not just the first -- measured directly: an unmemoized version
+    of this function made "warm" (post-compile) calls nearly as slow as
+    "cold" ones (10.7s vs 12.9s on a 74-gate circuit), because the
+    matrix-reconstruction cost, not recompilation, dominated."""
+    matrix_cache: dict = {}
 
     def row_matrix(row):
         g_id, q1, q2, param, transpose_flag = row
+        key = (g_id, param, transpose_flag)
+        cached = matrix_cache.get(key)
+        if cached is not None:
+            return cached, (int(q1), int(q2)) if g_id >= 20 else (int(q1),)
         g_id_arr = jnp.asarray(g_id).astype(jnp.int32)
         if g_id >= 20:
             mat4 = np.asarray(_mps_2q_matrix(g_id_arr, jnp.asarray(param), dtype))
             if transpose_flag > 0.5:
                 mat4 = np.transpose(mat4, (1, 0, 3, 2))
-            return mat4.reshape(4, 4), (int(q1), int(q2))
-        return np.asarray(_mps_1q_matrix(g_id_arr, jnp.asarray(param), dtype)), (int(q1),)
+            mat = mat4.reshape(4, 4)
+        else:
+            mat = np.asarray(_mps_1q_matrix(g_id_arr, jnp.asarray(param), dtype))
+        matrix_cache[key] = mat
+        return mat, (int(q1), int(q2)) if g_id >= 20 else (int(q1),)
 
     fused = []
     i = 0


### PR DESCRIPTION
## Summary
Real bug found by testing the literal, promoted `run_circuit_jit(ops, fuse_gates=True)` method for the first time -- every prior speedup number (2.77x, 2.04x) came from Dense-Evolution-Discovery's standalone reimplementation, which already had this memoization; production's `_fuse_compiled_rows` did not.

`_fuse_compiled_rows` called `_mps_1q_matrix`/`_mps_2q_matrix` (real JAX dispatch) once per compiled row with no caching, so every call -- "warm" or not -- paid the full eager matrix-reconstruction cost on top of the compiled kernel. Measured directly: a 74-gate test circuit showed "warm" barely faster than "cold" (10.7s vs 12.9s), since the compiled-kernel-reuse win was swamped by this unrelated host-side cost. A real 50-qubit TFIM circuit has 985 rows but only 3 distinct `(gate, parameter)` combinations -- caching by `(g_id, param, transpose_flag)` turns 985 real JAX calls into 3.

After the fix: the same N=50 circuit's warm call drops from the broken multi-second regime to 0.77s.

## Test plan
- [x] `pytest tests/unit/test_mps.py -k fuse_gates -q`: 4 passed (correctness unaffected -- memoizes the exact same values, doesn't change what's computed)
