### PR TITLE
Fix optional-dep import crash and test isolation (RAM, float32 precision, jax_enable_x64 leak)

### DIFF
--- a/dense_evolution/native_hf/bridge.py
+++ b/dense_evolution/native_hf/bridge.py
@@ -9,12 +9,17 @@ instead of reimplementing them.
 """
 
 import numpy as np
-import pennylane as qml
-import pennylane.qchem.observable_hf as _pl_observable
 
 from dense_evolution.native_hf.basis import build_molecule_shells
 from dense_evolution.native_hf.assembly import build_overlap_matrix, build_core_hamiltonian, build_repulsion_tensor
 from dense_evolution.native_hf.scf import run_scf, HFResult
+
+try:
+    import pennylane as qml
+    import pennylane.qchem.observable_hf as _pl_observable
+except ModuleNotFoundError:
+    qml = None
+    _pl_observable = None
 
 _BOHR_PER_ANGSTROM = 1.0 / 0.52917721067
 
@@ -64,6 +69,12 @@ def build_qubit_hamiltonian(
         latter useful for e.g. reporting the SCF energy alongside the
         post-mapping ground-state energy.
     """
+    if qml is None:
+        raise ModuleNotFoundError(
+            "build_qubit_hamiltonian requires pennylane. "
+            "Install it with: pip install dense-evolution[pennylane]"
+        )
+
     geometry_bohr = np.asarray(geometry_angstrom) * _BOHR_PER_ANGSTROM
     shells = build_molecule_shells(atomic_numbers, geometry_bohr, basis_name)
 

--- a/dense_evolution/native_hf/bridge.py
+++ b/dense_evolution/native_hf/bridge.py
@@ -14,10 +14,15 @@ from dense_evolution.native_hf.basis import build_molecule_shells
 from dense_evolution.native_hf.assembly import build_overlap_matrix, build_core_hamiltonian, build_repulsion_tensor
 from dense_evolution.native_hf.scf import run_scf, HFResult
 
+# pennylane is installed in this test suite's own environment, so the
+# except branch below (and the `if qml is None` check further down) is
+# only exercised by tests/unit/test_imports.py, which blocks pennylane
+# in a separate subprocess -- invisible to same-process coverage, so
+# excluded rather than chased with an artificial same-process test.
 try:
     import pennylane as qml
     import pennylane.qchem.observable_hf as _pl_observable
-except ModuleNotFoundError:
+except ModuleNotFoundError:  # pragma: no cover
     qml = None
     _pl_observable = None
 
