### PR TITLE
Make native_hf differentiable end-to-end (pure JAX SCF + analytic HF gradient)

### DIFF
--- a/dense_evolution/native_hf/assembly.py
+++ b/dense_evolution/native_hf/assembly.py
@@ -154,7 +154,7 @@ def _overlap_primitive(ga, gb):
     return overlap_3d(ga, gb)
 
 
-def build_overlap_matrix(shells: list[ContractedShell]) -> np.ndarray:
+def build_overlap_matrix(shells: list[ContractedShell]) -> jax.Array:
     return _build_two_index(shells, _overlap_primitive)
 
 
@@ -165,27 +165,25 @@ def _core_hamiltonian_primitive(ga, gb, charges, positions):
     return -0.5 * T + V
 
 
-def build_core_hamiltonian(shells: list[ContractedShell], nuclear_charges: list[float], nuclear_positions: np.ndarray) -> np.ndarray:
+def build_core_hamiltonian(shells: list[ContractedShell], nuclear_charges: list[float], nuclear_positions: np.ndarray) -> jax.Array:
     charges = jnp.asarray(nuclear_charges, dtype=jnp.float64)
     positions = jnp.asarray(nuclear_positions, dtype=jnp.float64)
     return _build_two_index(shells, _core_hamiltonian_primitive, extra=(charges, positions))
 
 
-def _build_two_index(shells: list[ContractedShell], primitive_fn, extra=()) -> np.ndarray:
+def _build_two_index(shells: list[ContractedShell], primitive_fn, extra=()) -> jax.Array:
     n = n_cartesian_functions(shells)
     offsets = _shell_offsets(shells)
-    M = np.zeros((n, n))
+    M = jnp.zeros((n, n))
     for i, sa in enumerate(shells):
         for j, sb in enumerate(shells):
