### PR TITLE
Dashboard: color Probabilità bars by amplitude phase

### DIFF
--- a/tests/integration/test_dashboard_visuals.py
+++ b/tests/integration/test_dashboard_visuals.py
@@ -58,6 +58,28 @@ def test_histogram_figure_returns_a_figure():
     assert isinstance(fig, Figure)
 
 
+def test_histogram_figure_with_phase_coloring_returns_a_figure():
+    result = _bell_result()
+    fig = histogram_figure(result.counts, statevector=result.statevector)
+    assert isinstance(fig, Figure)
+
+
+def test_histogram_figure_phase_colors_match_real_amplitude_angles():
+    # Bell state |00>+|11> (both amplitudes real positive, phase 0) --
+    # both bars must get the identical HSV color for phase=0, not two
+    # different colors, and it must be the actual HSV(phase=0) color,
+    # not an arbitrary default.
+    import matplotlib.pyplot as plt
+    sv = np.array([1, 0, 0, 1], dtype=complex) / np.sqrt(2)
+    counts = {'00': 512, '11': 488}
+    fig = histogram_figure(counts, statevector=sv)
+    ax = fig.axes[0]
+    bar_colors = [bar.get_facecolor() for bar in ax.patches]
+    expected = plt.get_cmap('hsv')(0.0)
+    assert bar_colors[0] == pytest.approx(expected, abs=1e-6)
+    assert bar_colors[1] == pytest.approx(expected, abs=1e-6)
+
+
 def test_qsphere_figure_returns_a_figure():
     result = _bell_result()
     fig = qsphere_figure(result.statevector)

--- a/tools/dashboard/app.py
+++ b/tools/dashboard/app.py
@@ -276,7 +276,15 @@ elif section == "Risultati":
             st.dataframe(rows, width="stretch")
         with tab_prob:
             st.caption("1000 shot reali campionati dallo statevector calcolato")
-            st.pyplot(dc.histogram_figure(result.counts))
+            color_by_phase = st.checkbox(
+                "Colora per fase", key="prob_color_by_phase",
+                help="Colora ogni barra secondo la fase complessa dell'ampiezza di quello "
+                     "stato (colormap ciclica) -- l'altezza della barra resta il conteggio "
+                     "di shot reale, invariata.",
+            )
+            st.pyplot(dc.histogram_figure(
+                result.counts, statevector=result.statevector if color_by_phase else None,
+            ))
         with tab_qsphere:
             st.pyplot(dc.qsphere_figure(result.statevector))
         with tab_bloch:

--- a/tools/dashboard/core/state_visuals.py
+++ b/tools/dashboard/core/state_visuals.py
@@ -26,10 +26,18 @@ _BLOCH_COLOR = "#4589ff"
 _QSPHERE_LINE_COLOR = "#8d8d8d"
 
 
-def native_histogram_figure(counts: dict):
+def native_histogram_figure(counts: dict, statevector=None):
     """Bar chart of shot counts, bitstrings sorted ascending -- the same
     information qiskit.visualization.plot_histogram showed, built from
     nothing but the counts dict itself.
+
+    statevector (optional): when given, each bar is colored by the
+    complex phase of that basis state's amplitude (same HSV cyclic
+    colormap and convention as native_qsphere_figure's own phase
+    coloring) instead of the flat default color -- a state's phase is
+    real physical information invisible in a bare shot-count bar
+    otherwise. statevector must be in the same Qiskit little-endian
+    convention as `counts`' own bitstrings (see module docstring).
 
     Examples
     --------
@@ -43,7 +51,19 @@ def native_histogram_figure(counts: dict):
     total = sum(values)
 
     fig, ax = plt.subplots(figsize=(max(4, 0.5 * len(states)), 4))
-    bars = ax.bar(states, values, color="#648fff")
+    if statevector is not None:
+        phases = np.angle([statevector[int(s, 2)] for s in states])
+        cmap = plt.get_cmap("hsv")
+        colors = cmap((phases % (2 * np.pi)) / (2 * np.pi))
+        bars = ax.bar(states, values, color=colors)
+        sm = plt.cm.ScalarMappable(cmap=cmap, norm=plt.Normalize(0, 2 * np.pi))
+        sm.set_array([])
+        cbar = fig.colorbar(sm, ax=ax, shrink=0.8, pad=0.02)
+        cbar.set_ticks([0, np.pi / 2, np.pi, 3 * np.pi / 2, 2 * np.pi])
+        cbar.set_ticklabels(["0", "π/2", "π", "3π/2", "2π"])
+        cbar.set_label("phase", fontsize=8)
+    else:
+        bars = ax.bar(states, values, color="#648fff")
     ax.set_ylabel("Counts")
     ax.set_ylim(0, max(values) * 1.15 if values else 1)
     for bar, v in zip(bars, values):

--- a/tools/dashboard/core/visuals.py
+++ b/tools/dashboard/core/visuals.py
@@ -43,10 +43,12 @@ def draw_circuit_figure(ops, n_qubits: int):
         return draw_native_circuit_diagram(ops, n_qubits)
 
 
-def histogram_figure(counts: dict):
-    """Native shot-count histogram (dashboard_core.state_visuals)."""
+def histogram_figure(counts: dict, statevector=None):
+    """Native shot-count histogram (dashboard_core.state_visuals).
+    statevector (optional): color bars by amplitude phase instead of a
+    flat color -- see native_histogram_figure's own docstring."""
     with plt.style.context(_LIGHT_STYLE):
-        return native_histogram_figure(counts)
+        return native_histogram_figure(counts, statevector=statevector)
 
 
 def qsphere_figure(statevector):


### PR DESCRIPTION
Risultati/Probabilità only ever showed shot-count bars in a flat color — phase (already reachable via Statevector's numeric columns) was invisible there.

Design confirmed with the user: a "Colora per fase" checkbox recolors the existing bars (same states, same shot-count heights) using the same HSV cyclic colormap and phase convention `native_qsphere_figure` already uses.

`native_histogram_figure`/`histogram_figure` gain an optional `statevector` parameter (default `None`, backward compatible); when given, each bar's color comes from `plt.get_cmap("hsv")(phase/(2*pi))` with a matching colorbar.

Live-verified via Playwright on the default Bell state: unchecked → flat blue bars; checked → both bars turn identical red (phase=0, correct — both amplitudes are real positive) with the cyclic colorbar visible, 0 console errors. Tests added proactively (figure returns a real Figure with/without statevector; phase=0 bar facecolors match `plt.get_cmap('hsv')(0.0)` exactly).