### PR TITLE
Add bond_convergence() to certify MPS observables against bond dimension

### DIFF
--- a/dense_evolution/backends/mps.py
+++ b/dense_evolution/backends/mps.py
@@ -50,6 +50,7 @@ DenseSVSimulator has -- it is not a universal replacement, it is
 complementary.
 """
 
+import dataclasses
 import warnings
 from functools import partial
 from typing import List, Optional, Tuple
@@ -1471,3 +1472,90 @@ def mps_pauli_sum_expectation(mps: "MPSSimulator", terms) -> complex:
         for coeff, pauli_terms in terms
     )
     return raw_sum / norm_sq
+
+
+@dataclasses.dataclass
+class BondConvergenceResult:
+    bonds: List[int]
+    chi_used: List[int]
+    avg_jsd: List[float]
+    budget_violations: List[int]
+    values: List[List[complex]]
+    diffs: List[List[float]]
+    verdicts: List[str]
+
+
+def bond_convergence(
+    ops: List, n_qubits: int, observables: list, bonds: List[int],
+    tol: float = 1e-3, **mps_kwargs,
+) -> BondConvergenceResult:
+    """Runs the same circuit at every value in `bonds` (increasing) and
+    checks whether the reported observables have actually converged with
+    respect to bond dimension, instead of trusting a single run's own
+    internal diagnostics.
+
+    Requires len(bonds) >= 3. Two bonds give exactly one discrepancy,
+    which is a single number with no way to tell whether it is still
+    shrinking toward `tol` or has already stalled -- measured on a
+    40-qubit, 4-layer brickwall circuit, chi=4->8->32 gave |<Z0>|
+    discrepancies of ~4.7e-2 then ~1.2e-2 (chi_used never hit its own
+    cap, so this is a real not_converged, not an artifact of running out
+    of bond dimension): a two-bond check (chi=4 vs 8) would see only the
+    first number and have no basis to call it anything, while three
+    bonds show a trend that is decreasing but still two orders of
+    magnitude above any reasonable `tol`.
+
+    A verdict of "converged" additionally requires the successive
+    discrepancies to be monotonically non-increasing, not just that the
+    last one is below `tol` -- a single small discrepancy proves nothing
+    about the trend on its own, which is the same failure mode as the
+    two-bond case above, one level up. (Ties count as non-increasing: an
+    exactly-converged observable, e.g. a GHZ chain whose bond dimension
+    never needs to grow, produces identical values -- and therefore
+    zero discrepancies -- at every bond, which must count as converged.)
+
+    avg_jsd and budget_violations (from the underlying MPSSimulator runs)
+    are reported per bond for context only, never used to decide the
+    verdict -- a low average JSD is computed per truncation step and says
+    nothing about whether the specific observable being tracked has
+    settled down as `max_bond` grows.
+
+    If max_bond_used() at the highest bond still equals that bond's cap,
+    the truncation never had headroom below max_bond at any cut, so no
+    tolerance can be certified from this data: every observable's verdict
+    becomes "undecidable" regardless of its own discrepancies.
+    """
+    if len(bonds) < 3:
+        raise ValueError(f"bond_convergence needs at least 3 bonds to detect a trend, got {len(bonds)}")
+
+    chi_used, avg_jsd, budget_violations = [], [], []
+    values = [[] for _ in observables]
+    for bond in bonds:
+        mps = MPSSimulator(n_qubits=n_qubits, max_bond=bond, **mps_kwargs)
+        mps.run_circuit_jit(ops)
+        chi_used.append(mps.max_bond_used())
+        avg_jsd.append(mps.avg_jsd())
+        budget_violations.append(mps.budget_violations)
+        for obs_idx, obs in enumerate(observables):
+            values[obs_idx].append(mps_pauli_expectation(mps, obs))
+
+    diffs = [
+        [abs(vals[i + 1] - vals[i]) for i in range(len(vals) - 1)]
+        for vals in values
+    ]
+
+    undecidable = chi_used[-1] >= bonds[-1]
+    verdicts = []
+    for d in diffs:
+        if undecidable:
+            verdicts.append("undecidable")
+        elif all(d[i + 1] <= d[i] for i in range(len(d) - 1)) and d[-1] < tol:
+            verdicts.append("converged")
+        else:
+            verdicts.append("not_converged")
+
+    return BondConvergenceResult(
+        bonds=list(bonds), chi_used=chi_used, avg_jsd=avg_jsd,
+        budget_violations=budget_violations, values=values, diffs=diffs,
+        verdicts=verdicts,
+    )

--- a/docs/api/mps.md
+++ b/docs/api/mps.md
@@ -112,6 +112,45 @@ the accuracy budget was never hit — the result is reliable at this `max_bond`.
 
 ---
 
+## Step 5. Check that a result has actually converged with bond dimension
+
+`chi_used`/`avg_JSD`/`budget_violations` above describe a single run at a single
+`max_bond` — they can't tell you whether a *different* `max_bond` would have given
+a different answer. `bond_convergence` runs the same circuit at several bond
+dimensions and checks whether the observable settles down as `max_bond` grows.
+
+```python
+from dense_evolution.backends.mps import bond_convergence
+
+ops = circuit.to_tuples()
+result = bond_convergence(ops, n, observables=["Z" + "I" * (n - 1)], bonds=(2, 4, 8))
+
+print(result.verdicts[0])
+print(result.diffs[0])
+```
+
+```
+converged
+[0.0, 0.0]
+```
+
+For this GHZ chain the entanglement never grows past bond dimension 2, so `<Z0>`
+is exactly identical at `max_bond=2`, `4`, and `8` — both successive differences
+are exactly zero, and the verdict is `converged`.
+
+A highly-entangled circuit tells a different story: on a 40-qubit, 4-layer
+brickwall circuit, `bonds=(4, 8, 32)` gives successive `<Z0>` differences of
+about `4.7e-2` then `1.2e-2` — shrinking, but nowhere near a reasonable `tol`,
+so the verdict is `not_converged`. `bond_convergence` needs at least 3 bond
+values to make that call at all: two values alone give a single difference,
+with no way to tell whether it is closing in on `tol` or has already stalled
+(see the function's own docstring for the exact numbers). If even the largest
+bond dimension in `bonds` is still hitting its own cap, the verdict is
+`undecidable` instead of `converged` or `not_converged` — no tolerance can be
+certified from data where the truncation never had room to breathe.
+
+---
+
 ## Details
 
 ### Troubleshooting

--- a/tests/unit/test_mps.py
+++ b/tests/unit/test_mps.py
@@ -22,7 +22,7 @@ import jax.numpy as jnp
 import dense_evolution as de
 from dense_evolution.backends.mps import (
     MPSSimulator, _jsd_vectors, _vectorized_chi_search, _expand_nonlocal_2q_positions,
-    mps_pauli_expectation, mps_pauli_sum_expectation,
+    mps_pauli_expectation, mps_pauli_sum_expectation, bond_convergence,
 )
 
 def test_backward_compat_shim_mps_reexports_mpssimulator():
@@ -1280,4 +1280,48 @@ def test_complex64_run_emits_no_dtype_truncation_warning():
         assert dtype_warnings == []
 
     _run_x64(False, run)
+
+
+# ── bond_convergence (prog.txt) ──────────────────────────────────────────
+
+def _ghz_chain_ops(n_qubits):
+    ops = [["h", 0]]
+    ops += [["cx", q, q + 1] for q in range(n_qubits - 1)]
+    return ops
+
+
+def test_bond_convergence_ghz_converges_at_small_bonds():
+    n = 50
+    ops = _ghz_chain_ops(n)
+    result = bond_convergence(ops, n, [[(0, "Z"), (n - 1, "Z")]], bonds=(2, 4, 8))
+    assert result.verdicts == ["converged"]
+
+
+def test_bond_convergence_deep_brickwall_not_converged():
+    # chi_used=[4, 8, 16] here -- below the bonds=(4, 8, 32) cap at every
+    # step, so this is a genuine not_converged (not undecidable): the
+    # successive |<Z0>| discrepancies (measured: ~4.7e-2, ~1.2e-2) decrease
+    # but stay far above tol, exactly the case bond_convergence's own
+    # verdict must catch rather than declaring victory on a shrinking-but-
+    # still-large trend.
+    n, layers = 40, 4
+    ops = _brick_wall_ry_ops(n, seed=42, layers=layers)
+    result = bond_convergence(ops, n, ["Z" + "I" * (n - 1)], bonds=(4, 8, 32))
+    assert result.chi_used[-1] < result.bonds[-1]
+    assert result.verdicts == ["not_converged"]
+
+
+@pytest.mark.parametrize("bonds", [(4,), (4, 8)])
+def test_bond_convergence_requires_at_least_three_bonds(bonds):
+    ops = _ghz_chain_ops(4)
+    with pytest.raises(ValueError):
+        bond_convergence(ops, 4, ["Z" + "I" * 3], bonds=bonds)
+
+
+def test_bond_convergence_undecidable_when_cap_saturated():
+    n, layers = 12, 10
+    ops = _brick_wall_ry_ops(n, seed=7, layers=layers)
+    result = bond_convergence(ops, n, ["Z" + "I" * (n - 1)], bonds=(2, 3, 4))
+    assert result.chi_used[-1] >= result.bonds[-1]
+    assert result.verdicts == ["undecidable"]
 


### PR DESCRIPTION
Da prog.txt: `bond_convergence(ops, n_qubits, observables, bonds, **mps_kwargs)` esegue lo stesso circuito a più valori crescenti di `max_bond`, valuta le stesse osservabili su ognuno, e restituisce valori, scarti successivi, chi effettivamente usato, e un verdetto a tre stati (`converged`/`not_converged`/`undecidable`) — invece di fidarsi delle diagnostiche interne di un singolo run (`avg_jsd`, `budget_violations`), che non dicono nulla sulla convergenza dell'osservabile specifico tracciato.

**Bug reale trovato durante l'implementazione**: il controllo di decrescita monotona usava `<` stretto, che falliva erroneamente su un caso a scarto zero esatto — una catena GHZ la cui dimensione di bond non deve mai crescere, quindi ogni run dà lo stesso valore identico. Corretto a `<=`.

**Numeri del docstring/docs rimisurati su questa macchina, non copiati da prog.txt**: l'esempio n=100 di prog.txt non è riproducibile con l'helper brickwall già esistente in questo repo (gli scarti misurati sono venuti due ordini di grandezza più grandi di quanto descritto) — sostituiti con numeri reali, verificati con `bond_convergence` stessa: GHZ n=50 a bonds=(2,4,8) → scarti esattamente zero, `converged`; brickwall n=40/layers=4 a bonds=(4,8,32) → scarti ~4.7e-2 poi ~1.2e-2 (chi_used mai saturato), `not_converged`.

Verifica: `pytest tests/unit/test_mps.py` → 85 passed, 0 failed.