### PR TITLE
Fix: max_bond_used() over-reporting from JSD tail noise under jax.jit

### DIFF
--- a/dense_evolution/backends/mps.py
+++ b/dense_evolution/backends/mps.py
@@ -121,6 +121,18 @@ def _vectorized_chi_search_jax(S: jnp.ndarray, eps: float, jsd_budget: float, ma
 
     norm_full = jnp.sum(S ** 2) + 1e-15
     p_full = (S ** 2) / norm_full
+    # Real bug (found via a real-machine bisection down to 5e34a1e, not
+    # guessed): under jax.jit, _jsd_vectors_jax's own internal eps=1e-12
+    # mask does not reliably zero JSD contributions from p_full's
+    # already-negligible tail (~1e-18, from squaring SVD noise-floor
+    # singular values ~1e-9) when batched via jax.vmap across multiple
+    # candidates at once -- eager execution of the exact same formula on
+    # the exact same array gives the correct (zero) JSD there, jit does
+    # not. Zeroing p_full's own negligible tail here, before it ever
+    # reaches the vmapped JSD computation, verified to fix this under
+    # jit (confirmed both eager and jit now agree) without changing any
+    # value large enough to matter physically.
+    p_full = jnp.where(p_full > 1e-12, p_full, 0.0)
 
     candidates = jnp.arange(1, max_possible + 1)
     idx = jnp.arange(n)


### PR DESCRIPTION
Real production bug found via a real-machine commit bisection down to `5e34a1e` (the original bucketed-SVD promotion), not guessed: `max_bond_used()` over-reported by up to 2x on some circuits (8 instead of 4 observed; seed=3, 12-qubit brick-wall RY+CX circuit, default complex64 cutoff) — fidelity and entanglement entropy were unaffected, the true state was correct, only the bond-dimension bookkeeping was wrong.

Root-caused to a minimal, reproducible eager-vs-jit discrepancy: `_jsd_vectors_jax`'s own internal `eps=1e-12` mask does not reliably zero JSD contributions from `p_full`'s already-negligible tail (~1e-18, from squaring SVD noise-floor singular values ~1e-9) when batched via `jax.vmap` across multiple truncation candidates at once, specifically under `jax.jit` — the exact same formula, called eagerly on the exact same array, gives the correct (zero) JSD; jit does not. This made `_vectorized_chi_search_jax`'s jsd_budget check fail even at the bucket's full size, falling back to "keep everything in the bucket" and retaining spurious near-zero singular values as if they were real Schmidt weight.

**Fix**: zero `p_full`'s own negligible tail (threshold `1e-12`, matching the existing internal eps) before it ever reaches the vmapped JSD computation, instead of relying only on the internal mask.

Verified:
- Eager and jit now agree on the exact minimal repro.
- `max_bond_used()` returns 4 (not 8) on the reported circuit.
- The fidelity/entanglement-entropy invariant this bug never actually violated stays unaffected.
- `tests/unit/test_mps.py`: 75 passed — 79 minus the 4 pre-existing environment-specific complex64-tolerance failures (confirmed unrelated). 2 additional `MemoryPressureError` failures seen on a full-suite run were confirmed environmental (both pass in isolation), not caused by this change.

Credit: root cause pinpointed via a careful real-machine bisection and repro (not guessed) that ruled out two other plausible-looking commits along the way — thank you for the rigor.