@@ -69,7 +74,7 @@ def build_qubit_hamiltonian(
         latter useful for e.g. reporting the SCF energy alongside the
         post-mapping ground-state energy.
     """
-    if qml is None:
+    if qml is None:  # pragma: no cover -- see the try/except above
         raise ModuleNotFoundError(
             "build_qubit_hamiltonian requires pennylane. "
             "Install it with: pip install dense-evolution[pennylane]"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,43 @@ assert _REPO_ROOT in pathlib.Path(dense_evolution.__file__).resolve().parents, (
 )
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "real_memory_probe: opt out of the autouse deterministic memory-budget "
+        "fixture, for tests that exercise _device_memory_budget_bytes/"
+        "_device_total_bytes themselves rather than code that merely calls them.",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_memory_budget(request, monkeypatch):
+    """SafeMemoryGuard reads the ACTIVE compute device's real memory (or
+    host RAM via psutil on CPU) -- see guard.py's own module docstring.
+    That makes any test that builds a Chunk/SafeMemoryGuard without
+    explicitly faking the probe pass or fail depending on what else is
+    using RAM on the machine at that moment (confirmed directly: a full
+    `pytest tests/unit/test_mps.py` run raised a real, non-deterministic
+    MemoryPressureError from cumulative RAM use partway through the
+    file). Fixed at a comfortable 50% free of 8 GB by default here so the
+    guard's pass/fail branch is a property of the code, not the host --
+    tests that specifically exercise SafeMemoryGuard's own thresholds
+    override this locally with their own monkeypatch of the same two
+    functions. Tests marked real_memory_probe (those exercising the probe
+    functions' own device-detection logic) opt out entirely."""
+    if request.node.get_closest_marker("real_memory_probe") is not None:
+        return
+
+    from dense_evolution.backends.chunk import guard as guard_mod
+
+    total_bytes = 8 * 1024 ** 3
+    available_bytes = 0.5 * total_bytes
+    monkeypatch.setattr(guard_mod, "_device_memory_budget_bytes",
+                         lambda device=None: (available_bytes, "test-fixed"))
+    monkeypatch.setattr(guard_mod, "_device_total_bytes",
+                         lambda device=None: total_bytes)
+
+
 @pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session, exitstatus):
     """

--- a/tests/unit/test_amplitude_damping_channel.py
+++ b/tests/unit/test_amplitude_damping_channel.py
@@ -1,10 +1,21 @@
 import jax
-jax.config.update("jax_enable_x64", True)
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
 from dense_evolution import amplitude_damping_channel
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _x64():
+    # float32 (the default without this) was measured to accumulate ~3e-7
+    # error here -- enabled only for this module's own tests (not at
+    # import time) so it doesn't leak into other test files that run in
+    # the same pytest process.
+    previous = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    yield
+    jax.config.update("jax_enable_x64", previous)
 
 
 def _rho1():

--- a/tests/unit/test_chunk.py
+++ b/tests/unit/test_chunk.py
@@ -216,15 +216,18 @@ class TestChunkMultiPiece:
 
     # ── MemoryPressureError actually firing, not just "doesn't crash" ────
 
+    def _fake_budget(self, monkeypatch, free_fraction, total_bytes=8 * 1024 ** 3):
+        from dense_evolution.backends.chunk import guard as guard_mod
+        available_bytes = free_fraction * total_bytes
+        monkeypatch.setattr(guard_mod, "_device_memory_budget_bytes",
+                             lambda device=None: (available_bytes, "fake"))
+        monkeypatch.setattr(guard_mod, "_device_total_bytes",
+                             lambda device=None: total_bytes)
+
     def test_memory_pressure_error_fires_on_insufficient_ram_num_chunks_1(self, monkeypatch):
         import dense_evolution.chunk as chunk_mod
 
-        class _FakeVM:
-            total = 8 * 1024 ** 3       # 8 GB
-            available = 0.05 * 8 * 1024 ** 3  # 5% free -- below any sane threshold
-            percent = 95.0
-
-        monkeypatch.setattr(chunk_mod.psutil, "virtual_memory", lambda: _FakeVM())
+        self._fake_budget(monkeypatch, free_fraction=0.05)  # below any sane threshold
         with pytest.raises(chunk_mod.MemoryPressureError, match="MEMORIA CRITICA"):
             Chunk(10, memory_threshold=0.15)
 
@@ -233,31 +236,19 @@ class TestChunkMultiPiece:
 
         force_chunk_bits(4)  # forces num_chunks>1 at small n_qubits
 
-        class _FakeVM:
-            total = 8 * 1024 ** 3
-            available = 0.05 * 8 * 1024 ** 3
-            percent = 95.0
-
-        monkeypatch.setattr(chunk_mod.psutil, "virtual_memory", lambda: _FakeVM())
+        self._fake_budget(monkeypatch, free_fraction=0.05)
         with pytest.raises(chunk_mod.MemoryPressureError, match="MEMORIA INSUFFICIENTE"):
             Chunk(6, memory_threshold=0.15)
 
     def test_memory_pressure_error_not_raised_with_ample_ram(self, monkeypatch, force_chunk_bits):
-        # Negative control: the same fake-psutil machinery, but with
+        # Negative control: the same fake-budget machinery, but with
         # generous available memory, must NOT raise -- confirms the two
         # tests above are catching a real threshold check, not e.g. an
         # unconditional raise or a monkeypatch that broke construction
         # entirely.
-        import dense_evolution.chunk as chunk_mod
-
         force_chunk_bits(4)
 
-        class _FakeVM:
-            total = 8 * 1024 ** 3
-            available = 0.90 * 8 * 1024 ** 3
-            percent = 10.0
-
-        monkeypatch.setattr(chunk_mod.psutil, "virtual_memory", lambda: _FakeVM())
+        self._fake_budget(monkeypatch, free_fraction=0.90)
         c = Chunk(6, memory_threshold=0.15)
         assert c.num_chunks == 4
 
@@ -602,6 +593,7 @@ class TestChunkUtilities:
         bits = chunk_mod.get_dynamic_chunk(np.complex64)
         assert 16 <= bits <= 27
 
+    @pytest.mark.real_memory_probe
     def test_safe_memory_guard_status_reads_device_memory_when_present(self, monkeypatch):
         import dense_evolution.chunk as chunk_mod
 

--- a/tests/unit/test_continuous_dissipative_evolve.py
+++ b/tests/unit/test_continuous_dissipative_evolve.py
@@ -1,9 +1,20 @@
 import jax
-jax.config.update("jax_enable_x64", True)
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from dense_evolution import continuous_dissipative_evolve, global_depolarizing_channel
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _x64():
+    # Enabled only for this module's own tests (not at import time) so it
+    # doesn't leak into other test files that run in the same pytest
+    # process.
+    previous = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    yield
+    jax.config.update("jax_enable_x64", previous)
 
 
 def _pure_state_rho(dim, index=0):

--- a/tests/unit/test_continuous_pulse_evolve.py
+++ b/tests/unit/test_continuous_pulse_evolve.py
@@ -1,12 +1,26 @@
 import jax
-jax.config.update("jax_enable_x64", True)
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from dense_evolution import continuous_pulse_evolve
 
-X = jnp.array([[0.0, 1.0], [1.0, 0.0]], dtype=jnp.complex128)
-Y = jnp.array([[0.0, -1j], [1j, 0.0]], dtype=jnp.complex128)
+X = None
+Y = None
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _x64_and_paulis():
+    # atol=1e-8 below needs complex128 -- enabled only for this module's
+    # own tests (not at import time) so it doesn't leak into other test
+    # files that run in the same pytest process.
+    previous = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    global X, Y
+    X = jnp.array([[0.0, 1.0], [1.0, 0.0]], dtype=jnp.complex128)
+    Y = jnp.array([[0.0, -1j], [1j, 0.0]], dtype=jnp.complex128)
+    yield
+    jax.config.update("jax_enable_x64", previous)
 
 
 def test_constant_coefficient_matches_single_expm_step():

--- a/tests/unit/test_cosmic_ray_burst_profile.py
+++ b/tests/unit/test_cosmic_ray_burst_profile.py
@@ -1,9 +1,20 @@
 import jax
-jax.config.update("jax_enable_x64", True)
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from dense_evolution import cosmic_ray_burst_profile
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _x64():
+    # Enabled only for this module's own tests (not at import time) so it
+    # doesn't leak into other test files that run in the same pytest
+    # process.
+    previous = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    yield
+    jax.config.update("jax_enable_x64", previous)
 
 
 def test_at_impact_returns_baseline():

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -1,0 +1,74 @@
+import subprocess
+import sys
+
+_BLOCKER_PREAMBLE = """
+import sys, importlib.abc
+
+class _Blocker(importlib.abc.MetaPathFinder):
+    def find_spec(self, name, path, target=None):
+        if any(name == root or name.startswith(root + ".") for root in {blocked!r}):
+            raise ModuleNotFoundError(f"No module named '{{name}}'")
+        return None
+
+sys.meta_path.insert(0, _Blocker())
+"""
+
+
+def _run_blocked(blocked_roots, body):
+    script = _BLOCKER_PREAMBLE.format(blocked=list(blocked_roots)) + body
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    return result
+
+
+def test_all_submodules_importable_with_only_base_dependencies():
+    body = """
+import pkgutil, importlib
+import dense_evolution as pkg
+failed = []
+for m in pkgutil.walk_packages(pkg.__path__, pkg.__name__ + "."):
+    try:
+        importlib.import_module(m.name)
+    except ModuleNotFoundError as e:
+        failed.append((m.name, str(e)))
+if failed:
+    print("FAILED:", failed)
+    sys.exit(1)
+print("OK")
+"""
+    result = _run_blocked(["pennylane", "qiskit", "stim", "pymatching"], body)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_native_hf_bridge_importable_without_pennylane():
+    body = """
+import dense_evolution.native_hf.bridge as bridge
+assert bridge.qml is None
+print("OK")
+"""
+    result = _run_blocked(["pennylane"], body)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_native_hf_bridge_raises_clear_error_without_pennylane():
+    body = """
+import dense_evolution.native_hf.bridge as bridge
+try:
+    bridge.build_qubit_hamiltonian(
+        atomic_numbers=[1, 1],
+        geometry_angstrom=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.74]],
+        n_electrons=2,
+    )
+except ModuleNotFoundError as e:
+    assert "pip install dense-evolution[pennylane]" in str(e), str(e)
+    print("OK")
+    sys.exit(0)
+print("did not raise")
+sys.exit(1)
+"""
+    result = _run_blocked(["pennylane"], body)
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/unit/test_libcint_bridge.py
+++ b/tests/unit/test_libcint_bridge.py
@@ -10,6 +10,7 @@ ImportError path -- same reasoning as this repo's stim/pymatching tests.
 `pytest.importorskip` is per-test, not module-level, so the pure-Python
 shell-matching/permutation tests below still run without pyscf installed.
 """
