### PR TITLE
Update Zenodo DOI and citation to v8.1.78

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,12 +12,12 @@ authors:
 repository-code: "https://github.com/tatopenn-cell/Dense-Evolution"
 url: "https://github.com/tatopenn-cell/Dense-Evolution"
 license: "BUSL-1.1"
-version: "8.1.74"
-doi: "10.5281/zenodo.22669081"
+version: "8.1.78"
+doi: "10.5281/zenodo.22706039"
 identifiers:
   - type: doi
     value: "10.5281/zenodo.21855643"
     description: "The concept DOI for all versions of this software."
   - type: doi
-    value: "10.5281/zenodo.22669081"
-    description: "The version-specific DOI for v8.1.74."
+    value: "10.5281/zenodo.22706039"
+    description: "The version-specific DOI for v8.1.78."

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ If Dense-Evolution is useful in academic work, please cite it via the metadata i
 Archived on [Zenodo](https://zenodo.org/):
 
 - **Concept DOI** (always resolves to the latest version): [10.5281/zenodo.21855643](https://doi.org/10.5281/zenodo.21855643)
-- **This release (v8.1.74)**: [10.5281/zenodo.22669081](https://doi.org/10.5281/zenodo.22669081)
+- **This release (v8.1.78)**: [10.5281/zenodo.22706039](https://doi.org/10.5281/zenodo.22706039)
 
 ---
 


### PR DESCRIPTION
CITATION.cff era fermo a v8.1.74 (DOI zenodo.22669081), saltato per 3 release. Zenodo ha già archiviato v8.1.78 automaticamente dopo la creazione della release GitHub — nuovo DOI versione-specifico: `10.5281/zenodo.22706039` (verificato via API Zenodo, record 22706039, version="v8.1.78"). Il DOI concetto (zenodo.21855643) resta invariato, come sempre.

Aggiornati: `version`/`doi`/`identifiers` in CITATION.cff, e la riga "This release" nella sezione Cite This del README.