### PR TITLE
Dashboard: expose bond_convergence diagnostic in Grandi Sistemi

### DIFF
--- a/tests/integration/test_dashboard_engine.py
+++ b/tests/integration/test_dashboard_engine.py
@@ -16,7 +16,10 @@ docstring for why that matters on macOS).
 import numpy as np
 import pytest
 
-from dashboard_core.engine import run_circuit_from_qasm, _to_qiskit_bit_order, _qiskit_bit_order_perm
+from dashboard_core.engine import (
+    run_circuit_from_qasm, _to_qiskit_bit_order, _qiskit_bit_order_perm,
+    run_bond_convergence_check,
+)
 
 _INV_SQRT2 = 1 / np.sqrt(2)
 
@@ -140,3 +143,19 @@ def test_qiskit_bit_order_perm_is_read_only():
     perm = _qiskit_bit_order_perm(4)
     with pytest.raises(ValueError):
         perm[0] = 999
+
+
+def test_bond_convergence_check_ghz_chain_is_trivially_converged():
+    # A GHZ chain's bond dimension never needs to grow past 2 -- <Z0>
+    # is exactly 0 at every bond tested, so the observable is trivially
+    # identical everywhere and the verdict must be "converged" with
+    # zero diffs, matching bond_convergence's own documented edge case.
+    result = run_bond_convergence_check(GHZ_QASM, ["ZII"], [2, 4, 8], tol=1e-3)
+    assert result.verdicts == ["converged"]
+    assert result.values[0] == pytest.approx([0.0, 0.0, 0.0], abs=1e-9)
+    assert result.diffs[0] == pytest.approx([0.0, 0.0], abs=1e-9)
+
+
+def test_bond_convergence_check_needs_at_least_three_bonds():
+    with pytest.raises(ValueError, match="at least 3 bonds"):
+        run_bond_convergence_check(GHZ_QASM, ["ZII"], [2, 4], tol=1e-3)

--- a/tools/dashboard/app.py
+++ b/tools/dashboard/app.py
@@ -767,6 +767,63 @@ elif section == "Grandi Sistemi":
             width="stretch",
         )
 
+    with st.expander("Convergenza rispetto al bond dimension"):
+        st.caption(
+            "mps_avg_jsd sopra è un errore di troncamento medio su tutto lo stato -- non dice "
+            "se l'osservabile che ti interessa si è davvero assestato al crescere del bond. "
+            "Qui il circuito viene rieseguito a bond crescenti e si guarda se il valore atteso "
+            "smette di cambiare. Se 'chi_used' al bond più alto è già uguale al suo tetto, il "
+            "verdetto è 'undecidable': il troncamento non ha mai avuto margine per dimostrare "
+            "la convergenza, non un converged/not_converged nascosto."
+        )
+        bc_qasm_text = st.text_area(
+            "OpenQASM 2.0 (circuito per il check)", value=default_large_qasm, height=150, key="bc_qasm_text",
+        )
+        bc_observable = st.text_input(
+            "Osservabile (stringa Pauli, es. ZIII)", value="Z" + "I" * 29, key="bc_observable",
+        )
+        bc_bonds_text = st.text_input("Bond da testare (crescenti, separati da virgola)", value="4,8,16,32", key="bc_bonds")
+        bc_tol = st.number_input("Tolleranza", min_value=1e-6, max_value=1.0, value=1e-3, format="%.6f", key="bc_tol")
+        if st.button("Esegui check di convergenza"):
+            try:
+                bonds = [int(b) for b in bc_bonds_text.split(",") if b.strip() != ""]
+                bc_result = dc.run_bond_convergence_check(bc_qasm_text, [bc_observable], bonds, tol=float(bc_tol))
+                st.session_state["bond_convergence_result"] = bc_result
+                st.session_state["bond_convergence_error"] = None
+            except Exception as exc:
+                st.session_state["bond_convergence_result"] = None
+                st.session_state["bond_convergence_error"] = str(exc)
+
+        bc_error = st.session_state.get("bond_convergence_error")
+        bc_result = st.session_state.get("bond_convergence_result")
+        if bc_error:
+            st.error(f"Errore: {bc_error}")
+        elif bc_result is not None:
+            verdict = bc_result.verdicts[0]
+            verdict_label = {
+                "converged": "✅ converged",
+                "not_converged": "⚠️ not_converged",
+                "undecidable": "❔ undecidable",
+            }[verdict]
+            st.metric("Verdetto", verdict_label)
+            st.dataframe(
+                [
+                    {
+                        "bond": b, "chi_used": c, "avg_jsd": j, "budget_violations": v,
+                        "|<P>|": abs(val),
+                    }
+                    for b, c, j, v, val in zip(
+                        bc_result.bonds, bc_result.chi_used, bc_result.avg_jsd,
+                        bc_result.budget_violations, bc_result.values[0],
+                    )
+                ],
+                width="stretch",
+            )
+            st.caption(
+                "diffs (variazione tra bond consecutivi): "
+                + ", ".join(f"{d:.2e}" for d in bc_result.diffs[0])
+            )
+
 
 # ── IMPORTA CIRCUITO ─────────────────────────────────────────────────────
 elif section == "Importa Circuito":

