### PR TITLE
Dashboard: add geometric syndrome map to QEC

### DIFF
--- a/tests/integration/test_dashboard_visuals.py
+++ b/tests/integration/test_dashboard_visuals.py
@@ -19,7 +19,7 @@ from matplotlib.figure import Figure
 from dashboard_core.engine import run_circuit_from_qasm
 from dashboard_core.visuals import (
     bloch_multivector_figure, draw_circuit_figure, histogram_figure, qsphere_figure,
-    energy_landscape_figure, zne_bar_figure,
+    energy_landscape_figure, zne_bar_figure, qec_syndrome_map_figure,
 )
 from dashboard_core.state_visuals import _reduced_density_matrix, _bloch_vector
 
@@ -83,6 +83,16 @@ def test_zne_bar_figure_returns_a_figure():
         noise_factors=[1.0, 2.0, 3.0], noisy_expectations=[0.8, 0.6, 0.4],
         noisy_sems=[0.02, 0.03, 0.04], zne_extrapolated=1.0, ideal_expectation=1.0,
     )
+    assert isinstance(fig, Figure)
+
+
+def test_qec_syndrome_map_figure_returns_a_figure():
+    fig = qec_syndrome_map_figure(['ZZI', 'IZZ'], (1, 1), 'IXI')
+    assert isinstance(fig, Figure)
+
+
+def test_qec_syndrome_map_figure_without_error_marked():
+    fig = qec_syndrome_map_figure(['ZZI', 'IZZ'], (0, 0), None)
     assert isinstance(fig, Figure)
 
 

--- a/tests/integration/test_dashboard_visuals.py
+++ b/tests/integration/test_dashboard_visuals.py
@@ -96,6 +96,14 @@ def test_qec_syndrome_map_figure_without_error_marked():
     assert isinstance(fig, Figure)
 
 
