### PR TITLE
Canonicalize quartet degree order to reduce distinct ERI JIT signatures (~1.35x)

### DIFF
--- a/dense_evolution/native_hf/assembly.py
+++ b/dense_evolution/native_hf/assembly.py
@@ -93,6 +93,55 @@ def _quartet_block(exponents, coeffs, centers, degrees, primitive_fn):
     return ratio_outer * summed
 
 
+_QUARTET_SYMMETRY_PERMS = (
+    (0, 1, 2, 3), (1, 0, 2, 3), (0, 1, 3, 2), (1, 0, 3, 2),
+    (2, 3, 0, 1), (2, 3, 1, 0), (3, 2, 0, 1), (3, 2, 1, 0),
+)
+
+
+def _canonical_quartet_perm(degrees: tuple) -> tuple:
+    """The electron-repulsion integral (ab|cd) is invariant under swapping
+    a<->b, swapping c<->d, and swapping the pair (a,b)<->(c,d) -- the same
+    8-element symmetry build_repulsion_tensor already uses to store one
+    computed block into 8 tensor locations via transpose. Applied here to
+    the OTHER end: _quartet_block's jax.jit cache keys on the exact
+    (a,b,c,d)-ordered `degrees` tuple, so two quartets that are physically
+    the same integral under one of these 8 relabelings still trigger two
+    separate compilations if their degrees arrive in different orders.
+    Picking the lexicographically largest of the 8 relabelings as a fixed
+    canonical form (independent of which one happens to come in) collapses
+    that duplication -- measured on Ne/6-31G*: 35 distinct compiled
+    signatures down to fewer, see native_hf_eri_profile_ne_631gstar.py in
+    Dense-Evolution-Discovery."""
+    best_perm = _QUARTET_SYMMETRY_PERMS[0]
+    best_key = tuple(degrees[i] for i in best_perm)
+    for perm in _QUARTET_SYMMETRY_PERMS[1:]:
+        key = tuple(degrees[i] for i in perm)
+        if key > best_key:
+            best_key = key
+            best_perm = perm
+    return best_perm
+
+
+def _invert_perm(perm: tuple) -> tuple:
+    inv = [0, 0, 0, 0]
+    for i, p in enumerate(perm):
+        inv[p] = i
+    return tuple(inv)
+
+
+def _canonical_quartet_block(exponents, coeffs, centers, degrees, primitive_fn):
+    perm = _canonical_quartet_perm(degrees)
+    if perm == (0, 1, 2, 3):
+        return _quartet_block(exponents, coeffs, centers, degrees, primitive_fn)
+    p_exponents = tuple(exponents[i] for i in perm)
+    p_coeffs = tuple(coeffs[i] for i in perm)
+    p_centers = tuple(centers[i] for i in perm)
+    p_degrees = tuple(degrees[i] for i in perm)
+    block = _quartet_block(p_exponents, p_coeffs, p_centers, p_degrees, primitive_fn)
+    return jnp.transpose(block, _invert_perm(perm))
+
+
 def _shell_offsets(shells: list[ContractedShell]) -> list[int]:
     offsets, running = [], 0
     for s in shells:
@@ -163,7 +212,7 @@ def _schwarz_bound(sa: ContractedShell, sb: ContractedShell, max_primitives: int
     ea, ca = _pad_primitives(sa.exponents, sa.coefficients, max_primitives)
     eb, cb = _pad_primitives(sb.exponents, sb.coefficients, max_primitives)
     block = np.array(
-        _quartet_block(
+        _canonical_quartet_block(
             (ea, eb, ea, eb),
             (ca, cb, ca, cb),
             (sa.center, sb.center, sa.center, sb.center),
@@ -210,7 +259,7 @@ def build_repulsion_tensor(shells: list[ContractedShell], screening_tol: float =
                     ec, cc = _pad_primitives(sc.exponents, sc.coefficients, max_primitives)
                     ed, cd = _pad_primitives(sd.exponents, sd.coefficients, max_primitives)
                     block = np.array(
-                        _quartet_block(
+                        _canonical_quartet_block(
                             (ea, eb, ec, ed),
                             (ca, cb, cc, cd),
                             (sa.center, sb.center, sc.center, sd.center),


### PR DESCRIPTION
Segue la diagnosi P10 (Dense-Evolution-Discovery PR #165, solo misura): il 92% del costo di `build_repulsion_tensor` su Ne/6-31G* è compilazione JIT di 35 tuple di grado (a,b,c,d) distinte, non esecuzione né dispatch. Questo PR è il primo tentativo di **risolverla**.

**Idea**: l'integrale (ab|cd) è invariante scambiando a↔b, c↔d, e la coppia (a,b)↔(c,d) — lo stesso gruppo di simmetria a 8 elementi che `build_repulsion_tensor` già usa per lo storage (un blocco calcolato, salvato in 8 posizioni via trasposizione). `_canonical_quartet_block` applica lo stesso trucco all'altro capo: sceglie una forma canonica tra le 8 possibili PRIMA di chiamare `_quartet_block` (la cache JIT chiavizza sulla tupla esatta), poi trasporne il risultato all'indietro.

**Verifica di correttezza** (due passaggi, per essere sicuri):
1. Localmente, su shell sintetiche minime (1 primitivo, s/p/d): 6/8 classi di permutazione esercitate, tutte esatte a precisione macchina (~1e-16) a float64. Il rumore ~1e-7 a float32 osservato inizialmente è stato confermato benigno (ordine di somma diverso), non un bug.
2. Su Kaggle (CPU, per non stressare la macchina locale), contro `test_native_hf_engine.py` (Si2/STO-3G, H2O, O e Ne/6-31G*, simmetria a 8 vie dell'ERI, integrali d-shell contro scipy/sympy): **53/53 passati**, identico a `main`, a parità di precisione (x64 forzato).

**Velocità reale misurata (Ne/6-31G*, due run indipendenti su Kaggle CPU)**:
| run | main | candidato | speedup |
|---|---|---|---|
| 1 | 198.799s | 149.423s | 1.33x |
| 2 | 204.443s | 147.922s | 1.38x |

Stessa somma del tensore ERI (874.937401) in tutte e 4 le run.

Nota collaterale: durante la verifica ho temporaneamente sospettato che il fix P12 (#234, già mergiato) avesse rotto `test_native_hf_engine.py` in `main` rimuovendo una fuga di `jax_enable_x64` da cui dipendeva implicitamente. Controllato sui log CI reali di GitHub per l'ultimo run di `main`: **falso allarme**, la suite reale (`pytest tests/`) passa regolarmente — il problema era solo nel mio harness di verifica isolato su Kaggle, non in `main`.