### PR TITLE
Fix Graphical Builder tab: query parentElement, not a detached root div

### DIFF
--- a/tools/dashboard/core/circuit_builder_component.py
+++ b/tools/dashboard/core/circuit_builder_component.py
@@ -136,8 +136,8 @@ export default function(component) {
   root.appendChild(gridEl);
   parentElement.appendChild(root);
 
-  const countEl = root.querySelector('[data-role="count"]');
-  root.querySelector('[data-role="clear"]').addEventListener('click', () => {
+  const countEl = parentElement.querySelector('[data-role="count"]');
+  parentElement.querySelector('[data-role="clear"]').addEventListener('click', () => {
     for (let r = 0; r < nQubits; r++) {
       for (let c = 0; c < nCols; c++) {
         grid[r][c] = null;


### PR DESCRIPTION
Trovato caricando la dashboard dal vivo in un browser (Playwright), non solo dal sorgente. Il tab "Graphical Builder" dava `BidiComponent Error: Cannot read properties of null (reading 'addEventListener')` e non si caricava mai.

**Causa**: CCv2 di Streamlit (`st.components.v2.component`) inietta la stringa `html=` direttamente come figlia di `parentElement` prima che il modulo JS giri (confermato nella documentazione CCv2 inclusa nel pacchetto Streamlit stesso: "Prefer querying under parentElement (not document)"). Il modulo invece creava un `root` nuovo e vuoto, ci appendeva solo palette/griglia costruite dinamicamente, e poi cercava dentro `root` gli elementi contatore/pulsante che vivono nella stringa statica `_HTML` — che non era mai stata figlia di `root`. La query tornava `null`, e `.addEventListener` su `null` lanciava subito.

**Fix**: interrogare `parentElement` (dove `_HTML` è realmente atterrato) invece di `root` per quei due elementi.

**Verificato dal vivo**: il tab ora renderizza la palette completa dei gate, una griglia 3-qubit cliccabile, e la toolbar "0 porte piazzate" / "Pulisci griglia", senza errori in console (prima ne segnalava esattamente uno).