### PR TITLE
Dashboard: add 2D VQE energy-landscape scan

### DIFF
--- a/tests/integration/test_dashboard_visuals.py
+++ b/tests/integration/test_dashboard_visuals.py
@@ -19,6 +19,7 @@ from matplotlib.figure import Figure
 from dashboard_core.engine import run_circuit_from_qasm
 from dashboard_core.visuals import (
     bloch_multivector_figure, draw_circuit_figure, histogram_figure, qsphere_figure,
+    energy_landscape_figure,
 )
 from dashboard_core.state_visuals import _reduced_density_matrix, _bloch_vector
 
@@ -66,6 +67,14 @@ def test_qsphere_figure_returns_a_figure():
 def test_bloch_multivector_figure_returns_a_figure():
     result = _bell_result()
     fig = bloch_multivector_figure(result.statevector)
+    assert isinstance(fig, Figure)
+
+
+def test_energy_landscape_figure_returns_a_figure():
+    values_i = np.linspace(-1.0, 1.0, 5)
+    values_j = np.linspace(-1.0, 1.0, 5)
+    energies = np.outer(values_i, values_j)
+    fig = energy_landscape_figure(values_i, values_j, energies, 0, 1, 0.0, 0.0, energies[2, 2])
     assert isinstance(fig, Figure)
 
 

--- a/tests/integration/test_dashboard_vqe.py
+++ b/tests/integration/test_dashboard_vqe.py
@@ -176,6 +176,24 @@ class TestEnergyLandscapeScan:
         assert energies.shape == (2, 1)
         assert energies[0, 0] != pytest.approx(energies[1, 0], abs=1e-6)
 
+    def test_raises_on_param_count_mismatch(self, monkeypatch):
+        # Same desync guard as run_vqe's own (see TestParamCountMismatch
+        # above) -- can't happen through the normal public API, forced
+        # here via monkeypatching circuit_to_energy_fn's return value.
+        import dashboard_core.vqe as vqe_module
+        real_circuit_to_energy_fn = vqe_module.de.circuit_to_energy_fn
+
+        def wrong_count(parsed, n_qubits):
+            energy_fn, n_params = real_circuit_to_energy_fn(parsed, n_qubits)
+            return energy_fn, n_params + 1  # deliberately wrong
+
+        monkeypatch.setattr(vqe_module.de, "circuit_to_energy_fn", wrong_count)
+        with pytest.raises(ValueError, match="circuit_to_energy_fn found"):
+            scan_hardware_efficient_energy_landscape(
+                H2_SYMBOLS, H2_GEOMETRY, 0, 1, [1, 1, 0, 0], np.zeros(4),
+                0, 1, np.array([0.0]), np.array([0.0]),
+            )
+
 
 def build_h2_pauli_terms():
     from dashboard_core.hamiltonians import build_molecular_hamiltonian

--- a/tests/integration/test_dashboard_vqe.py
+++ b/tests/integration/test_dashboard_vqe.py
@@ -13,7 +13,7 @@ run against H2's real Hamiltonian, not a stub. No Qiskit involved
 import numpy as np
 import pytest
 
-from dashboard_core.vqe import run_vqe
+from dashboard_core.vqe import run_vqe, scan_hardware_efficient_energy_landscape
 
 H2_SYMBOLS = ['H', 'H']
 H2_GEOMETRY = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.7414]])
@@ -149,6 +149,32 @@ class TestParamCountConsistencyCheck:
         monkeypatch.setattr(vqe_module.de, "circuit_to_energy_fn", wrong_count)
         with pytest.raises(ValueError, match="circuit_to_energy_fn found"):
             run_vqe(H2_SYMBOLS, H2_GEOMETRY, charge=0, ansatz_type="uccsd", maxiter=1)
