### PR TITLE
Fix: two real perf bugs in run_circuit_jit(fuse_gates=True) found via real GPU testing

### DIFF
--- a/dense_evolution/backends/mps.py
+++ b/dense_evolution/backends/mps.py
@@ -51,6 +51,7 @@ complementary.
 """
 
 import warnings
+from functools import partial
 from typing import List, Optional, Tuple
 
 import jax
@@ -382,6 +383,24 @@ def _embed_1q_matrix(mat1: np.ndarray, qubit: int, pair: Tuple[int, int]) -> np.
     return np.kron(mat1, eye2) if qubit == a else np.kron(eye2, mat1)
 
 
+@partial(jax.jit, static_argnums=(2,))
+def _jit_mps_1q_matrix(g_id, param, dtype):
+    """Persistent-compiled-cache wrapper around _mps_1q_matrix, keyed by
+    JAX on (g_id, param, dtype) across the whole process lifetime, not
+    just within one _fuse_compiled_rows call -- without this, each
+    separate run_circuit_jit(fuse_gates=True) call pays a real XLA
+    compile cost again for the same gate/parameter combination, since
+    _mps_1q_matrix's own jax.lax.switch is never wrapped in @jax.jit."""
+    return _mps_1q_matrix(g_id, param, dtype)
+
+
+@partial(jax.jit, static_argnums=(2,))
+def _jit_mps_2q_matrix(g_id, param, dtype):
+    """Same persistent-compiled-cache fix as _jit_mps_1q_matrix, for
+    _mps_2q_matrix."""
+    return _mps_2q_matrix(g_id, param, dtype)
+
+
 def _fuse_compiled_rows(rows: List[List[float]], dtype) -> List[tuple]:
     """Host-side (pure Python/NumPy, outside any jit region), exact --
     fuses a chain of consecutive _compile_mps_ops rows into one matrix
@@ -427,12 +446,12 @@ def _fuse_compiled_rows(rows: List[List[float]], dtype) -> List[tuple]:
             return cached, (int(q1), int(q2)) if g_id >= 20 else (int(q1),)
         g_id_arr = jnp.asarray(g_id).astype(jnp.int32)
         if g_id >= 20:
-            mat4 = np.asarray(_mps_2q_matrix(g_id_arr, jnp.asarray(param), dtype))
+            mat4 = np.asarray(_jit_mps_2q_matrix(g_id_arr, jnp.asarray(param), dtype))
             if transpose_flag > 0.5:
                 mat4 = np.transpose(mat4, (1, 0, 3, 2))
             mat = mat4.reshape(4, 4)
         else:
-            mat = np.asarray(_mps_1q_matrix(g_id_arr, jnp.asarray(param), dtype))
+            mat = np.asarray(_jit_mps_1q_matrix(g_id_arr, jnp.asarray(param), dtype))
         matrix_cache[key] = mat
         return mat, (int(q1), int(q2)) if g_id >= 20 else (int(q1),)
 

--- a/dense_evolution/backends/mps.py
+++ b/dense_evolution/backends/mps.py
@@ -299,6 +299,27 @@ def _pad_lambda(lam: jnp.ndarray, max_bond: int) -> jnp.ndarray:
     return out.at[:n].set(lam)
 
 
+@partial(jax.jit, static_argnums=(1, 2))
+def _pad_all_gammas(gammas, max_bond: int, dtype) -> jnp.ndarray:
+    """Batches the whole per-gamma padding+stacking loop into one
+    compiled call instead of n_qubits separate eager _pad_gamma
+    dispatches -- profiling run_circuit_jit directly found this eager
+    loop (50-51 separate JAX dispatches for N=50) cost 52-55% of total
+    run_circuit_jit time, present equally on the fuse_gates=True and
+    default paths, diluting the real speedup ratio between them.
+    Persistent-compiled-cache wrapper, keyed by the tuple of gamma
+    shapes + max_bond + dtype -- valid across the whole process
+    lifetime, same principle as _jit_mps_1q_matrix/_jit_mps_2q_matrix."""
+    return jnp.stack([_pad_gamma(g, max_bond).astype(dtype) for g in gammas])
+
+
+@partial(jax.jit, static_argnums=(1, 2))
+def _pad_all_lambdas(lambdas, max_bond: int, dtype) -> jnp.ndarray:
+    """Same persistent-compiled-cache fix as _pad_all_gammas, for
+    lambdas."""
+    return jnp.stack([_pad_lambda(l, max_bond).astype(dtype) for l in lambdas])
+
+
 def _compile_mps_ops(ops, n_qubits: int) -> List[List[float]]:
     """Pre-compile-time (pure Python, outside any jit region) translation
     of a circuit -- list of (name, *args) tuples/lists, same convention as