+import jax
 import numpy as np
 import pytest
 
@@ -82,10 +83,19 @@ def test_shell_matching_finds_reordered_shells():
     assert starts == [0, 2, 1]
 
 
-def test_h2_sto3g_bridge_matches_native_hf_eri():
-    pytest.importorskip("pyscf")
-    import jax
+@pytest.fixture
+def _x64():
+    # Function-scoped, not module-level: restores the previous value after
+    # this one test so it doesn't leak into other test files that run in
+    # the same pytest process.
+    previous = jax.config.jax_enable_x64
     jax.config.update("jax_enable_x64", True)
+    yield
+    jax.config.update("jax_enable_x64", previous)
+
+
+def test_h2_sto3g_bridge_matches_native_hf_eri(_x64):
+    pytest.importorskip("pyscf")
     from dense_evolution.native_hf.basis import build_molecule_shells
     from dense_evolution.native_hf.assembly import build_repulsion_tensor
     from dense_evolution.native_hf.libcint_bridge import build_repulsion_tensor_libcint
@@ -99,15 +109,13 @@ def test_h2_sto3g_bridge_matches_native_hf_eri():
     assert V_bridge == pytest.approx(V_native, abs=1e-8)
 
 
-def test_ne_631gstar_bridge_matches_pyscf_anchor():
+def test_ne_631gstar_bridge_matches_pyscf_anchor(_x64):
     # The real point: a mixed s/p/d basis, where native_hf and libcint
     # disagree on both shell order (native_hf keeps basis-file order,
     # libcint groups by ascending degree) and per-component d normalization
     # -- exercises the shell-identity matching and rescale in
     # libcint_bridge.py, not just a trivial pass-through.
     pytest.importorskip("pyscf")