+
+
+class TestEnergyLandscapeScan:
+
+    def test_center_of_scan_matches_converged_energy(self):
+        result = run_vqe(H2_SYMBOLS, H2_GEOMETRY, charge=0, ansatz_type='hardware_efficient',
+                          n_layers=1, maxiter=5, seed=0)
+        base_params = np.asarray(result['params'])
+        energies = scan_hardware_efficient_energy_landscape(
+            H2_SYMBOLS, H2_GEOMETRY, 0, result['n_layers'], result['hf_occupation'],
+            base_params, 0, 1, base_params[0:1], base_params[1:2],
+        )
+        assert energies.shape == (1, 1)
+        assert energies[0, 0] == pytest.approx(result['vqe_energy_hartree'], abs=1e-9)
+
+    def test_energy_varies_away_from_converged_point(self):
+        result = run_vqe(H2_SYMBOLS, H2_GEOMETRY, charge=0, ansatz_type='hardware_efficient',
+                          n_layers=1, maxiter=5, seed=0)
+        base_params = np.asarray(result['params'])
+        values_i = np.array([base_params[0], base_params[0] + np.pi])
+        energies = scan_hardware_efficient_energy_landscape(
+            H2_SYMBOLS, H2_GEOMETRY, 0, result['n_layers'], result['hf_occupation'],
+            base_params, 0, 1, values_i, base_params[1:2],
+        )
+        assert energies.shape == (2, 1)
+        assert energies[0, 0] != pytest.approx(energies[1, 0], abs=1e-6)
 
 
 def build_h2_pauli_terms():

--- a/tools/dashboard/app.py
+++ b/tools/dashboard/app.py
@@ -416,6 +416,59 @@ elif section == "Chimica":
             st.session_state["nav_section"] = "Costruisci"
             st.rerun()
 
+        with st.expander("Paesaggio energetico 2D"):
+            if vqe_result["ansatz_type"] != "hardware_efficient" or vqe_result["n_params"] < 2:
+                st.info(
+                    "Disponibile solo per l'ansatz hardware_efficient con almeno 2 "
+                    "parametri -- UCCSD usa una mappatura affine tra pesi ed angoli "
+                    "reali (non un parametro per rotazione), quindi 'parametro i' non "
+                    "corrisponde qui a un singolo angolo."
+                )
+            else:
+                st.caption(
+                    "Rieseguendo il circuito reale a griglia fissa attorno al minimo "
+                    "trovato dal VQE, tenendo fissi tutti gli altri parametri -- non "
+                    "un'interpolazione, ogni punto è un'energia calcolata da zero."
+                )
+                n_p = vqe_result["n_params"]
+                col_pi, col_pj = st.columns(2)
+                land_i = col_pi.number_input(
+                    "Parametro A (indice)", min_value=0, max_value=n_p - 1, value=0, key="land_param_i",
+                )
+                land_j = col_pj.number_input(
+                    "Parametro B (indice)", min_value=0, max_value=n_p - 1,
+                    value=min(1, n_p - 1), key="land_param_j",
+                )
+                land_res = st.slider("Risoluzione griglia", 5, 41, 21, step=2, key="land_resolution")
+                if land_i == land_j:
+                    st.warning("Scegli due indici diversi.")
+                elif st.button("Calcola paesaggio energetico"):
+                    base_params = np.asarray(vqe_result["params"], dtype=np.float64)
+                    center_i, center_j = base_params[int(land_i)], base_params[int(land_j)]
+                    values_i = np.linspace(center_i - np.pi, center_i + np.pi, int(land_res))
+                    values_j = np.linspace(center_j - np.pi, center_j + np.pi, int(land_res))
+                    try:
+                        energies = dc.scan_hardware_efficient_energy_landscape(
+                            mol["symbols"], mol["geometry"], mol["charge"], vqe_result["n_layers"],
+                            vqe_result["hf_occupation"], base_params, int(land_i), int(land_j),
+                            values_i, values_j,
+                        )
+                        st.session_state["landscape_result"] = (
+                            values_i, values_j, energies, int(land_i), int(land_j),
+                            center_i, center_j, vqe_result["vqe_energy_hartree"],
+                        )
+                        st.session_state["landscape_error"] = None
+                    except Exception as exc:
+                        st.session_state["landscape_result"] = None
+                        st.session_state["landscape_error"] = str(exc)
+
+                land_error = st.session_state.get("landscape_error")
+                land_data = st.session_state.get("landscape_result")
+                if land_error:
+                    st.error(f"Errore: {land_error}")
+                elif land_data is not None:
+                    st.pyplot(dc.energy_landscape_figure(*land_data))
+
     if advanced_mode:
         st.divider()
         with st.expander("Ottimizza geometria (dE/dR analitico, native_hf)"):

--- a/tools/dashboard/core/__init__.py
+++ b/tools/dashboard/core/__init__.py
@@ -29,6 +29,7 @@ from .engine import (
 )
 from .visuals import (
     draw_circuit_figure, histogram_figure, qsphere_figure, bloch_multivector_figure,
+    energy_landscape_figure,
 )
 from .graphical_builder import GATE_PALETTE, ops_to_native_tuples
 from .circuit_builder_component import mount_circuit_builder
