### PR TITLE
Fix SafeMemoryGuard blocking trivial allocations on tight-RAM machines

### DIFF
--- a/dense_evolution/backends/chunk/guard.py
+++ b/dense_evolution/backends/chunk/guard.py
@@ -74,6 +74,27 @@ class SafeMemoryGuard:
     """
 
     _WARN_MULTIPLIER = 2.0
+    # Below this, check_allocation's own margin-after-allocation math
+    # reduces to "is ambient free RAM currently below threshold_pct?",
+    # independent of required_mb -- for a request this small that's not
+    # protecting against anything, since real machines don't run out of
+    # memory over a request this size regardless of ambient load. Sized
+    # to comfortably cover a dense statevector up to 24 qubits at
+    # complex128 (2**24 * 16 bytes = 268.4 MB) with a real margin -- the
+    # same 24-qubit figure dashboard_core.system_limits already treats as
+    # MPS's own RAM-independent ceiling, and well inside the 16-27 qubit
+    # range dense_evolution.chunk.get_dynamic_chunk considers safe on any
+    # machine (27 qubits / 2 GB is that function's own practical ceiling
+    # for a single dense block). An 8 GB minimum-spec machine can always
+    # absorb an allocation this size without real risk, even while
+    # running low on RAM from unrelated processes. A 2-qubit statevector
+    # (64 bytes) used to be refused on a machine sitting at 8% free RAM
+    # from unrelated processes, which was not a real anti-OOM save, just
+    # a false positive from a threshold designed for actual multi-GB
+    # allocations. Only bypasses when available_mb is itself comfortably
+    # above this floor too (see check_allocation below) -- a machine
+    # truly down to its last few hundred MB still gets the real check.
+    _NEGLIGIBLE_MB = 512.0
 
     def __init__(self, threshold_pct: float = 0.15, gc_before_check: bool = True):
         if not 0.0 < threshold_pct < 1.0:
@@ -134,7 +155,10 @@ class SafeMemoryGuard:
         if self.gc_before_check:
             gc.collect()
 
-        s   = self.status()
+        s = self.status()
+        if required_mb < self._NEGLIGIBLE_MB and s["available_mb"] > self._NEGLIGIBLE_MB:
+            return
+
         tag = f"[{context}] " if context else ""
         available_after_mb = s["available_mb"] - required_mb
         free_frac_after = available_after_mb / self._total_mb if self._total_mb > 0 else 0.0

--- a/tests/unit/test_chunk.py
+++ b/tests/unit/test_chunk.py
@@ -266,10 +266,10 @@ class TestChunkDiskOverflow:
     in-RAM multi-chunk path (which could share a bug with a naive
     streaming reimplementation) -- this is bit-manipulation-heavy code
     where a plausible-looking-but-wrong formula is easy to miss by
-    inspection alone. memory_threshold=0.999999 forces
-    SafeMemoryGuard.check_allocation to fail regardless of the actual
-    (tiny, forced) geometry's real size, so the disk-overflow fallback
-    triggers reliably in a test without needing a real large allocation.
+    inspection alone. _fake_low_ram (below) fakes available_mb genuinely
+    low so SafeMemoryGuard.check_allocation reliably fails despite this
+    class's real (tiny, forced) chunk geometries, and the disk-overflow
+    fallback triggers without needing a real large allocation.
     """
 
     @pytest.fixture
@@ -294,8 +294,28 @@ class TestChunkDiskOverflow:
         yield
         gc.collect()
 