+def test_qec_syndrome_map_figure_skips_identity_only_stabilizer():
+    # A stabilizer with no non-identity positions has nothing to draw a
+    # bracket between -- must be skipped, not raise or draw a
+    # degenerate zero-width bracket.
+    fig = qec_syndrome_map_figure(['III', 'IZZ'], (0, 1), 'IXI')
+    assert isinstance(fig, Figure)
+
+
 class TestReducedDensityMatrixAndBlochVector:
     """dashboard_core.state_visuals' own partial-trace math, checked
     against known analytic states -- the same real-physics standard the

--- a/tools/dashboard/app.py
+++ b/tools/dashboard/app.py
@@ -755,10 +755,19 @@ elif section == "QEC":
         try:
             syndrome = dense_evolution.compute_syndrome(pauli_error, stabilizers)
             st.session_state["qec_syndrome"] = syndrome
+            st.session_state["qec_syndrome_error"] = pauli_error
         except Exception as exc:
             st.error(f"Errore: {exc}")
     if "qec_syndrome" in st.session_state:
         st.write(f"Sindrome: `{st.session_state['qec_syndrome']}`")
+        st.caption(
+            "In rosso gli stabilizzatori che anticommutano con l'errore (bit di sindrome 1, "
+            "rilevato) -- in grigio quelli che commutano (bit 0, non rilevato). Il qubit "
+            "marcato è dove agisce l'errore iniettato."
+        )
+        st.pyplot(dc.qec_syndrome_map_figure(
+            stabilizers, st.session_state["qec_syndrome"], st.session_state["qec_syndrome_error"],
+        ))
 
     st.subheader("Decodifica")
     observed_text = st.text_input("Sindrome osservata (es. '1,0')", value="1,0", key="qec_observed")

--- a/tools/dashboard/core/__init__.py
+++ b/tools/dashboard/core/__init__.py
@@ -29,7 +29,7 @@ from .engine import (
 )
 from .visuals import (
     draw_circuit_figure, histogram_figure, qsphere_figure, bloch_multivector_figure,
-    energy_landscape_figure, zne_bar_figure,
+    energy_landscape_figure, zne_bar_figure, qec_syndrome_map_figure,
 )
 from .graphical_builder import GATE_PALETTE, ops_to_native_tuples
 from .circuit_builder_component import mount_circuit_builder
@@ -65,7 +65,7 @@ __all__ = [
     'LargeScaleMPSResult', 'run_large_circuit_mps', 'MPS_DENSE_CONTRACTION_LIMIT',
     'run_bond_convergence_check',
     'draw_circuit_figure', 'histogram_figure', 'qsphere_figure', 'bloch_multivector_figure',
-    'energy_landscape_figure', 'zne_bar_figure',
+    'energy_landscape_figure', 'zne_bar_figure', 'qec_syndrome_map_figure',
     'GATE_PALETTE', 'ops_to_native_tuples',
     'mount_circuit_builder',
     'MOLECULE_CATALOG', 'build_molecular_hamiltonian', 'get_compatible_molecules',

--- a/tools/dashboard/core/visuals.py
+++ b/tools/dashboard/core/visuals.py
@@ -19,7 +19,7 @@ from .state_visuals import native_histogram_figure, native_qsphere_figure, nativ
 
 __all__ = [
     'draw_circuit_figure', 'histogram_figure', 'qsphere_figure', 'bloch_multivector_figure',
-    'energy_landscape_figure', 'zne_bar_figure',
+    'energy_landscape_figure', 'zne_bar_figure', 'qec_syndrome_map_figure',
 ]
 
 # dense_evolution.registry sets plt.style.use('dark_background') globally
@@ -103,5 +103,47 @@ def zne_bar_figure(noise_factors, noisy_expectations, noisy_sems, zne_extrapolat
         ax.set_xlabel('Fattore di scala del rumore')
         ax.set_ylabel('<P> misurato')
         ax.legend(loc='best', fontsize=8)
+        fig.tight_layout()
+        return fig
+
+
+def qec_syndrome_map_figure(stabilizers, syndrome, pauli_error=None):
+    """Real syndrome-measurement map: physical qubits laid out in a line,
+    each stabilizer drawn as a bracket connecting the qubits it acts on
+    (its own non-identity Pauli positions), colored red if its syndrome
+    bit is 1 (anticommutes / detected, from dense_evolution's own
+    compute_syndrome output) or gray if 0 (commutes / undetected) --
+    not a schematic, the real per-stabilizer outcome. Qubits touched by
+    pauli_error (if given) are marked filled and labeled with their
+    Pauli letter."""
+    with plt.style.context(_LIGHT_STYLE):
+        n_qubits = len(stabilizers[0]) if stabilizers else (len(pauli_error) if pauli_error else 1)
+        error_positions = {i for i, p in enumerate(pauli_error) if p != 'I'} if pauli_error else set()
+
+        fig_height = 2.2 + 0.4 * max(1, len(stabilizers))
+        fig, ax = plt.subplots(figsize=(max(4, n_qubits * 1.2), fig_height))
+
+        for i in range(n_qubits):
+            if i in error_positions:
+                ax.scatter([i], [0], s=350, color='#d62728', edgecolors='black', zorder=3)
+                ax.annotate(pauli_error[i], (i, 0), ha='center', va='center', color='white',
+                            fontsize=9, fontweight='bold', zorder=4)
+            else:
+                ax.scatter([i], [0], s=350, color='white', edgecolors='black', zorder=3)
+            ax.annotate(f'q{i}', (i, -0.35), ha='center', fontsize=8)
+
+        for s_idx, (stab, bit) in enumerate(zip(stabilizers, syndrome)):
+            positions = [i for i, p in enumerate(stab) if p != 'I']
+            if not positions:
+                continue
+            height = 0.5 + 0.4 * s_idx
+            color = '#d62728' if bit else '#999999'
+            lo, hi = min(positions), max(positions)
+            ax.plot([lo, lo, hi, hi], [0.15, height, height, 0.15], color=color, linewidth=2)
+            ax.annotate(stab, ((lo + hi) / 2, height + 0.05), ha='center', fontsize=8, color=color)
+
+        ax.set_xlim(-0.7, n_qubits - 0.3)
+        ax.set_ylim(-0.6, fig_height - 1.9)
+        ax.axis('off')
         fig.tight_layout()
         return fig


### PR DESCRIPTION
The existing "Calcolatrice sindrome" tool computed a real syndrome (`dense_evolution.compute_syndrome`) but only ever showed it as a bare tuple like `(1, 1)` — no sense of which physical qubits were involved or which stabilizers actually caught the error.

Design confirmed with the user before implementing: physical qubits drawn in a row; each stabilizer becomes a bracket connecting the qubits it acts on (its own non-identity Pauli positions) — red if its syndrome bit is 1 (detected), gray if 0 (undetected); the qubit(s) touched by the injected Pauli error are marked filled and labeled with their Pauli letter. Generalizes to any stabilizer set the user types, since the geometry comes directly from each stabilizer string's own support.

New `dashboard_core.visuals.qec_syndrome_map_figure(stabilizers, syndrome, pauli_error)`. Live-verified via Playwright on the default ZZI/IZZ repetition code: error 'IXI' → syndrome (1,1), both brackets red, q1 marked; error 'XII' → syndrome (1,0), ZZI red / IZZ gray, q0 marked — matches `compute_syndrome`'s real output exactly. 0 console errors. Tests added proactively.