### PR TITLE
Add Entropia & informazione mutua panel; fix a Qiskit/native qubit-index mix-up in Magia & Divergenze

### DIFF
--- a/tools/dashboard/app.py
+++ b/tools/dashboard/app.py
@@ -165,8 +165,8 @@ elif section == "Risultati":
             f"{result.n_qubits} qubit — puoi aggiungere rumore (Rumore) o costruirne "
             "uno nuovo (Costruisci)."
         )
-        tab_sv, tab_prob, tab_qsphere, tab_bloch = st.tabs(
-            ["Statevector", "Probabilità", "Q-sphere", "Bloch per qubit"]
+        tab_sv, tab_prob, tab_qsphere, tab_bloch, tab_entropy = st.tabs(
+            ["Statevector", "Probabilità", "Q-sphere", "Bloch per qubit", "Entropia & informazione mutua"]
         )
         with tab_sv:
             st.caption(f"{result.n_qubits} qubit — {len(result.statevector)} ampiezze (convenzione Qiskit)")
@@ -190,6 +190,50 @@ elif section == "Risultati":
         with tab_bloch:
             st.caption("Una sfera di Bloch per ogni qubit -- dalla sua matrice densità ridotta.")
             st.pyplot(dc.bloch_multivector_figure(result.statevector))
+        with tab_entropy:
+            st.caption(
+                "Un qubit entangled ha <Z>=0 anche se il suo partner ha subito un'operazione -- "
+                "l'informazione mutua vede correlazioni che un valore di aspettazione singolo non "
+                "può vedere per costruzione (teorema no-signaling). Numerazione qubit: come in "
+                "Risultati (convenzione Qiskit)."
+            )
+            all_qubits = list(range(result.n_qubits))
+            qa_text = st.text_input("Sottosistema A (indici separati da virgola)", value="0", key="entropy_a")
+            qb_text = st.text_input("Sottosistema B (indici separati da virgola)", value="1" if result.n_qubits > 1 else "", key="entropy_b")
+            if st.button("Calcola entropia e informazione mutua"):
+                try:
+                    qa = [int(x) for x in qa_text.split(",") if x.strip() != ""]
+                    qb = [int(x) for x in qb_text.split(",") if x.strip() != ""]
+                    if set(qa) & set(qb):
+                        raise ValueError("i due sottosistemi devono essere disgiunti")
+                    # Same Qiskit-little-endian -> native-MSB-first conversion
+                    # as Magia & Divergenze: flip each index before calling
+                    # partial_trace/mutual_information, which use dense_evolution's
+                    # own convention, not Qiskit's.
+                    n = result.n_qubits
+                    native_a = [n - 1 - q for q in qa]
+                    native_b = [n - 1 - q for q in qb]
+                    rho_a = dense_evolution.partial_trace(result.statevector, n, native_a)
+                    rho_b = dense_evolution.partial_trace(result.statevector, n, native_b)
+                    s_a = dense_evolution.von_neumann_entropy(rho_a)
+                    s_b = dense_evolution.von_neumann_entropy(rho_b)
+                    i_ab = dense_evolution.mutual_information(result.statevector, n, native_a, native_b)
+                    st.session_state["entropy_result"] = (s_a, s_b, i_ab)
+                    st.session_state["entropy_error"] = None
+                except Exception as exc:
+                    st.session_state["entropy_result"] = None
+                    st.session_state["entropy_error"] = str(exc)
+
+            entropy_error = st.session_state.get("entropy_error")
+            entropy_result = st.session_state.get("entropy_result")
+            if entropy_error:
+                st.error(f"Errore: {entropy_error}")
+            elif entropy_result is not None:
+                s_a, s_b, i_ab = entropy_result
+                col1, col2, col3 = st.columns(3)
+                col1.metric("S(A) (nat)", f"{s_a:.4f}")
+                col2.metric("S(B) (nat)", f"{s_b:.4f}")
+                col3.metric("I(A:B) (nat)", f"{i_ab:.4f}")
 
 
 # ── CHIMICA ──────────────────────────────────────────────────────────────
@@ -583,10 +627,17 @@ elif section == "Magia & Divergenze":
         st.caption("Zero per ogni stato stabilizzatore, positiva per stati 'magici' (non-Clifford).")
 
         qubit_idx = st.number_input(
-            "Qubit per magic_entropy (singolo qubit)", min_value=0, max_value=result.n_qubits - 1,
-            value=0, key="magic_qubit",
+            "Qubit per magic_entropy (singolo qubit, numerazione Qiskit -- come in Risultati)",
+            min_value=0, max_value=result.n_qubits - 1, value=0, key="magic_qubit",
         )
-        rho = dense_evolution.partial_trace(result.statevector, result.n_qubits, [int(qubit_idx)])
+        # result.statevector is in Qiskit's little-endian order; partial_trace
+        # uses dense_evolution's own MSB-first convention -- the two disagree
+        # on which physical qubit index N means, so the Qiskit-facing index
+        # has to be flipped before calling it (BUG FIX: this used to pass
+        # qubit_idx straight through, silently tracing out a different qubit
+        # than the one displayed everywhere else in the app).
+        native_qubit_idx = result.n_qubits - 1 - int(qubit_idx)
+        rho = dense_evolution.partial_trace(result.statevector, result.n_qubits, [native_qubit_idx])
         st.metric(f"magic_entropy (qubit {qubit_idx})", f"{magic_entropy(rho):.6f} bit")
         st.caption("Costruzione Key-Unitary a 3 copie -- 0 per |0>,|1>,|+>,|->,|+i>,|-i>, 0.811 per T e H.")
 


### PR DESCRIPTION
## Summary
- New "Entropia & informazione mutua" tab in Risultati (`partial_trace`/`von_neumann_entropy`/`mutual_information` from `physics/entropy.py`, previously only used internally by the wormhole module).
- **Bugfix**: the already-merged Magia & Divergenze panel passed `result.statevector`'s Qiskit little-endian qubit index straight into `partial_trace`, which expects `dense_evolution`'s own MSB-first convention -- silently tracing out the wrong physical qubit for any non-symmetric multi-qubit state. Fixed in both panels via `native_index = n_qubits - 1 - qiskit_index`.

## Test plan
- [x] Live-verified: Bell state gives S(A)=S(B)=0.6931 nat (ln 2), I(A:B)=1.3863 nat (2 ln 2) -- exact match to `physics/entropy.py`'s own documented reference value for a Bell pair
- [x] Zero console errors