--- a/tools/dashboard/core/__init__.py
+++ b/tools/dashboard/core/__init__.py
@@ -25,6 +25,7 @@ from .qasm_library import QASM_LIBRARY, gate_tuples_to_qasm
 from .engine import (
     SimulationResult, run_circuit_from_qasm,
     LargeScaleMPSResult, run_large_circuit_mps, MPS_DENSE_CONTRACTION_LIMIT,
+    run_bond_convergence_check,
 )
 from .visuals import (
     draw_circuit_figure, histogram_figure, qsphere_figure, bloch_multivector_figure,
@@ -61,6 +62,7 @@ __all__ = [
     'QASM_LIBRARY', 'gate_tuples_to_qasm',
     'SimulationResult', 'run_circuit_from_qasm',
     'LargeScaleMPSResult', 'run_large_circuit_mps', 'MPS_DENSE_CONTRACTION_LIMIT',
+    'run_bond_convergence_check',
     'draw_circuit_figure', 'histogram_figure', 'qsphere_figure', 'bloch_multivector_figure',
     'GATE_PALETTE', 'ops_to_native_tuples',
     'mount_circuit_builder',

--- a/tools/dashboard/core/engine.py
+++ b/tools/dashboard/core/engine.py
@@ -30,7 +30,10 @@ import numpy as np
 
 import dense_evolution as de
 
-__all__ = ['SimulationResult', 'run_circuit_from_qasm', 'LargeScaleMPSResult', 'run_large_circuit_mps']
+__all__ = [
+    'SimulationResult', 'run_circuit_from_qasm', 'LargeScaleMPSResult',
+    'run_large_circuit_mps', 'run_bond_convergence_check',
+]
 
 
 def _qasm_to_tuples(qasm_text: str):
@@ -292,3 +295,22 @@ def run_large_circuit_mps(qasm_text: str, k: int = 32, seed: Optional[int] = Non
         mps_memory_mb=mps.memory_mb(),
         mps_avg_jsd=mps.avg_jsd(),
     )
+
+
+def run_bond_convergence_check(qasm_text: str, observables: list, bonds: list, tol: float = 1e-3):
+    """Runs the circuit at every bond dimension in `bonds` and checks
+    whether each observable's expectation value has actually converged
+    as bond dimension grows -- a single MPS run's own diagnostics
+    (avg_jsd, budget_violations) say nothing about whether a *specific*
+    observable has settled, since they are truncation-error proxies
+    averaged over the whole state, not the observable itself.
+
+    Thin wrapper around dense_evolution.backends.mps.bond_convergence:
+    parses qasm_text the same way as every other entry point here, then
+    delegates. See that function's own docstring for the "undecidable"
+    verdict (fires when chi_used at the top bond already equals its own
+    cap, i.e. truncation never had headroom to demonstrate convergence).
+    """
+    n_qubits, raw_ops = _qasm_to_tuples(qasm_text)
+    ops = de.QuantumTranspiler.transpile(raw_ops)
+    return de.backends.mps.bond_convergence(ops, n_qubits, observables, bonds, tol=tol)


### PR DESCRIPTION
`mps_avg_jsd`/`mps_max_bond_used` shown for `run_large_circuit_mps` are whole-state truncation-error proxies — they say nothing about whether a specific observable has actually settled as bond dimension grows. `dense_evolution.backends.mps.bond_convergence` already computes exactly that but was never surfaced.

Added a thin `dashboard_core.run_bond_convergence_check(qasm_text, observables, bonds, tol)` wrapper and a new expander in Grandi Sistemi showing per-bond `chi_used`/`avg_jsd`/`budget_violations`, the observable's value at each bond, and the verdict (converged/not_converged/undecidable) — with the "undecidable" caveat spelled out in the UI text (fires when `chi_used` at the top bond already equals its own cap, meaning no real headroom to demonstrate convergence).

Live-verified on the default 30-qubit GHZ-chain preset, observable Z on qubit 0, bonds [4,8,16,32]: verdict "converged", diffs all 0.00e+00 — the documented edge case where a GHZ chain's bond never needs to grow past 2. 0 console errors.