@@ -1303,8 +1324,8 @@ class MPSSimulator:
             if self._fused_mps_runner is None:
                 self._fused_mps_runner = _build_fused_mps_runner(self.n, self.chi, self.eps, self.jsd_budget)
 
-            gammas_padded = jnp.stack([_pad_gamma(g, self.chi).astype(dtype) for g in self.gammas])
-            lambdas_padded = jnp.stack([_pad_lambda(l, self.chi).astype(lambda_dtype) for l in self.lambdas])
+            gammas_padded = _pad_all_gammas(tuple(self.gammas), self.chi, dtype)
+            lambdas_padded = _pad_all_lambdas(tuple(self.lambdas), self.chi, lambda_dtype)
             real_chi_initial = jnp.asarray(self._real_chi, dtype=jnp.int32)
 
             if fused:


### PR DESCRIPTION
Real GPU testing (Kaggle T4) of the promoted `run_circuit_jit(fuse_gates=True)` API showed only 1.36x speedup, well short of Dense-Evolution-Discovery's own 1.99x reimplementation number (PR #227/#228 territory). Two separate real bugs found so far, both fixed here.

**Fix 1 — persistent JIT cache for gate-matrix constructors.** `_mps_1q_matrix`/`_mps_2q_matrix` are plain functions containing `jax.lax.switch`, never wrapped in `@jax.jit`. Every eager call paid a real XLA compile cost, repeated on every separate `run_circuit_jit(fuse_gates=True)` call since `_fuse_compiled_rows`'s `matrix_cache` is scoped per-call. Wrapped both in module-level `@partial(jax.jit, static_argnums=(2,))` closures. Re-verified on Kaggle GPU: two separate `fuse_gates=True` calls now measure the same (2.196s vs 2.223s) — no more repeated recompile. But the end-to-end speedup stayed flat at 1.37-1.39x, so this wasn't the (only) explanation for the gap.

**Fix 2 — batch the per-tensor gamma/lambda padding.** Profiling the real `run_circuit_jit` directly (cProfile) found the actual dominant cost, shared equally by `fuse_gates=True` and the default path: `_pad_gamma`/`_pad_lambda` are called once per tensor (50-51 separate eager JAX dispatches for N=50) — 52-55% of total time on both paths. Shared-equally overhead dilutes the speedup ratio toward 1x, which is exactly why the real API number was so much lower than the kernel-only reimplementation ratio. Batched the whole padding+stacking loop into one module-level `@jax.jit` closure.

Both validated first in Dense-Evolution-Discovery:
- `scripts/mps_gate_blocking_jit_matrix_cache_fix.py`: correctness identical, 497.8/431.7/230.5ms → 9.8/10.6/10.3ms per call.
- `scripts/mps_padding_batch_jit_fix.py`: correctness identical, ~70ms → ~3-4ms per call.

`tests/unit/test_mps.py`: 75 passed, 4 pre-existing environment-specific complex64-tolerance failures (confirmed present on main before either fix, and confirmed test-order-dependent flakiness, not a regression from these changes).

Still pending: re-verification of both fixes together on Kaggle GPU to get the final real speedup number.