### PR TITLE
Bump version to 8.1.79

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -57,7 +57,7 @@ from .physics.qec import (pauli_commutes, compute_syndrome, erasure_aware_decode
                            blind_minimum_weight_decode, decode_with_erasure_fallback,
                            counts_in_intervals_dimension, nearest_coset_decode)
 
-__version__ = "8.1.78"
+__version__ = "8.1.79"
 
 __all__ = [
     "__version__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dense-evolution"
-version = "8.1.78"
+version = "8.1.79"
 description = "High-performance quantum simulation toolkit -- Statevector/MPS engines with JIT compilation, noise modeling, VQE, QEC, quantum chemistry, and agent-native tooling"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Same pattern as #235 (8.1.78 bump): `pyproject.toml` + `dense_evolution/__init__.py` only.

Covers everything merged since 8.1.78 (#239-#252): the Streamlit dashboard's full sidebar restructure (Semplice/Avanzata mode, grouped sections), Costruisci noise/backend controls, Grandi Sistemi/MPS wiring for >24-qubit circuits, bond_convergence exposure in the dashboard, Entropia & informazione mutua panel (plus a real Qiskit/native qubit-index bugfix in the already-merged Magia & Divergenze panel), VQE energy-history flattening warning, first-visit guided tour, 2D VQE energy-landscape scan, ±1 SEM error band on the ZNE chart, geometric syndrome map for QEC, interactive Plotly band-structure plot for Materia Condensata, and phase-as-color in the Probabilità tab. All dashboard-only changes; no core `dense_evolution` library API changes.