### PR TITLE
Bump version to 8.1.78

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -57,7 +57,7 @@ from .physics.qec import (pauli_commutes, compute_syndrome, erasure_aware_decode
                            blind_minimum_weight_decode, decode_with_erasure_fallback,
                            counts_in_intervals_dimension, nearest_coset_decode)
 
-__version__ = "8.1.77"
+__version__ = "8.1.78"
 
 __all__ = [
     "__version__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dense-evolution"
-version = "8.1.77"
+version = "8.1.78"
 description = "High-performance quantum simulation toolkit -- Statevector/MPS engines with JIT compilation, noise modeling, VQE, QEC, quantum chemistry, and agent-native tooling"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Since 8.1.77:

- **New**: `bond_convergence()` in `dense_evolution.backends.mps` — certifica se un'osservabile MPS è davvero convergente rispetto alla dimensione di bond, eseguendo lo stesso circuito a più `max_bond` crescenti (verdetto a tre stati: converged/not_converged/undecidable), invece di fidarsi delle diagnostiche di un singolo run. (#234)
- **Fix**: `dense_evolution.native_hf.bridge` andava in crash all'import senza pennylane installato (extra opzionale) — ora l'import è lazy con errore chiaro solo alla chiamata. (#233)
- **Fix**: `SafeMemoryGuard` nei test dipendeva dalla RAM reale della macchina, causando `MemoryPressureError` non deterministici — budget ora iniettabile e fissato nei test. (#233)
- **Fix**: 4 asserzioni in `test_mps.py` usavano una tolleranza troppo stretta per complex64. (#233)
- **Fix**: fuga dello stato globale `jax_enable_x64` tra moduli di test — 6 file lo impostavano a livello di modulo senza mai ripristinarlo. (#233)