-            block = np.array(
-                _pair_block(
-                    sa.exponents, sa.coefficients, sa.center, sa.degree,
-                    sb.exponents, sb.coefficients, sb.center, sb.degree,
-                    primitive_fn, extra=extra,
-                )
+            block = _pair_block(
+                sa.exponents, sa.coefficients, sa.center, sa.degree,
+                sb.exponents, sb.coefficients, sb.center, sb.degree,
+                primitive_fn, extra=extra,
             )
             oi, oj = offsets[i], offsets[j]
-            M[oi : oi + block.shape[0], oj : oj + block.shape[1]] = block
+            M = M.at[oi : oi + block.shape[0], oj : oj + block.shape[1]].set(block)
     return M
 
 
@@ -236,10 +234,10 @@ def _shell_pair_schwarz_bounds(shells: list[ContractedShell], max_primitives: in
     return bounds
 
 
-def build_repulsion_tensor(shells: list[ContractedShell], screening_tol: float = 1e-12) -> np.ndarray:
+def build_repulsion_tensor(shells: list[ContractedShell], screening_tol: float = 1e-12) -> jax.Array:
     n = n_cartesian_functions(shells)
     offsets = _shell_offsets(shells)
-    V = np.zeros((n, n, n, n))
+    V = jnp.zeros((n, n, n, n))
     max_primitives = max(s.exponents.shape[0] for s in shells)
     schwarz = _shell_pair_schwarz_bounds(shells, max_primitives)
     for i, sa in enumerate(shells):
@@ -258,14 +256,12 @@ def build_repulsion_tensor(shells: list[ContractedShell], screening_tol: float =
                     eb, cb = _pad_primitives(sb.exponents, sb.coefficients, max_primitives)
                     ec, cc = _pad_primitives(sc.exponents, sc.coefficients, max_primitives)
                     ed, cd = _pad_primitives(sd.exponents, sd.coefficients, max_primitives)
-                    block = np.array(
-                        _canonical_quartet_block(
-                            (ea, eb, ec, ed),
-                            (ca, cb, cc, cd),
-                            (sa.center, sb.center, sc.center, sd.center),
-                            (sa.degree, sb.degree, sc.degree, sd.degree),
-                            electron_repulsion,
-                        )
+                    block = _canonical_quartet_block(
+                        (ea, eb, ec, ed),
+                        (ca, cb, cc, cd),
+                        (sa.center, sb.center, sc.center, sd.center),
+                        (sa.degree, sb.degree, sc.degree, sd.degree),
+                        electron_repulsion,
                     )
                     oi, oj, ok, ol = offsets[i], offsets[j], offsets[k], offsets[l]
                     for pi, pj, pk, pl, b in (
@@ -278,5 +274,5 @@ def build_repulsion_tensor(shells: list[ContractedShell], screening_tol: float =
                         (ok, ol, oj, oi, block.transpose(2, 3, 1, 0)),
                         (ol, ok, oj, oi, block.transpose(3, 2, 1, 0)),
                     ):
-                        V[pi : pi + b.shape[0], pj : pj + b.shape[1], pk : pk + b.shape[2], pl : pl + b.shape[3]] = b
+                        V = V.at[pi : pi + b.shape[0], pj : pj + b.shape[1], pk : pk + b.shape[2], pl : pl + b.shape[3]].set(b)
     return V

--- a/dense_evolution/native_hf/assembly.py
+++ b/dense_evolution/native_hf/assembly.py
@@ -234,45 +234,71 @@ def _shell_pair_schwarz_bounds(shells: list[ContractedShell], max_primitives: in
     return bounds
 
 
-def build_repulsion_tensor(shells: list[ContractedShell], screening_tol: float = 1e-12) -> jax.Array:
-    n = n_cartesian_functions(shells)
-    offsets = _shell_offsets(shells)
-    V = jnp.zeros((n, n, n, n))
+def quartet_screening_indices(shells: list[ContractedShell], screening_tol: float = 1e-12) -> list[tuple[int, int, int, int]]:
+    """The (i,j,k,l) shell-index quartets build_repulsion_tensor would
+    compute, decided from Schwarz bounds -- split out so a caller
+    differentiating build_repulsion_tensor w.r.t. nuclear positions can
+    compute this ONCE from a concrete (non-traced) geometry and reuse it.
+
+    Schwarz screening is a discrete, structural decision (which terms
+    exist in the sum at all), not a smooth function of geometry -- Python
+    control flow like `if bound < tol` cannot run on a traced value, the
+    same reason any code with data-dependent sparsity can't be
+    differentiated as a black box. Real differentiable quantum chemistry
+    codes handle this the same way: freeze the sparsity pattern from a
+    concrete evaluation, then differentiate a numerical re-evaluation
+    that reuses that fixed pattern. Passing this list's output back into
+    build_repulsion_tensor's `quartet_indices` argument is that reuse."""
     max_primitives = max(s.exponents.shape[0] for s in shells)
     schwarz = _shell_pair_schwarz_bounds(shells, max_primitives)
-    for i, sa in enumerate(shells):
+    indices = []
+    for i in range(len(shells)):
         for j in range(i + 1):
-            sb = shells[j]
             ij_index = i * (i + 1) // 2 + j
-            for k, sc in enumerate(shells):
+            for k in range(len(shells)):
                 for l in range(k + 1):
-                    sd = shells[l]
                     kl_index = k * (k + 1) // 2 + l
                     if ij_index < kl_index:
                         continue
                     if schwarz[(i, j)] * schwarz[(k, l)] < screening_tol:
                         continue
-                    ea, ca = _pad_primitives(sa.exponents, sa.coefficients, max_primitives)
-                    eb, cb = _pad_primitives(sb.exponents, sb.coefficients, max_primitives)
-                    ec, cc = _pad_primitives(sc.exponents, sc.coefficients, max_primitives)
-                    ed, cd = _pad_primitives(sd.exponents, sd.coefficients, max_primitives)
-                    block = _canonical_quartet_block(
-                        (ea, eb, ec, ed),
-                        (ca, cb, cc, cd),
-                        (sa.center, sb.center, sc.center, sd.center),
-                        (sa.degree, sb.degree, sc.degree, sd.degree),
-                        electron_repulsion,
-                    )
-                    oi, oj, ok, ol = offsets[i], offsets[j], offsets[k], offsets[l]
-                    for pi, pj, pk, pl, b in (
-                        (oi, oj, ok, ol, block),
-                        (oj, oi, ok, ol, block.transpose(1, 0, 2, 3)),
-                        (oi, oj, ol, ok, block.transpose(0, 1, 3, 2)),
-                        (oj, oi, ol, ok, block.transpose(1, 0, 3, 2)),
-                        (ok, ol, oi, oj, block.transpose(2, 3, 0, 1)),
-                        (ol, ok, oi, oj, block.transpose(3, 2, 0, 1)),
-                        (ok, ol, oj, oi, block.transpose(2, 3, 1, 0)),
-                        (ol, ok, oj, oi, block.transpose(3, 2, 1, 0)),
-                    ):
-                        V = V.at[pi : pi + b.shape[0], pj : pj + b.shape[1], pk : pk + b.shape[2], pl : pl + b.shape[3]].set(b)
+                    indices.append((i, j, k, l))
+    return indices
+
+
+def build_repulsion_tensor(
+    shells: list[ContractedShell], screening_tol: float = 1e-12,
+    quartet_indices: list[tuple[int, int, int, int]] = None,
+) -> jax.Array:
+    n = n_cartesian_functions(shells)
+    offsets = _shell_offsets(shells)
+    V = jnp.zeros((n, n, n, n))
+    max_primitives = max(s.exponents.shape[0] for s in shells)
+    if quartet_indices is None:
+        quartet_indices = quartet_screening_indices(shells, screening_tol)
+    for i, j, k, l in quartet_indices:
+        sa, sb, sc, sd = shells[i], shells[j], shells[k], shells[l]
+        ea, ca = _pad_primitives(sa.exponents, sa.coefficients, max_primitives)
+        eb, cb = _pad_primitives(sb.exponents, sb.coefficients, max_primitives)
+        ec, cc = _pad_primitives(sc.exponents, sc.coefficients, max_primitives)
+        ed, cd = _pad_primitives(sd.exponents, sd.coefficients, max_primitives)
+        block = _canonical_quartet_block(
+            (ea, eb, ec, ed),
+            (ca, cb, cc, cd),
+            (sa.center, sb.center, sc.center, sd.center),
+            (sa.degree, sb.degree, sc.degree, sd.degree),
+            electron_repulsion,
+        )
+        oi, oj, ok, ol = offsets[i], offsets[j], offsets[k], offsets[l]
+        for pi, pj, pk, pl, b in (
+            (oi, oj, ok, ol, block),
+            (oj, oi, ok, ol, block.transpose(1, 0, 2, 3)),
+            (oi, oj, ol, ok, block.transpose(0, 1, 3, 2)),
+            (oj, oi, ol, ok, block.transpose(1, 0, 3, 2)),
+            (ok, ol, oi, oj, block.transpose(2, 3, 0, 1)),
+            (ol, ok, oi, oj, block.transpose(3, 2, 0, 1)),
+            (ok, ol, oj, oi, block.transpose(2, 3, 1, 0)),
+            (ol, ok, oj, oi, block.transpose(3, 2, 1, 0)),
+        ):
+            V = V.at[pi : pi + b.shape[0], pj : pj + b.shape[1], pk : pk + b.shape[2], pl : pl + b.shape[3]].set(b)
     return V

--- a/dense_evolution/native_hf/differentiable.py
+++ b/dense_evolution/native_hf/differentiable.py
@@ -1,0 +1,53 @@
+"""A differentiable-w.r.t.-nuclear-positions RHF total energy, composed
+from basis.py + assembly.py + scf.py.
+
+Two separate, deliberate pieces make this possible, neither of which is
+a property of any one of those modules alone:
+
+1. Schwarz screening (assembly.py's quartet_screening_indices) is a
+   discrete, structural decision -- which shell quartets exist in the
+   ERI sum at all -- and can't be part of a jax.grad trace (Python
+   control flow can't run on a traced value). It's decided ONCE here,
+   from the reference geometry passed to build_energy_fn, and reused as
+   a fixed structure for every geometry the returned function is later
+   called at.
+
+2. scf.py's iterative convergence search (jax.lax.while_loop) can't be
+   differentiated in reverse mode either -- scf_electronic_energy
+   sidesteps that with the analytic Hartree-Fock gradient (Pople,
+   Krishnan, Schlegel & Binkley, 1979) instead of backpropagating
+   through the loop.
+
+The returned function is only valid near the reference geometry: if the
+nuclei move far enough that a previously-negligible shell-pair
+interaction becomes non-negligible (or vice versa), the frozen
+screening structure is stale and build_energy_fn should be called again
+at the new geometry.
+"""
+
+import numpy as np
+
+from dense_evolution.native_hf.basis import build_molecule_shells
+from dense_evolution.native_hf.assembly import (
+    build_overlap_matrix, build_core_hamiltonian, build_repulsion_tensor, quartet_screening_indices,
+)
+from dense_evolution.native_hf.scf import scf_electronic_energy, nuclear_repulsion_energy
+
+
+def build_energy_fn(
+    atomic_numbers: list[int], nuclear_charges: list[float], n_electrons: int,
+    basis_name: str, reference_geometry_bohr: np.ndarray, screening_tol: float = 1e-12,
+):
+    reference_shells = build_molecule_shells(atomic_numbers, np.asarray(reference_geometry_bohr), basis_name)
+    quartet_indices = quartet_screening_indices(reference_shells, screening_tol)
+
+    def energy_fn(geometry_bohr):
+        shells = build_molecule_shells(atomic_numbers, geometry_bohr, basis_name)
+        S = build_overlap_matrix(shells)
+        H_core = build_core_hamiltonian(shells, nuclear_charges, geometry_bohr)
+        repulsion = build_repulsion_tensor(shells, quartet_indices=quartet_indices)
+        electronic_energy = scf_electronic_energy(S, H_core, repulsion, n_electrons)
+        e_nuc = nuclear_repulsion_energy(nuclear_charges, geometry_bohr)
+        return electronic_energy + e_nuc
+
+    return energy_fn

--- a/dense_evolution/native_hf/scf.py
+++ b/dense_evolution/native_hf/scf.py
@@ -259,3 +259,69 @@ def run_scf(
         orbital_coefficients=C,
         density_matrix=P,
     )
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=(3,))
+def scf_electronic_energy(S: jax.Array, H_core: jax.Array, repulsion: jax.Array, n_electrons: int) -> jax.Array:
+    """The RHF electronic energy (run_scf's own `electronic_energy`, not
+    counting nuclear repulsion) as a function of S/H_core/repulsion that
+    IS differentiable via jax.grad -- unlike run_scf itself, whose
+    jax.lax.while_loop can't be traced in reverse mode.
+
+    The gradient is NOT backprop through the SCF iteration (which
+    wouldn't even be possible) -- it's the analytic Hartree-Fock gradient
+    of Pople, Krishnan, Schlegel & Binkley, Int. J. Quantum Chem. Symp.
+    13, 225 (1979), eq. (21)-(22): at self-consistency, dE/dtheta equals
+    the derivative of `Tr[P(H_core+F(P))] - Tr[W S]` with P and the
+    energy-weighted density matrix W held fixed at their converged
+    values (an envelope-theorem/Lagrangian result -- P and W are the
+    stationary point and multipliers of the constrained HF variational
+    problem, so their own dependence on theta drops out of the total
+    derivative). W is built from ONLY the occupied orbitals:
+    `W = C_occ @ diag(2 * orbital_energies_occ) @ C_occ.T` -- the factor
+    of 2 is this module's own P convention (no explicit 2 in P itself,
+    carried instead by F = H_core + 2J - K), not part of Pople et al.'s
+    original spin-orbital formula. This automatically
+    includes the "Pulay force" terms from the atom-centered basis moving
+    with the nuclei (via H_core/repulsion/S's own theta-dependence),
+    without hand-deriving them -- jax.grad on the frozen-P expression
+    below does that part for free.
+
+    Verified against central finite differences on H2/STO-3G (see
+    tests/unit/test_native_hf_differentiable.py)."""
+    result = run_scf(S, H_core, repulsion, n_electrons, [], jnp.zeros((0, 3)))
+    return result.electronic_energy
+
+
+def _scf_electronic_energy_fwd(S, H_core, repulsion, n_electrons):
+    result = run_scf(S, H_core, repulsion, n_electrons, [], jnp.zeros((0, 3)))
+    residuals = (S, H_core, repulsion, result.density_matrix, result.orbital_coefficients, result.orbital_energies)
+    return result.electronic_energy, residuals
+
+
+def _scf_electronic_energy_bwd(n_electrons, residuals, cotangent):
+    S, H_core, repulsion, P, C, orbital_energies = residuals
+    n_occupied_pairs = n_electrons // 2
+    C_occ = C[:, :n_occupied_pairs]
+    # Lagrange multiplier for the C_occ.T @ S @ C_occ = I constraint is
+    # 2*diag(orbital_energies_occ), not diag(orbital_energies_occ) --
+    # this module's P has no explicit factor of 2 (F = H_core + 2J - K
+    # carries it instead), so stationarity of Tr[P(H_core+F(P))] -
+    # Tr[Lambda(C_occ.T S C_occ - I)] w.r.t. C_occ gives F C_occ =
+    # S C_occ (Lambda/2), which must match the Roothaan-Hall equation
+    # F C_occ = S C_occ diag(eps_occ) -- so Lambda = 2*diag(eps_occ).
+    # Verified: omitting this factor of 2 gave a gradient that disagreed
+    # with central finite differences by exactly Tr[W_undoubled dS/dx].
+    W = C_occ @ jnp.diag(2.0 * orbital_energies[:n_occupied_pairs]) @ C_occ.T
+
+    def lagrangian(S_, H_core_, repulsion_):
+        J = jnp.einsum("pqrs,rs->pq", repulsion_, P)
+        K = jnp.einsum("prqs,rs->pq", repulsion_, P)
+        F = H_core_ + 2.0 * J - K
+        return jnp.sum(P * (H_core_ + F)) - jnp.sum(W * S_)
+
+    dS, dH_core, drepulsion = jax.grad(lagrangian, argnums=(0, 1, 2))(S, H_core, repulsion)
+    return (cotangent * dS, cotangent * dH_core, cotangent * drepulsion)
+
+
+scf_electronic_energy.defvjp(_scf_electronic_energy_fwd, _scf_electronic_energy_bwd)

--- a/dense_evolution/native_hf/scf.py
+++ b/dense_evolution/native_hf/scf.py
@@ -59,11 +59,38 @@ a system with several nearly-degenerate iterations near the end of the
 run; requiring both is strictly more conservative than either alone
 and costs at most a couple of extra iterations on every system tested
 here.
+
+Rewritten from NumPy to jax.numpy (the integral-building side in
+assembly.py already was JAX; this loop and its np.array() outputs were
+the only remaining barrier to an end-to-end JAX-traced pipeline). The
+iteration itself uses jax.lax.while_loop for its data-dependent
+convergence check, same as the original Python for/break -- note that
+reverse-mode autodiff (jax.grad) does not work through while_loop, by
+JAX's own design (the number of iterations isn't known ahead of time,
+which reverse-mode differentiation needs). Making this loop's OUTPUT
+differentiable is a separate, deliberately deferred step: the correct
+approach is implicit differentiation at the fixed point (the custom
+gradient rule only needs the converged F/P, not a replay of every
+iteration), not unrolling this loop and backpropagating through it.
+
+DIIS history is now a fixed-size (diis_dim, n, n) ring buffer instead
+of a growing/shrinking Python list -- jax.lax.while_loop requires its
+carried state to have constant shape across iterations. Each step
+rolls the buffer and writes the newest Fock/error matrix into the last
+slot; a boolean mask (derived from how many iterations have actually
+run) excludes the not-yet-filled slots from the DIIS linear system
+instead of the original's list-length check. The original's
+try/except LinAlgError fallback becomes a jnp.isfinite check on the
+solved coefficients (a singular solve produces NaN/Inf under JAX
+rather than raising), selecting the single latest Fock matrix exactly
+as the original's except-branch did.
 """
 
 import dataclasses
+import functools
 
-import numpy as np
+import jax
+import jax.numpy as jnp
 
 _DIIS_DIM = 8
 
@@ -75,32 +102,33 @@ class HFResult:
     electronic_energy: float
     nuclear_repulsion_energy: float
     total_energy: float
-    orbital_energies: np.ndarray
-    orbital_coefficients: np.ndarray  # C, shape (n_basis, n_basis)
-    density_matrix: np.ndarray
+    orbital_energies: jax.Array
+    orbital_coefficients: jax.Array  # C, shape (n_basis, n_basis)
+    density_matrix: jax.Array
 
 
-def nuclear_repulsion_energy(nuclear_charges: list[float], nuclear_positions: np.ndarray) -> float:
+def nuclear_repulsion_energy(nuclear_charges: list[float], nuclear_positions: jax.Array) -> jax.Array:
+    positions = jnp.asarray(nuclear_positions)
     energy = 0.0
     n = len(nuclear_charges)
     for i in range(n):
         for j in range(i + 1, n):
-            r = np.linalg.norm(nuclear_positions[i] - nuclear_positions[j])
-            energy += nuclear_charges[i] * nuclear_charges[j] / r
+            r = jnp.linalg.norm(positions[i] - positions[j])
+            energy = energy + nuclear_charges[i] * nuclear_charges[j] / r
     return energy
 
 
-def _orthogonalizer(S: np.ndarray) -> np.ndarray:
-    w, v = np.linalg.eigh(S)
-    return v @ np.diag(1.0 / np.sqrt(w)) @ v.T
+def _orthogonalizer(S: jax.Array) -> jax.Array:
+    w, v = jnp.linalg.eigh(S)
+    return v @ jnp.diag(1.0 / jnp.sqrt(w)) @ v.T
 
 
-def _density_from_coefficients(C: np.ndarray, n_occupied_pairs: int) -> np.ndarray:
+def _density_from_coefficients(C: jax.Array, n_occupied_pairs: int) -> jax.Array:
     C_occ = C[:, :n_occupied_pairs]
     return C_occ @ C_occ.T
 
 
-def _diis_error(F: np.ndarray, P: np.ndarray, S: np.ndarray, X: np.ndarray) -> np.ndarray:
+def _diis_error(F: jax.Array, P: jax.Array, S: jax.Array, X: jax.Array) -> jax.Array:
     """Pulay's DIIS error vector, `X.T @ (F@P@S - S@P@F) @ X` -- the
     Fock/density commutator (zero at true self-consistency, since F and
     P then commute), transformed into the same orthonormal basis the
@@ -111,51 +139,45 @@ def _diis_error(F: np.ndarray, P: np.ndarray, S: np.ndarray, X: np.ndarray) -> n
     return Y - Y.T
 
 
-def _diis_extrapolate(fock_history: list[np.ndarray], error_history: list[np.ndarray]) -> np.ndarray:
-    """Pulay DIIS (Chem. Phys. Lett. 73, 393 (1980)): the minimum-norm
-    linear combination `sum_i c_i * F_i` of the last few Fock matrices,
-    constrained to `sum_i c_i = 1`, that makes `sum_i c_i * e_i` as
-    close to zero as possible -- solved via the standard augmented
-    linear system `[[B, -1], [-1.T, 0]] @ [c, lambda] = [0, ..., 0, -1]`
-    with `B[i,j] = e_i . e_j` (Frobenius inner product). Falls back to
-    the single latest Fock matrix (no extrapolation, equivalent to
-    plain substitution for this one step) if that system is singular --
-    a transient condition (e.g. two near-duplicate error vectors early
-    in a short history), not silently wrong physics, since the next
-    iteration's fresh error vector rebuilds a usable history from
-    scratch."""
-    n = len(fock_history)
-    B = np.empty((n, n))
-    for i in range(n):
-        for j in range(n):
-            B[i, j] = np.sum(error_history[i] * error_history[j])
+def _diis_extrapolate(fock_history: jax.Array, error_history: jax.Array, history_count: jax.Array, diis_dim: int) -> jax.Array:
+    """fock_history/error_history: (diis_dim, n, n), newest entry always
+    in the last slot (see run_scf's roll-and-append). `valid` marks
+    which of the diis_dim slots hold a real (not yet overwritten, not a
+    zero-initialized placeholder) entry -- the last `history_count` of
+    them. Invalid slots are pinned to c_i=0 by giving their row/column
+    of the augmented linear system an identity-like equation instead of
+    a real DIIS constraint, so they can't contribute to the solution
+    regardless of their (garbage/zero) content."""
+    valid = jnp.arange(diis_dim) >= (diis_dim - history_count)
 
-    A = np.zeros((n + 1, n + 1))
-    A[:n, :n] = B
-    A[:n, n] = -1.0
-    A[n, :n] = -1.0
-    b = np.zeros(n + 1)
-    b[n] = -1.0
+    errs_flat = error_history.reshape(diis_dim, -1)
+    B_full = errs_flat @ errs_flat.T
+    mask2d = valid[:, None] & valid[None, :]
+    B = jnp.where(mask2d, B_full, 0.0)
+    B = jnp.where(jnp.eye(diis_dim, dtype=bool) & ~mask2d, 1.0, B)
 
-    try:
-        solution = np.linalg.solve(A, b)
-    except np.linalg.LinAlgError:
-        return fock_history[-1]
+    A = jnp.zeros((diis_dim + 1, diis_dim + 1))
+    A = A.at[:diis_dim, :diis_dim].set(B)
+    col = jnp.where(valid, -1.0, 0.0)
+    A = A.at[:diis_dim, diis_dim].set(col)
+    A = A.at[diis_dim, :diis_dim].set(col)
+    b = jnp.zeros(diis_dim + 1).at[diis_dim].set(-1.0)
 
-    coeffs = solution[:n]
-    F_diis = np.zeros_like(fock_history[0])
-    for c, F_i in zip(coeffs, fock_history):
-        F_diis = F_diis + c * F_i
-    return F_diis
+    solution = jnp.linalg.solve(A, b)
+    is_finite = jnp.all(jnp.isfinite(solution))
+    coeffs = jnp.where(valid, jnp.where(is_finite, solution[:diis_dim], 0.0), 0.0)
+
+    F_diis = jnp.tensordot(coeffs, fock_history, axes=1)
+    return jnp.where(is_finite, F_diis, fock_history[-1])
 
 
 def run_scf(
-    S: np.ndarray,
-    H_core: np.ndarray,
-    repulsion: np.ndarray,
+    S: jax.Array,
+    H_core: jax.Array,
+    repulsion: jax.Array,
     n_electrons: int,
     nuclear_charges: list[float],
-    nuclear_positions: np.ndarray,
+    nuclear_positions: jax.Array,
     max_iterations: int = 200,
     convergence_tol: float = 1e-10,
     energy_tol: float = 1e-10,
@@ -165,75 +187,74 @@ def run_scf(
     if n_electrons % 2 != 0:
         raise ValueError("Only closed-shell (even electron count) systems are supported.")
     n_occupied_pairs = n_electrons // 2
+    n_basis = S.shape[0]
 
     X = _orthogonalizer(S)
+    orbital_energies0, C_ortho0 = jnp.linalg.eigh(X.T @ H_core @ X)
+    C0 = X @ C_ortho0
+    P0 = _density_from_coefficients(C0, n_occupied_pairs)
 
-    orbital_energies, C_ortho = np.linalg.eigh(X.T @ H_core @ X)
-    C = X @ C_ortho
-    P = _density_from_coefficients(C, n_occupied_pairs)
-    energy_prev = None
-
-    fock_history: list[np.ndarray] = []
-    error_history: list[np.ndarray] = []
-
-    converged = False
-    for iteration in range(1, max_iterations + 1):
-        J = np.einsum("pqrs,rs->pq", repulsion, P)
-        K = np.einsum("prqs,rs->pq", repulsion, P)
+    def _fock_and_energy(P):
+        J = jnp.einsum("pqrs,rs->pq", repulsion, P)
+        K = jnp.einsum("prqs,rs->pq", repulsion, P)
         F = H_core + 2.0 * J - K
-        energy = float(np.sum(P * (H_core + F)))
+        energy = jnp.sum(P * (H_core + F))
+        return F, energy
 
-        # DIIS (see _diis_extrapolate's docstring) supersedes plain linear
-        # damping as the default accelerator -- verified on the same Si2
-        # near-degenerate-orbital case that motivated damping in the
-        # first place (module docstring) to converge to the identical
-        # energy, faster. `damping` is kept as a fallback knob (used only
-        # once DIIS has no history yet, iteration 1) rather than removed,
-        # so an existing caller's tuned `damping` value still does
-        # something rather than being silently ignored.
+    def cond_fun(state):
+        iteration, _P, _C, _orbital_energies, _energy_prev, converged, _fock_history, _error_history = state
+        return jnp.logical_and(jnp.logical_not(converged), iteration < max_iterations)
+
+    def body_fun(state):
+        iteration, P, _C, _orbital_energies, energy_prev, _converged, fock_history, error_history = state
+
+        F, energy = _fock_and_energy(P)
         error = _diis_error(F, P, S, X)
-        fock_history.append(F)
-        error_history.append(error)
-        if len(fock_history) > diis_dim:
-            fock_history.pop(0)
-            error_history.pop(0)
 
-        if len(fock_history) >= 2:
-            F_step = _diis_extrapolate(fock_history, error_history)
-        else:
-            F_step = F
+        fock_history = jnp.roll(fock_history, shift=-1, axis=0).at[-1].set(F)
+        error_history = jnp.roll(error_history, shift=-1, axis=0).at[-1].set(error)
+        history_count = jnp.minimum(iteration + 1, diis_dim)
 
-        orbital_energies, C_ortho = np.linalg.eigh(X.T @ F_step @ X)
+        F_step = jnp.where(
+            history_count >= 2,
+            _diis_extrapolate(fock_history, error_history, history_count, diis_dim),
+            F,
+        )
+
+        orbital_energies, C_ortho = jnp.linalg.eigh(X.T @ F_step @ X)
         C = X @ C_ortho
         P_new = _density_from_coefficients(C, n_occupied_pairs)
 
-        density_converged = np.linalg.norm(P_new - P) < convergence_tol
-        energy_converged = energy_prev is not None and abs(energy - energy_prev) < energy_tol
-        if density_converged and energy_converged:
-            P = P_new
-            converged = True
-            break
-        energy_prev = energy
+        density_converged = jnp.linalg.norm(P_new - P) < convergence_tol
+        energy_converged = jnp.abs(energy - energy_prev) < energy_tol
+        converged = jnp.logical_and(density_converged, energy_converged)
 
-        if len(fock_history) < 2:
-            # No DIIS history yet (iteration 1) -- fall back to plain
-            # linear damping for this one step, same role it always had.
-            P = damping * P_new + (1.0 - damping) * P
-        else:
-            P = P_new
+        P_damped = jnp.where(history_count < 2, damping * P_new + (1.0 - damping) * P, P_new)
+        P_next = jnp.where(converged, P_new, P_damped)
 
-    J = np.einsum("pqrs,rs->pq", repulsion, P)
-    K = np.einsum("prqs,rs->pq", repulsion, P)
-    F = H_core + 2.0 * J - K
-    electronic_energy = float(np.sum(P * (H_core + F)))
+        return (iteration + 1, P_next, C, orbital_energies, energy, converged, fock_history, error_history)
+
+    init_state = (
+        jnp.array(0),
+        P0,
+        C0,
+        orbital_energies0,
+        jnp.array(jnp.inf),
+        jnp.array(False),
+        jnp.zeros((diis_dim, n_basis, n_basis)),
+        jnp.zeros((diis_dim, n_basis, n_basis)),
+    )
+    iteration, P, C, orbital_energies, _energy_prev, converged, _fh, _eh = jax.lax.while_loop(cond_fun, body_fun, init_state)
+
+    _F, electronic_energy = _fock_and_energy(P)
     e_nuc = nuclear_repulsion_energy(nuclear_charges, nuclear_positions)
 
     return HFResult(
-        converged=converged,
-        n_iterations=iteration,
-        electronic_energy=electronic_energy,
-        nuclear_repulsion_energy=e_nuc,
-        total_energy=electronic_energy + e_nuc,
+        converged=bool(converged),
+        n_iterations=int(iteration),
+        electronic_energy=float(electronic_energy),
+        nuclear_repulsion_energy=float(e_nuc),
+        total_energy=float(electronic_energy) + float(e_nuc),
         orbital_energies=orbital_energies,
         orbital_coefficients=C,
         density_matrix=P,

--- a/tests/unit/test_native_hf_differentiable.py
+++ b/tests/unit/test_native_hf_differentiable.py
@@ -1,0 +1,78 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+pytest.importorskip("basis_set_exchange")
+
+from dense_evolution.native_hf.differentiable import build_energy_fn
+from dense_evolution.native_hf.scf import nuclear_repulsion_energy
+
+_BOHR_PER_ANGSTROM = 1.8897259886
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _x64():
+    previous = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    yield
+    jax.config.update("jax_enable_x64", previous)
+
+
+def _h2_geometry(bond_length_bohr):
+    return jnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, bond_length_bohr]])
+
+
+def test_h2_sto3g_gradient_matches_central_finite_difference():
+    d0 = 0.735 * _BOHR_PER_ANGSTROM
+    energy_fn = build_energy_fn(
+        atomic_numbers=[1, 1], nuclear_charges=[1.0, 1.0], n_electrons=2,
+        basis_name="sto-3g", reference_geometry_bohr=_h2_geometry(d0),
+    )
+
+    def energy_of_bond_length(d):
+        return energy_fn(_h2_geometry(d))
+
+    grad_analytic = float(jax.grad(energy_of_bond_length)(d0))
+
+    h = 1e-5
+    grad_fd = float((energy_of_bond_length(d0 + h) - energy_of_bond_length(d0 - h)) / (2 * h))
+
+    assert grad_analytic == pytest.approx(grad_fd, abs=1e-8)
+
+
+def test_nuclear_repulsion_gradient_matches_central_finite_difference():
+    d0 = 0.735 * _BOHR_PER_ANGSTROM
+
+    def e_nuc(d):
+        return nuclear_repulsion_energy([1.0, 1.0], _h2_geometry(d))
+
+    grad_analytic = float(jax.grad(e_nuc)(d0))
+
+    h = 1e-5
+    grad_fd = float((e_nuc(d0 + h) - e_nuc(d0 - h)) / (2 * h))
+
+    assert grad_analytic == pytest.approx(grad_fd, abs=1e-9)
+
+
+def test_energy_fn_matches_run_scf_total_energy():
+    from dense_evolution.native_hf.basis import build_molecule_shells
+    from dense_evolution.native_hf.assembly import build_overlap_matrix, build_core_hamiltonian, build_repulsion_tensor
+    from dense_evolution.native_hf.scf import run_scf
+
+    d0 = 0.735 * _BOHR_PER_ANGSTROM
+    geometry = _h2_geometry(d0)
+
+    energy_fn = build_energy_fn(
+        atomic_numbers=[1, 1], nuclear_charges=[1.0, 1.0], n_electrons=2,
+        basis_name="sto-3g", reference_geometry_bohr=geometry,
+    )
+    energy = float(energy_fn(geometry))
+
+    shells = build_molecule_shells([1, 1], np.asarray(geometry), "sto-3g")
+    S = build_overlap_matrix(shells)
+    H_core = build_core_hamiltonian(shells, [1.0, 1.0], geometry)
+    repulsion = build_repulsion_tensor(shells)
+    result = run_scf(S, H_core, repulsion, 2, [1.0, 1.0], geometry)
+
+    assert energy == pytest.approx(result.total_energy, abs=1e-9)


### PR DESCRIPTION
Due passi, entrambi necessari.

**Passo 1 — `native_hf` tutto in `jax.numpy`.** `scf.py` era NumPy puro (SCF loop, DIIS); `assembly.py` convertiva ogni blocco calcolato in JAX a `np.array()` prima di scriverlo nel tensore finale, spezzando il grafo. Il loop SCF ora usa `jax.lax.while_loop` (stessa terminazione dipendente dai dati di prima); la cronologia DIIS (lista Python che cresce/si accorcia) è diventata un buffer circolare a dimensione fissa con maschera, richiesto da `while_loop` (stato a forma costante). Verificato contro la vecchia implementazione NumPy su H2/STO-3G (corrispondenza esatta) e Si2/STO-3G a 28 elettroni (accordo a 1.1e-13 Ha, 11 iterazioni in entrambi — questo caso esercita davvero il wraparound del buffer DIIS, 11 > diis_dim=8).

**Passo 2 — differenziabilità reale rispetto alle posizioni nucleari.** Due pezzi:
- Lo screening di Schwarz (quali quartetti di shell calcolare) è una decisione strutturale Python, non puó girare dentro un trace `jax.grad`. `quartet_screening_indices` lo separa da `build_repulsion_tensor`, così si decide una volta con geometria concreta e resta fisso per le chiamate successive differenziabili.
- `scf_electronic_energy`, un `jax.custom_vjp` attorno a `run_scf`: il gradiente non è backprop attraverso il loop SCF (impossibile, `while_loop` non supporta reverse-mode) — è il gradiente analitico di Pople, Krishnan, Schlegel & Binkley, *Int. J. Quantum Chem. Symp.* 13, 225 (1979), eq. (21)-(22), ottenuto via `jax.grad` ordinario su un'espressione Lagrangiana congelata al punto di convergenza (teorema dell'inviluppo) — cattura automaticamente i termini di Pulay (la base si muove con i nuclei) senza formule scritte a mano per gli integrali.

**Bug reale trovato e corretto durante la verifica**: il moltiplicatore di Lagrange usato per W non era `diag(ε)` ma doveva essere `2·diag(ε)` — la convenzione di P di questo modulo (senza fattore 2 esplicito, assorbito nel Fock "2J-K") non corrisponde a quella di Pople (orbitali di spin). Trovato perché il gradiente iniziale disaccordava dalle differenze finite centrali di una quantità stabile su più valori di `h` (non rumore numerico). Dopo la correzione: **accordo a ~4e-11 su H2/STO-3G** (h=1e-5), col pattern classico di convergenza delle differenze finite.

Nuovo modulo `differentiable.py`: `build_energy_fn` compone basis+assembly+scf in una funzione `geometria -> energia totale` pronta per `jax.grad`.

**Verifica completa su Kaggle CPU** (per non stressare la macchina locale): `test_native_hf_bridge.py`, `test_native_hf_engine.py` (53 test, inclusi i casi 6-31G* con shell-d), `test_native_hf_differentiable.py` (nuovo, verifica contro differenze finite) — **59/59 passati**, nessuna regressione.