-    import jax
-    jax.config.update("jax_enable_x64", True)
     from dense_evolution.native_hf.basis import build_molecule_shells
     from dense_evolution.native_hf.assembly import build_overlap_matrix, build_core_hamiltonian
     from dense_evolution.native_hf.libcint_bridge import build_repulsion_tensor_libcint

--- a/tests/unit/test_mps.py
+++ b/tests/unit/test_mps.py
@@ -95,10 +95,14 @@ def test_bell_state():
     mps.apply_cx(0, 1)
     sv = mps.contract_to_statevector()
     prob = np.abs(sv) ** 2
-    assert prob[0] == pytest.approx(0.5, abs=1e-9)
-    assert prob[3] == pytest.approx(0.5, abs=1e-9)
-    assert prob[1] == pytest.approx(0.0, abs=1e-9)
-    assert prob[2] == pytest.approx(0.0, abs=1e-9)
+    # abs=1e-6, not 1e-9: MPSSimulator defaults to complex64, and 1e-9 is
+    # below float32's own precision floor for this computation (measured
+    # ~6e-8 error here) -- see test_nonlocal_2q_gate_ctrl_greater_than_tgt_both_dtypes
+    # for the same tolerance applied explicitly across both dtypes.
+    assert prob[0] == pytest.approx(0.5, abs=1e-6)
+    assert prob[3] == pytest.approx(0.5, abs=1e-6)
+    assert prob[1] == pytest.approx(0.0, abs=1e-6)
+    assert prob[2] == pytest.approx(0.0, abs=1e-6)
 
 
 def test_ghz_chain_n_qubits():
@@ -109,9 +113,9 @@ def test_ghz_chain_n_qubits():
         mps.apply_cx(q, q + 1)
     sv = mps.contract_to_statevector()
     prob = np.abs(sv) ** 2
-    assert prob[0] == pytest.approx(0.5, abs=1e-9)
-    assert prob[-1] == pytest.approx(0.5, abs=1e-9)
-    assert prob.sum() == pytest.approx(1.0, abs=1e-9)
+    assert prob[0] == pytest.approx(0.5, abs=1e-6)
+    assert prob[-1] == pytest.approx(0.5, abs=1e-6)
+    assert prob.sum() == pytest.approx(1.0, abs=1e-6)
 
 
 def test_statevector_stays_normalized_after_many_gates():
@@ -135,8 +139,8 @@ def test_nonlocal_2q_gate_via_swap_chain():
     sv = mps.contract_to_statevector()
     prob = np.abs(sv) ** 2
     # H on q0 then CX(0,3): entangles q0/q3, q1/q2 stay |0>
-    assert prob[0b0000] == pytest.approx(0.5, abs=1e-9)
-    assert prob[0b1001] == pytest.approx(0.5, abs=1e-9)
+    assert prob[0b0000] == pytest.approx(0.5, abs=1e-6)
+    assert prob[0b1001] == pytest.approx(0.5, abs=1e-6)
 
 
 def test_toffoli_matches_classical_truth_table():
@@ -165,8 +169,8 @@ def test_nonlocal_2q_gate_ctrl_greater_than_tgt():
     sv = mps.contract_to_statevector()
     prob = np.abs(sv) ** 2
     # H on q3 then CX(ctrl=3,tgt=0): entangles q3/q0, q1/q2 stay |0>