+    @pytest.fixture(autouse=True)
+    def _fake_low_ram(self, monkeypatch):
+        # SafeMemoryGuard.check_allocation now skips its percentage-margin
+        # check entirely for small requests when available_mb is itself
+        # comfortably high (see guard.py's _NEGLIGIBLE_MB) -- a real fix
+        # for false positives on a machine with plenty of RAM, but it
+        # means memory_threshold=0.999999 alone no longer reliably forces
+        # a "RAM full" failure against this class's real (small, forced)
+        # chunk geometries. Faking available_mb genuinely low (below
+        # _NEGLIGIBLE_MB) makes the disk-overflow path trigger for the
+        # right reason -- real memory pressure -- instead of an
+        # unreachable threshold.
+        from dense_evolution.backends.chunk import guard as guard_mod
+        total_bytes = 8 * 1024 ** 3
+        available_bytes = 0.01 * total_bytes
+        monkeypatch.setattr(guard_mod, "_device_memory_budget_bytes",
+                             lambda device=None: (available_bytes, "fake"))
+        monkeypatch.setattr(guard_mod, "_device_total_bytes",
+                             lambda device=None: total_bytes)
+
     def _make_disk_chunk(self, n_qubits):
-        c = Chunk(n_qubits, memory_threshold=0.999999, allow_disk_overflow=True)
+        c = Chunk(n_qubits, memory_threshold=0.15, allow_disk_overflow=True)
         assert c._chunk_paths is not None  # confirms this test is really on the disk path
         return c
 
@@ -316,7 +336,7 @@ class TestChunkDiskOverflow:
         from dense_evolution.chunk import MemoryPressureError
         force_chunk_bits(4)
         with pytest.raises(MemoryPressureError):
-            Chunk(6, memory_threshold=0.999999)
+            Chunk(6, memory_threshold=0.15)
 
     def test_empty_circuit_canary(self, force_chunk_bits):
         force_chunk_bits(4)


### PR DESCRIPTION
Trovato caricando dal vivo la dashboard Streamlit ed eseguendo il circuito demo di default a 2 qubit: falliva con "MEMORIA INSUFFICIENTE" anche se la richiesta reale era 0 MB (un vettore di stato a 2 qubit sono 64 byte).

**Causa**: la matematica del margine percentuale di `check_allocation` (`available_after_mb / total_mb < threshold_pct`) si riduce a "la RAM libera ambientale è sotto la soglia?" per qualunque `required_mb` trascurabile, indipendentemente dalla richiesta reale — su una macchina temporaneamente all'8% di RAM libera per processi non correlati (browser, IDE, il warmup JAX della dashboard stessa), questo bloccava un'allocazione completamente innocua.

**Fix**: `check_allocation` ora salta il controllo percentuale quando `required_mb` è sotto una soglia fissa (`_NEGLIGIBLE_MB = 512 MB`) **E** `available_mb` è essa stessa comodamente sopra quella soglia — la seconda condizione mantiene il controllo reale attivo per una macchina davvero agli sgoccioli, quindi non è un bypass generico. La soglia copre comodamente un vettore di stato denso fino a 24 qubit a complex128 (2^24 × 16 byte = 268.4 MB) con margine reale — la stessa cifra di 24 qubit che `dashboard_core.system_limits` già tratta come limite di MPS, e ben dentro il range 16-27 qubit che `get_dynamic_chunk` considera sicuro su qualunque macchina. Una macchina minima da 8GB non dovrebbe mai vedere un falso positivo in quel range.

**Test**: `TestChunkDiskOverflow` si affidava a `memory_threshold=0.999999` da solo per forzare `MemoryPressureError` indipendentemente dalla geometria (deliberatamente minuscola) dei suoi chunk forzati — quella tecnica non funziona più una volta che la guardia smette di trattare "qualunque richiesta, per quanto piccola" come "un'allocazione reale" su una macchina con RAM assoluta abbondante. Sostituito con la stessa iniezione di RAM finta bassa già usata altrove nel file (`_fake_budget` in `TestChunkMultiPiece`), che forza il percorso disk-overflow per il motivo giusto (pressione di memoria reale, iniettata) invece di una soglia irraggiungibile. `tests/unit/test_chunk.py` completo: 58 passed, 19 skipped.

**Verificato dal vivo**: il circuito demo a 2 qubit della dashboard ora gira e renderizza un risultato invece di sollevare `MemoryPressureError`.