### PR TITLE
Dashboard: add ±1 SEM error band to ZNE chart

### DIFF
--- a/tests/integration/test_dashboard_mitigation.py
+++ b/tests/integration/test_dashboard_mitigation.py
@@ -33,6 +33,18 @@ class TestScalarZne:
         assert all(v == pytest.approx(1.0, abs=1e-9) for v in result.noisy_expectations)
         assert result.zne_extrapolated == pytest.approx(1.0, abs=1e-9)
 
+    def test_no_noise_means_zero_sem_at_every_scale(self):
+        # noise_p=0.0 short-circuits to the ideal channel -- every trial
+        # returns the identical value, so the sample std (and therefore
+        # the SEM) is exactly zero, not just small.
+        result = run_zne_mitigation(BELL_QASM, 'ZZ', 'ideal', 0.0, seed=1, n_trials=5)
+        assert result.noisy_sems == pytest.approx([0.0, 0.0, 0.0], abs=1e-12)
+
+    def test_real_noise_gives_positive_sem(self):
+        result = run_zne_mitigation(BELL_QASM, 'ZZ', 'depolarizing', 0.1, seed=7, n_trials=100)
+        assert len(result.noisy_sems) == 3
+        assert all(sem > 0.0 for sem in result.noisy_sems)
+
     def test_real_depolarizing_noise_decays_with_scale(self):
         result = run_zne_mitigation(BELL_QASM, 'ZZ', 'depolarizing', 0.1, seed=7, n_trials=100)
         # Real depolarizing channel: <ZZ> should decrease monotonically

--- a/tests/integration/test_dashboard_visuals.py
+++ b/tests/integration/test_dashboard_visuals.py
@@ -19,7 +19,7 @@ from matplotlib.figure import Figure
 from dashboard_core.engine import run_circuit_from_qasm
 from dashboard_core.visuals import (
     bloch_multivector_figure, draw_circuit_figure, histogram_figure, qsphere_figure,
-    energy_landscape_figure,
+    energy_landscape_figure, zne_bar_figure,
 )
 from dashboard_core.state_visuals import _reduced_density_matrix, _bloch_vector
 
@@ -75,6 +75,14 @@ def test_energy_landscape_figure_returns_a_figure():
     values_j = np.linspace(-1.0, 1.0, 5)
     energies = np.outer(values_i, values_j)
     fig = energy_landscape_figure(values_i, values_j, energies, 0, 1, 0.0, 0.0, energies[2, 2])
+    assert isinstance(fig, Figure)
+
+
+def test_zne_bar_figure_returns_a_figure():
+    fig = zne_bar_figure(
+        noise_factors=[1.0, 2.0, 3.0], noisy_expectations=[0.8, 0.6, 0.4],
+        noisy_sems=[0.02, 0.03, 0.04], zne_extrapolated=1.0, ideal_expectation=1.0,
+    )
     assert isinstance(fig, Figure)
 
 

--- a/tools/dashboard/app.py
+++ b/tools/dashboard/app.py
@@ -565,13 +565,15 @@ elif section == "Rumore":
             col1, col2 = st.columns(2)
             col1.metric("Valore ideale", f"{zne_result.ideal_expectation:.4f}")
             col2.metric("Estrapolato a rumore zero", f"{zne_result.zne_extrapolated:.4f}")
-            chart_data = {
-                str(f): v for f, v in zip(zne_result.noise_factors, zne_result.noisy_expectations)
-            }
-            st.bar_chart(chart_data)
+            st.pyplot(dc.zne_bar_figure(
+                zne_result.noise_factors, zne_result.noisy_expectations, zne_result.noisy_sems,
+                zne_result.zne_extrapolated, zne_result.ideal_expectation,
+            ))
             st.caption(
-                "Ogni barra è il valore misurato a quella scala di rumore (1x, 2x, 3x...) -- "
-                "l'estrapolazione stima cosa accadrebbe a rumore zero."
+                "Ogni punto è il valore misurato a quella scala di rumore (1x, 2x, 3x...), con "
+                "barra d'errore ±1 SEM (errore standard della media sui n_trials campioni Monte "
+                "Carlo -- non la dispersione dei singoli trial) -- l'estrapolazione stima cosa "
+                "accadrebbe a rumore zero."
             )
 
     st.divider()

--- a/tools/dashboard/core/__init__.py
+++ b/tools/dashboard/core/__init__.py
@@ -29,7 +29,7 @@ from .engine import (
 )
 from .visuals import (
     draw_circuit_figure, histogram_figure, qsphere_figure, bloch_multivector_figure,
-    energy_landscape_figure,
+    energy_landscape_figure, zne_bar_figure,
 )
 from .graphical_builder import GATE_PALETTE, ops_to_native_tuples
 from .circuit_builder_component import mount_circuit_builder
