### PR TITLE
Dashboard: add interactive Plotly band-structure plot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,11 @@ gpu = [
 dashboard = [
     "streamlit>=1.30.0",
     "qiskit>=1.0.0",
-    "pylatexenc>=2.10"
+    "pylatexenc>=2.10",
+    # dashboard_core.band_structure's Plotly band-structure plot is the
+    # one interactive (hover/zoom) visualization in the dashboard --
+    # everywhere else is static matplotlib (dashboard_core.visuals).
+    "plotly>=5.0.0"
 ]
 qiskit = [
     "qiskit>=1.0.0"
@@ -117,6 +121,7 @@ full = [
     "streamlit>=1.30.0",
     "qiskit>=1.0.0",
     "pylatexenc>=2.10",
+    "plotly>=5.0.0",
     "pennylane>=0.35.0",
     "basis_set_exchange>=0.9",
     "fastapi>=0.110.0",

--- a/tests/integration/test_dashboard_band_structure.py
+++ b/tests/integration/test_dashboard_band_structure.py
@@ -1,0 +1,40 @@
+"""
+Tests for dashboard_core.band_structure -- real sp3s* tight-binding
+band scan (dense_evolution.sp3s_star_hamiltonian) plus the interactive
+Plotly figure, checked against known physics (Si's real direct gap at
+Gamma), not just "no exception".
+"""
+
+import numpy as np
+import pytest
+
+from plotly.graph_objs import Figure
+
+from dashboard_core.band_structure import scan_bands_along_path, band_structure_figure
+
+
+def test_scan_returns_expected_shapes():
+    t, bands = scan_bands_along_path('Si', (0.0, 0.0, 0.0), (1.0, 0.0, 0.0), n_points=11)
+    assert t.shape == (11,)
+    assert bands.shape == (11, 10)
+
+
+def test_bands_are_sorted_ascending_at_every_k_point():
+    _, bands = scan_bands_along_path('Si', (0.0, 0.0, 0.0), (1.0, 0.0, 0.0), n_points=11)
+    for row in bands:
+        assert list(row) == sorted(row)
+
+
+def test_gamma_point_vbm_cbm_gap_matches_direct_gap_at_gamma():
+    import dense_evolution as de
+    t, bands = scan_bands_along_path('Si', (0.0, 0.0, 0.0), (1.0, 0.0, 0.0), n_points=5)
+    assert t[0] == pytest.approx(0.0)
+    gamma_gap = bands[0, 4] - bands[0, 3]
+    assert gamma_gap == pytest.approx(de.direct_gap_at_gamma('Si'), abs=1e-9)
+
+
+def test_band_structure_figure_returns_a_plotly_figure():
+    t, bands = scan_bands_along_path('Si', (0.0, 0.0, 0.0), (1.0, 0.0, 0.0), n_points=11)
+    fig = band_structure_figure(t, bands, 'Si')
+    assert isinstance(fig, Figure)
+    assert len(fig.data) == 10

--- a/tools/dashboard/app.py
+++ b/tools/dashboard/app.py
@@ -835,6 +835,19 @@ elif section == "Materia Condensata":
             "\"Calcola gap a Gamma\" da solo darebbe il valore sbagliato per quelli."
         )
 
+    if st.button("Disegna struttura a bande (Γ→X, interattiva)"):
+        t_path, bands = dc.scan_bands_along_path(material, (0.0, 0.0, 0.0), (1.0, 0.0, 0.0), n_points=201)
+        st.session_state["band_structure_result"] = (t_path, bands, material)
+
+    if "band_structure_result" in st.session_state:
+        t_path, bands, band_material = st.session_state["band_structure_result"]
+        st.plotly_chart(dc.band_structure_figure(t_path, bands, band_material))
+        st.caption(
+            "Tutte e 10 le bande sp3s* reali lungo Γ→X -- passa il mouse su un punto "
+            "per vedere energia esatta e posizione nel k-path. Banda 3 (rossa) e "
+            "banda 4 (blu) sono la VBM/CBM che \"Scansiona banda Γ→X\" riassume in un numero."
+        )
+
     st.divider()
     st.header("Modello di Hubbard")
     n_sites = st.slider("n_sites", 2, 6, 4, key="hub_n_sites")

--- a/tools/dashboard/core/__init__.py
+++ b/tools/dashboard/core/__init__.py
@@ -58,6 +58,7 @@ from .noise_tools import (
     OscillatingNoiseResult, run_oscillating_noise,
     DensityMatrixChannelResult, run_density_matrix_channel,
 )
+from .band_structure import scan_bands_along_path, band_structure_figure
 
 __all__ = [
     'QASM_LIBRARY', 'gate_tuples_to_qasm',
@@ -84,4 +85,5 @@ __all__ = [
     'CosmicRayBurstResult', 'run_cosmic_ray_burst',
     'OscillatingNoiseResult', 'run_oscillating_noise',
     'DensityMatrixChannelResult', 'run_density_matrix_channel',
+    'scan_bands_along_path', 'band_structure_figure',
 ]

--- a/tools/dashboard/core/band_structure.py
+++ b/tools/dashboard/core/band_structure.py
@@ -1,0 +1,71 @@
+"""
+Real sp3s* tight-binding band structure along a k-path
+(dense_evolution.sp3s_star_hamiltonian, the same real Hamiltonian
+direct_gap_at_gamma/band_extrema_along_path already use -- all 10 bands
+here, not just the VBM/CBM pair those two track), plus an interactive
+Plotly figure with real hover tooltips (k-point and energy per band).
+
+This is the one interactive (hover/zoom) visualization in the dashboard;
+everywhere else in dashboard_core.visuals uses static matplotlib. The
+choice here is unrelated to that module's own reason for staying
+matplotlib-only (Qiskit's macOS instability, see visuals.py) -- this is
+purely about wanting real per-point hover data that a static image
+cannot provide, and needed adding plotly as a declared dependency
+(pyproject.toml's `dashboard` extra) since it was only ever an
+incidental transitive package before.
+"""
+
+import numpy as np
+import plotly.graph_objects as go
+
+import dense_evolution as de
+
+__all__ = ['scan_bands_along_path', 'band_structure_figure']
+
+
+def scan_bands_along_path(material, k_start, k_end, n_points=201):
+    """All 10 sp3s* tight-binding bands (real eigenvalues of
+    dense_evolution.sp3s_star_hamiltonian at each sampled k-point, not
+    just the single VBM/CBM pair band_extrema_along_path tracks) along
+    the straight line from k_start to k_end, both in the same 2*pi/a
+    cubic-axis units as sp3s_star_hamiltonian itself.
+
+    Returns (t, bands): t is the fractional position along the path
+    (0..1, n_points), bands is a (n_points, 10) array with band j's
+    energy at t[i] in bands[i, j] (sorted ascending at every k-point).
+    """
+    k_start = np.asarray(k_start, dtype=float)
+    k_end = np.asarray(k_end, dtype=float)
+    t = np.linspace(0.0, 1.0, n_points)
+    ks = k_start[None, :] + t[:, None] * (k_end - k_start)[None, :]
+
+    bands = np.empty((n_points, 10))
+    for i, k in enumerate(ks):
+        bands[i] = np.sort(np.linalg.eigvalsh(de.sp3s_star_hamiltonian(k, material)).real)
+    return t, bands
+
+
+def band_structure_figure(t, bands, material_name, k_start_label='Γ', k_end_label='X'):
+    """Interactive Plotly band-structure plot: one line per band, real
+    hover tooltip per point showing the exact k-path position and
+    energy (not read off a static image). Bands 3/4 (0-indexed, the
+    valence-band maximum / conduction-band minimum pair
+    band_extrema_along_path itself tracks) are highlighted."""
+    fig = go.Figure()
+    n_bands = bands.shape[1]
+    for j in range(n_bands):
+        is_frontier = j in (3, 4)
+        fig.add_trace(go.Scatter(
+            x=t, y=bands[:, j], mode='lines',
+            name=f'banda {j}' + (' (VBM)' if j == 3 else ' (CBM)' if j == 4 else ''),
+            line=dict(width=3 if is_frontier else 1, color='#d62728' if j == 3 else '#1f77b4' if j == 4 else '#999999'),
+            hovertemplate=f'banda {j}<br>t=%{{x:.3f}}<br>E=%{{y:.4f}} eV<extra></extra>',
+        ))
+    fig.update_layout(
+        title=f'Struttura a bande sp3s* -- {material_name} ({k_start_label}→{k_end_label})',
+        xaxis_title=f'{k_start_label} → {k_end_label}',
+        yaxis_title='Energia (eV)',
+        hovermode='closest',
+        template='plotly_white',
+    )
+    return fig


### PR DESCRIPTION
Materia Condensata could scan the Γ→X path for the VBM/CBM pair (`band_extrema_along_path`) but never showed the actual band structure — just two numbers.

Design confirmed with the user before implementing: real hover interactivity (exact k-point and energy per band on mouseover) over a static image, which meant introducing Plotly — the first interactive chart in this dashboard, everywhere else is static matplotlib. Added as a declared dependency (`plotly>=5.0.0`) to pyproject.toml's `dashboard`/`full` extras. Same Γ→X path as the existing "Scansiona banda Γ→X" button.

New `dashboard_core.band_structure` module: `scan_bands_along_path(...)` returns all 10 real sp3s* tight-binding bands at each sampled k-point (not just the VBM/CBM pair `band_extrema_along_path` tracks); `band_structure_figure(...)` renders them as an interactive Plotly chart with the VBM/CBM bands highlighted.

Live-verified via Playwright on Si: hovering the CBM band at t=0.555 showed the exact tooltip "banda 4, t=0.555, E=1.3850 eV"; Plotly's zoom/pan toolbar confirmed real interactivity, 0 console errors. Tests added proactively (shapes, band sorting, Γ-point gap matches `direct_gap_at_gamma` exactly, figure type/trace count).