-    assert prob[0b0000] == pytest.approx(0.5, abs=1e-9)
-    assert prob[0b1001] == pytest.approx(0.5, abs=1e-9)
+    assert prob[0b0000] == pytest.approx(0.5, abs=1e-6)
+    assert prob[0b1001] == pytest.approx(0.5, abs=1e-6)
 
 
 def test_nonlocal_2q_gate_ctrl_greater_than_tgt_matches_dense_simulator():

--- a/tests/unit/test_stabilizer_renyi_entropy.py
+++ b/tests/unit/test_stabilizer_renyi_entropy.py
@@ -6,17 +6,27 @@ derived by hand from the source paper's own Eq. 5 (arXiv:2106.12587), not
 copied from anywhere else.
 """
 import jax
-jax.config.update("jax_enable_x64", True)  # needed for the tight "exactly
-# 0 for stabilizer states" tolerances below -- float32 (the default
-# without this) was measured to accumulate ~3e-7 error on a 4-qubit GHZ
-# state through this module's O(d^3) computation, same pattern already
-# used in tests/unit/test_amplitude_damping_channel.py for the same reason.
-
 import numpy as np
 import pytest
 
 from dense_evolution.mitigation import stabilizer_renyi_entropy, stabilizer_renyi_entropy_jit
 from dense_evolution import DenseSVSimulator
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _x64():
+    # Needed for the tight "exactly 0 for stabilizer states" tolerances
+    # below -- float32 (the default without this) was measured to
+    # accumulate ~3e-7 error on a 4-qubit GHZ state through this module's
+    # O(d^3) computation, same pattern used in
+    # tests/unit/test_amplitude_damping_channel.py for the same reason.
+    # Enabled only for this module's own tests (not at import time) so it
+    # doesn't leak into other test files that run in the same pytest
+    # process.
+    previous = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    yield
+    jax.config.update("jax_enable_x64", previous)
 
 
 def _original_loop_reference(psi):


### PR DESCRIPTION
Da un audit indipendente sulla wheel 8.1.77, verificato empiricamente prima di implementare. Copre P11 e tutti e tre i punti di P12 di prog.txt.

**bridge.py**: `dense_evolution.native_hf.bridge` era l'unico modulo dell'intero pacchetto a fallire l'import senza pennylane (extra opzionale) — confermato camminando tutti i submoduli con pennylane bloccato via meta-path finder. Ora pennylane è opzionale a import-time; `build_qubit_hamiltonian` solleva un errore chiaro solo se chiamata senza. Nuovo `tests/unit/test_imports.py`: guardiano generale che verifica tutti i submoduli importabili con sole dipendenze base.

**SafeMemoryGuard**: confermato peggio dell'audit — `pytest tests/unit/test_mps.py` da solo produceva 2 `MemoryPressureError` reali da uso cumulativo di RAM durante la suite. `tests/conftest.py` ora ha una fixture autouse che fissa il budget della guardia a un valore deterministico; i test che esercitano la guardia stessa iniettano budget specifici tramite lo stesso seam invece di mockare `psutil` direttamente.

**test_mps.py, tolleranze float32**: l'audit ipotizzava una fuga di stato `jax_enable_x64` tra moduli come causa di 4 fallimenti. Causa reale verificata: 4 asserzioni confrontavano risultati con tolleranza `abs=1e-9`, troppo stretta per complex64 (default di MPSSimulator, errore reale ~6e-8). Allineate a `abs=1e-6`, come un test gemello nello stesso file già faceva.

**Fuga di `jax_enable_x64`**: reale e ora risolta. 6 file (`test_continuous_pulse_evolve.py`, `test_amplitude_damping_channel.py`, `test_continuous_dissipative_evolve.py`, `test_cosmic_ray_burst_profile.py`, `test_stabilizer_renyi_entropy.py`, `test_libcint_bridge.py`) impostavano `jax.config.update("jax_enable_x64", True)` a livello di modulo/import senza mai ripristinarlo, alterando permanentemente lo stato globale JAX per il resto del processo pytest. Convertiti in fixture (module- o function-scoped) che abilitano il flag solo per i test di quel file e lo ripristinano dopo.

Verifica finale: `test_stabilizer_renyi_entropy.py` eseguito subito prima di `test_mps.py` (l'ordine esatto con cui prog.txt dimostrava la fuga) — 112 passed, 0 failed, per entrambi i file. Suite completa toccata: 141+ passed, 0 failed.

Nessun bump di versione, nessun merge automatico.