### PR TITLE
Bump version to 8.1.77

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -57,7 +57,7 @@ from .physics.qec import (pauli_commutes, compute_syndrome, erasure_aware_decode
                            blind_minimum_weight_decode, decode_with_erasure_fallback,
                            counts_in_intervals_dimension, nearest_coset_decode)
 
-__version__ = "8.1.76"
+__version__ = "8.1.77"
 
 __all__ = [
     "__version__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dense-evolution"
-version = "8.1.76"
+version = "8.1.77"
 description = "High-performance quantum simulation toolkit -- Statevector/MPS engines with JIT compilation, noise modeling, VQE, QEC, quantum chemistry, and agent-native tooling"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Since 8.1.76:
- Persistent JIT cache for gate-matrix constructors and batched gamma/lambda padding in `run_circuit_jit(fuse_gates=True)` (#229).
- Fix: `max_bond_used()` over-reporting from JSD tail noise under `jax.jit` — eager and jit now agree on bond-dimension bookkeeping, verified on both CPU and real GPU hardware (#230, #231).

Next: PyPI upload (manual), then tag + GitHub release once that succeeds.