### PR TITLE
Fix docs build: add plotly to the docs extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,14 @@ docs = [
     # mkdocstrings/griffe version bump surfaced as a real, reproducible
     # docs-build failure.
     "pennylane>=0.35.0",
-    "basis_set_exchange>=0.9"
+    "basis_set_exchange>=0.9",
+    # Same gap, same root cause, one module further: dashboard_core also
+    # transitively imports band_structure.py (PR #251), which does
+    # `import plotly.graph_objects as go` at module level -- plotly was
+    # added to the dashboard/full extras but not here, so the docs build
+    # broke again with the identical ModuleNotFoundError pattern the
+    # pennylane comment above already documents.
+    "plotly>=5.0.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
Docs build on `main` (commit #253) is red: `mkdocstrings` fails with `ModuleNotFoundError: No module named 'plotly'` while introspecting `dashboard_core`, which transitively imports `band_structure.py` (PR #251, `import plotly.graph_objects as go` at module level). `plotly>=5.0.0` was added to the `dashboard`/`full` extras in that PR but not to `docs`, the same gap the existing pennylane comment in this same extra already documents for a prior occurrence.

Fix: add `plotly>=5.0.0` to the `docs` extra in `pyproject.toml`.