@@ -65,7 +65,7 @@ __all__ = [
     'LargeScaleMPSResult', 'run_large_circuit_mps', 'MPS_DENSE_CONTRACTION_LIMIT',
     'run_bond_convergence_check',
     'draw_circuit_figure', 'histogram_figure', 'qsphere_figure', 'bloch_multivector_figure',
-    'energy_landscape_figure',
+    'energy_landscape_figure', 'zne_bar_figure',
     'GATE_PALETTE', 'ops_to_native_tuples',
     'mount_circuit_builder',
     'MOLECULE_CATALOG', 'build_molecular_hamiltonian', 'get_compatible_molecules',

--- a/tools/dashboard/core/mitigation.py
+++ b/tools/dashboard/core/mitigation.py
@@ -36,6 +36,7 @@ class MitigationResult:
     noisy_expectations: list
     zne_extrapolated: float
     extrapolation_method: str = "richardson"
+    noisy_sems: list = None
 
 
 def run_zne_mitigation(
@@ -126,6 +127,7 @@ def run_zne_mitigation(
 
     rng = np.random.default_rng(seed)
     noisy_expectations = []
+    noisy_sems = []
     for factor in noise_factors:
         scaled_p = min(noise_p * factor, 1.0)
         trial_values = np.empty(n_trials)
@@ -135,6 +137,11 @@ def run_zne_mitigation(
             )
             trial_values[i] = np.real(de.pauli_expectation(sv_noisy, pauli_string))
         noisy_expectations.append(float(trial_values.mean()))
+        # Standard error of the mean (sample std / sqrt(n_trials)), not
+        # the per-trial spread itself -- this is the real Monte Carlo
+        # uncertainty on the plotted mean, from the n_trials draws
+        # already computed above, not a separate/approximate estimate.
+        noisy_sems.append(float(trial_values.std(ddof=1) / np.sqrt(n_trials)))
 
     if extrapolation_method == "polynomial":
         zne_value = float(de.polynomial_extrapolate(noisy_expectations, list(noise_factors), degree=_POLYNOMIAL_DEGREE))
@@ -149,6 +156,7 @@ def run_zne_mitigation(
         noisy_expectations=noisy_expectations,
         zne_extrapolated=zne_value,
         extrapolation_method=extrapolation_method,
+        noisy_sems=noisy_sems,
     )
 
 

--- a/tools/dashboard/core/visuals.py
+++ b/tools/dashboard/core/visuals.py
@@ -19,7 +19,7 @@ from .state_visuals import native_histogram_figure, native_qsphere_figure, nativ
 
 __all__ = [
     'draw_circuit_figure', 'histogram_figure', 'qsphere_figure', 'bloch_multivector_figure',
-    'energy_landscape_figure',
+    'energy_landscape_figure', 'zne_bar_figure',
 ]
 
 # dense_evolution.registry sets plt.style.use('dark_background') globally
@@ -82,5 +82,26 @@ def energy_landscape_figure(
         ax.set_xlabel(f'θ[{param_i}]')
         ax.set_ylabel(f'θ[{param_j}]')
         ax.legend(loc='upper right', fontsize=8)
+        fig.tight_layout()
+        return fig
+
+
+def zne_bar_figure(noise_factors, noisy_expectations, noisy_sems, zne_extrapolated, ideal_expectation):
+    """Real ZNE measurement chart with a +-1 SEM (standard error of the
+    mean, not the raw per-trial spread) band around each measured point
+    -- the Monte Carlo uncertainty on run_zne_mitigation's own
+    n_trials-averaged expectation values, not a decorative estimate."""
+    with plt.style.context(_LIGHT_STYLE):
+        fig, ax = plt.subplots(figsize=(5, 4))
+        ax.errorbar(
+            noise_factors, noisy_expectations, yerr=noisy_sems,
+            fmt='o-', color='#1f77b4', capsize=4, label='Misurato (media Monte Carlo ±1 SEM)',
+        )
+        ax.axhline(ideal_expectation, color='green', linestyle='--', label=f'Ideale ({ideal_expectation:.4f})')
+        ax.scatter([0], [zne_extrapolated], color='red', marker='*', s=150, zorder=5,
+                   label=f'Estrapolato a 0 ({zne_extrapolated:.4f})')
+        ax.set_xlabel('Fattore di scala del rumore')
+        ax.set_ylabel('<P> misurato')
+        ax.legend(loc='best', fontsize=8)
         fig.tight_layout()
         return fig


### PR DESCRIPTION
`run_zne_mitigation` already draws `n_trials` Monte Carlo samples per noise scale to compute each `noisy_expectations` point, but discarded their spread — the ZNE chart showed a bare bar per scale with no sense of how noisy that Monte Carlo estimate itself was.

`MitigationResult` gains a `'noisy_sems'` field: standard error of the mean (sample std / sqrt(n_trials)) computed from the same `trial_values` already sampled in `run_zne_mitigation`'s loop, not a separate estimate. New `dashboard_core.visuals.zne_bar_figure(...)` replaces the previous `st.bar_chart` with a matplotlib errorbar plot: measured points with ±1 SEM bars, the ideal expectation as a reference line, and the ZNE-extrapolated value marked at x=0.

Live-verified via Playwright on the default Bell state (ZZ, depolarizing, p=0.05, 200 trials): 3 points with visibly growing error bars at higher noise scales, ideal line at 1.0, extrapolated star at 0.8800, 0 console errors. Tests added proactively (zero SEM under noise_p=0, positive SEM under real noise, figure returns a real Figure).