@@ -42,7 +43,7 @@ from .mitigation import (
     MitigationResult, run_zne_mitigation, DensityMatrixZNEResult, run_density_matrix_zne,
 )
 from .system_limits import max_safe_dense_qubits
-from .vqe import run_vqe
+from .vqe import run_vqe, scan_hardware_efficient_energy_landscape
 from .qmmm import (
     ATOMIC_MASSES_AMU,
     compute_hellmann_feynman_forces, md_step, run_md_trajectory,
@@ -64,6 +65,7 @@ __all__ = [
     'LargeScaleMPSResult', 'run_large_circuit_mps', 'MPS_DENSE_CONTRACTION_LIMIT',
     'run_bond_convergence_check',
     'draw_circuit_figure', 'histogram_figure', 'qsphere_figure', 'bloch_multivector_figure',
+    'energy_landscape_figure',
     'GATE_PALETTE', 'ops_to_native_tuples',
     'mount_circuit_builder',
     'MOLECULE_CATALOG', 'build_molecular_hamiltonian', 'get_compatible_molecules',
@@ -73,7 +75,7 @@ __all__ = [
     'MitigationResult', 'run_zne_mitigation',
     'DensityMatrixZNEResult', 'run_density_matrix_zne',
     'max_safe_dense_qubits',
-    'run_vqe',
+    'run_vqe', 'scan_hardware_efficient_energy_landscape',
     'ATOMIC_MASSES_AMU',
     'compute_hellmann_feynman_forces', 'md_step', 'run_md_trajectory',
     'build_sparse_syk_terms', 'commuting_pair_count', 'select_good_instance',

--- a/tools/dashboard/core/visuals.py
+++ b/tools/dashboard/core/visuals.py
@@ -17,7 +17,10 @@ import matplotlib.pyplot as plt
 from .circuit_diagram import draw_native_circuit_diagram
 from .state_visuals import native_histogram_figure, native_qsphere_figure, native_bloch_multivector_figure
 
-__all__ = ['draw_circuit_figure', 'histogram_figure', 'qsphere_figure', 'bloch_multivector_figure']
+__all__ = [
+    'draw_circuit_figure', 'histogram_figure', 'qsphere_figure', 'bloch_multivector_figure',
+    'energy_landscape_figure',
+]
 
 # dense_evolution.registry sets plt.style.use('dark_background') globally
 # for its own diagnostic plots (import-time side effect). Rendering inside
@@ -57,3 +60,27 @@ def bloch_multivector_figure(statevector):
     """Native per-qubit Bloch spheres (dashboard_core.state_visuals)."""
     with plt.style.context(_LIGHT_STYLE):
         return native_bloch_multivector_figure(statevector)
+
+
+def energy_landscape_figure(
+    values_i, values_j, energies, param_i, param_j,
+    converged_i, converged_j, converged_energy,
+):
+    """Contour plot of a real VQE energy landscape scan (dashboard_core.
+    vqe.scan_hardware_efficient_energy_landscape) over two parameters,
+    with the converged optimum marked at its actual (converged_i,
+    converged_j) coordinates -- not assumed to sit at the grid's center,
+    since the caller decides the scan range independently."""
+    with plt.style.context(_LIGHT_STYLE):
+        fig, ax = plt.subplots(figsize=(5, 4))
+        contour = ax.contourf(values_i, values_j, energies.T, levels=30, cmap='viridis')
+        fig.colorbar(contour, ax=ax, label='Energia (Hartree)')
+        ax.scatter(
+            [converged_i], [converged_j],
+            color='red', marker='o', s=60, label=f'Minimo VQE ({converged_energy:.6f} Hartree)',
+        )
+        ax.set_xlabel(f'θ[{param_i}]')
+        ax.set_ylabel(f'θ[{param_j}]')
+        ax.legend(loc='upper right', fontsize=8)
+        fig.tight_layout()
+        return fig

--- a/tools/dashboard/core/vqe.py
+++ b/tools/dashboard/core/vqe.py
@@ -77,7 +77,7 @@ import dense_evolution as de
 
 from .hamiltonians import _get_pennylane_hamiltonian, build_molecular_hamiltonian
 
-__all__ = ['run_vqe']
+__all__ = ['run_vqe', 'scan_hardware_efficient_energy_landscape']
 
 
 def _hardware_efficient_ansatz(params, n_qubits, n_layers, hf_occupation):
@@ -458,4 +458,56 @@ def run_vqe(symbols, geometry, charge=0, ansatz_type="hardware_efficient", n_lay
         'vqe_energy_hartree': final_energy,
         'exact_energy_hartree': exact_energy,
         'qasm': qasm,
+        'params': params.tolist(),
     }
+
+
+def scan_hardware_efficient_energy_landscape(
+    symbols, geometry, charge, n_layers, hf_occupation, base_params,
+    param_i, param_j, values_i, values_j,
+    active_electrons=None, active_orbitals=None,
+):
+    """Real 2D energy-landscape scan around a converged hardware_efficient
+    VQE result: re-evaluates <psi(theta)|H|psi(theta)> on
+    dense_evolution's own circuit_to_energy_fn for every (values_i,
+    values_j) grid point, holding every parameter except param_i/param_j
+    fixed at its converged value from base_params -- the same real
+    Hamiltonian and ansatz circuit run_vqe itself used for this molecule,
+    not a separate or approximate model.
+
+    hardware_efficient only: UCCSD's parameter space is an affine
+    expansion over full per-gate values (_uccsd_native_expansion), not a
+    direct one-parameter-per-rotation-gate mapping, so "parameter i"
+    doesn't correspond to a single rotation angle the way it does here.
+
+    Returns a (len(values_i), len(values_j)) numpy array of energies in
+    Hartree.
+    """
+    import jax
+    import jax.numpy as jnp
+
+    n_qubits = len(hf_occupation)
+    n_params = n_qubits * n_layers
+    H_dense, _ = build_molecular_hamiltonian(
+        symbols, geometry, charge, "jordan_wigner", active_electrons, active_orbitals,
+    )
+    qasm_template = _hardware_efficient_qasm(np.zeros(n_params), n_qubits, n_layers, hf_occupation)
+    parsed = de.QASMParser().parse(qasm_template)
+    energy_fn, n_params_native = de.circuit_to_energy_fn(parsed, n_qubits)
+    if n_params_native != n_params:
+        raise ValueError(
+            f"circuit_to_energy_fn found {n_params_native} parametric gates, expected {n_params}"
+        )
+
+    h_matrix = jnp.array(H_dense)
+    base = jnp.array(base_params)
+    energy_fn_jit = jax.jit(energy_fn)
+
+    energies = np.zeros((len(values_i), len(values_j)))
+    for a, vi in enumerate(values_i):
+        theta_a = base.at[param_i].set(vi)
+        for b, vj in enumerate(values_j):
+            theta_ab = theta_a.at[param_j].set(vj)
+            energy, _sv = energy_fn_jit(theta_ab, h_matrix)
+            energies[a, b] = float(energy)
+    return energies


### PR DESCRIPTION
Chimica/VQE showed a 1D `energy_history` line chart but no way to see the landscape around the converged optimum — another of the outstanding "consigli" visual-polish items.

Adds `dashboard_core.vqe.scan_hardware_efficient_energy_landscape(...)`: re-runs the real hardware_efficient ansatz circuit through `dense_evolution`'s own `circuit_to_energy_fn` at a grid of (param_i, param_j) values around the converged parameters, holding every other parameter fixed — each grid point is a real energy evaluation, not an interpolation. hardware_efficient only: UCCSD's parameter space is an affine expansion over per-gate values, not one-parameter-per-rotation, so "parameter i" has no single-angle meaning there; the UI shows an info message instead when ansatz_type is uccsd or n_params < 2.

`run_vqe`'s return dict gains a `'params'` key (the converged variational parameters), needed to center the scan.

New `dashboard_core.visuals.energy_landscape_figure(...)` renders a matplotlib contourf plot with the converged optimum marked at its actual coordinates. New expander "Paesaggio energetico 2D" in Chimica/VQE: pick 2 parameter indices (default 0, 1), grid resolution (5-41, default 21), range fixed at ±π around the converged value.

Live-verified via Playwright on H2/hardware_efficient/n_layers=4: 21x21 real grid, minimum marked exactly at the converged energy (-1.137270 Hartree), smooth periodic RY-rotation landscape visible in the contour, 0 console errors. Added 2 pytest tests for the scan function proactively (center-point exact match, energy varies away from center).