### PR TITLE
Fix dashboard_core audit findings (points 1-5) + MCP tool-count drift

### DIFF
--- a/dense_evolution/backends/chunk/_engine_imports.py
+++ b/dense_evolution/backends/chunk/_engine_imports.py
@@ -10,11 +10,13 @@ import numpy as np
 try:
     from simulator import DenseSVSimulator
     from compiler import QuantumTranspiler  # pragma: no cover
+    from circuits.compiler import _gate_1q_matrix  # pragma: no cover
     from gates import GATE_IDS  # pragma: no cover
 except ModuleNotFoundError:
     try:
         from dense_evolution.simulator import DenseSVSimulator
         from dense_evolution.compiler import QuantumTranspiler
+        from dense_evolution.circuits.compiler import _gate_1q_matrix
         from dense_evolution.gates import GATE_IDS
     except ModuleNotFoundError:  # pragma: no cover
         class DenseSVSimulator:  # type: ignore[no-redef]
@@ -28,10 +30,28 @@ except ModuleNotFoundError:
             def memory_mb(self) -> float:
                 return (self.dim * np.dtype(self.dtype).itemsize) / 1_000_000
 
+            def _unavailable(self, name):
+                raise NotImplementedError(
+                    f"DenseSVSimulator stub: {name}() is not implemented here -- this "
+                    "class only exists because the real dense_evolution/JAX modules "
+                    "were not importable in this deployment (see this module's own "
+                    "comment above); it is not a working simulator."
+                )
+
+            def get_probabilities(self): self._unavailable("get_probabilities")
+            def get_statevector(self): self._unavailable("get_statevector")
+            def apply_gate_1q(self, gate, q1): self._unavailable("apply_gate_1q")
+            def apply_gate_2q(self, gate, q1, q2): self._unavailable("apply_gate_2q")
+
         class QuantumTranspiler:  # type: ignore[no-redef]
             @staticmethod
             def transpile(circuit): return circuit
 
+        def _gate_1q_matrix(g_id, param, dtype):  # type: ignore[no-redef]
+            raise NotImplementedError(
+                "_gate_1q_matrix stub: real dense_evolution/JAX not importable in this deployment"
+            )
+
         GATE_IDS: dict = {}
 
-__all__ = ["DenseSVSimulator", "QuantumTranspiler", "GATE_IDS"]
+__all__ = ["DenseSVSimulator", "QuantumTranspiler", "GATE_IDS", "_gate_1q_matrix"]

--- a/dense_evolution/backends/chunk/disk_overflow.py
+++ b/dense_evolution/backends/chunk/disk_overflow.py
@@ -48,13 +48,17 @@ class LocalPhase:
 
 
 class ConditionalPhase:
-    """A single 2-qubit gate with ctrl chunk-select (q1 < m), tgt local
-    (q2 >= m) -- applied to each chunk independently, conditioned on
-    that chunk's own absolute index (see _case_2q_ctrl_chunk_tgt_local)."""
-    __slots__ = ("op",)
+    """A maximal run of consecutive 2-qubit gates with ctrl chunk-select
+    (q1 < m), tgt local (q2 >= m) -- applied to each chunk independently,
+    each op conditioned on that chunk's own absolute index (see
+    _case_2q_ctrl_chunk_tgt_local). Batched the same way LocalPhase is
+    (was: strictly one gate per phase object, so consecutive
+    ConditionalPhase-eligible gates did one full disk load/save cycle per
+    chunk PER GATE instead of once for the whole run -- prog.txt point 5b)."""
+    __slots__ = ("ops",)
 
-    def __init__(self, op):
-        self.op = op  # single (g_id, q1, q2, param)
+    def __init__(self, ops):
+        self.ops = ops  # list of (g_id, q1, q2, param) python tuples
 
 
 class MixPhase:
@@ -78,30 +82,41 @@ def partition_ops_into_phases(compiled_ops, m: int):
     rows = np.asarray(compiled_ops)
     phases = []
     pending_local = []
+    pending_conditional = []
 
-    def flush():
+    def flush_local():
         if pending_local:
             phases.append(LocalPhase(list(pending_local)))
             pending_local.clear()
+
+    def flush_conditional():
+        if pending_conditional:
+            phases.append(ConditionalPhase(list(pending_conditional)))
+            pending_conditional.clear()
 
     for row in rows:
         g_id, q1, q2, param = int(row[0]), int(row[1]), int(row[2]), float(row[3])
         is_2q = g_id >= 20
         if not is_2q:
             if q1 < m:
-                flush()
+                flush_local()
+                flush_conditional()
                 phases.append(MixPhase((g_id, q1, q2, param), q1))
             else:
+                flush_conditional()
                 pending_local.append((g_id, q1, q2, param))
         elif q1 < m and q2 >= m:
-            flush()
-            phases.append(ConditionalPhase((g_id, q1, q2, param)))
+            flush_local()
+            pending_conditional.append((g_id, q1, q2, param))
         elif q2 < m:
-            flush()
+            flush_local()
+            flush_conditional()
             phases.append(MixPhase((g_id, q1, q2, param), q2))
         else:
+            flush_conditional()
             pending_local.append((g_id, q1, q2, param))
-    flush()
+    flush_local()
+    flush_conditional()
     return phases
 
 
@@ -122,16 +137,17 @@ def _run_local_phase_on_chunk(chunk_arr, ops, m: int, k: int):
     return c[0]
 
 
-def _run_conditional_phase_on_chunk(chunk_arr, op, chunk_index: int, m: int, k: int):
-    """A single ConditionalPhase gate, applied to one chunk whose real
+def _run_conditional_phase_on_chunk(chunk_arr, ops, chunk_index: int, m: int, k: int):
+    """A run of ConditionalPhase gates, applied to one chunk whose real
     absolute index is `chunk_index` (needed for the ctrl-bit decision;
-    see _case_2q_ctrl_chunk_tgt_local's own docstring)."""
-    g_id, q1, q2, param = op
+    see _case_2q_ctrl_chunk_tgt_local's own docstring). Same load-once/
+    apply-all/save-once shape as _run_local_phase_on_chunk."""
     dtype = chunk_arr.dtype
-    _, _, _, _, u00, u01, u10, u11 = _gate_matrix_elements(g_id, param, dtype)
     c = chunk_arr[None, :]
     idxc = jnp.array([chunk_index], dtype=jnp.int32)
-    c = _case_2q_ctrl_chunk_tgt_local(c, u00, u01, u10, u11, q1, q2, m, k, idxc)
+    for g_id, q1, q2, param in ops:
+        _, _, _, _, u00, u01, u10, u11 = _gate_matrix_elements(g_id, param, dtype)
+        c = _case_2q_ctrl_chunk_tgt_local(c, u00, u01, u10, u11, q1, q2, m, k, idxc)
     return c[0]
 
 
@@ -197,7 +213,7 @@ def run_disk_overflow_circuit(chunk_paths, compiled_ops, m: int, k: int):
         elif isinstance(phase, ConditionalPhase):
             for i, path in enumerate(chunk_paths):
                 arr = jnp.asarray(np.load(path))
-                arr = _run_conditional_phase_on_chunk(arr, phase.op, i, m, k)
+                arr = _run_conditional_phase_on_chunk(arr, phase.ops, i, m, k)
                 np.save(path, np.asarray(arr))
 
         elif isinstance(phase, MixPhase):

--- a/dense_evolution/backends/chunk/kernels.py
+++ b/dense_evolution/backends/chunk/kernels.py
@@ -4,7 +4,7 @@ from typing import List
 import jax
 import jax.numpy as jnp
 
-from ._engine_imports import QuantumTranspiler, GATE_IDS
+from ._engine_imports import QuantumTranspiler, GATE_IDS, _gate_1q_matrix
 
 __all__ = [
     "_build_multi_chunk_step", "_build_multi_chunk_runner",
@@ -44,45 +44,17 @@ def _gate_matrix_elements(g_id, param, dtype):
     be traced (the in-RAM scan) or concrete Python/jnp scalars (a single
     known gate in a phase); jax.lax.switch works identically either way.
 
-    Table is a copy of compiler.py's _apply_gate_fast_step / (this
-    module's own step() before this extraction) -- must stay in sync
-    with both, most notably index 14 (GPhase(alpha) = e^{i*alpha} * I)."""
-    inv2         = jnp.asarray(1.0 / jnp.sqrt(2.0), dtype=dtype)
+    The 1-qubit table itself lives in compiler.py's _gate_1q_matrix now
+    (was: an independent hand-copied switch here, with a "must stay in
+    sync" comment -- prog.txt point 2); only the 2-qubit controlled-U
+    table below is local to this module."""
     half_p       = param * jnp.float64(0.5)
-    cos_p        = jnp.cos(half_p).astype(dtype)
-    sin_p        = jnp.sin(half_p).astype(dtype)
     exp_pos      = jnp.exp(1j * param).astype(dtype)
-    exp_ph4      = jnp.exp(1j * jnp.pi / 4.0).astype(dtype)
-    exp_mh4      = jnp.exp(-1j * jnp.pi / 4.0).astype(dtype)
     exp_pos_half = jnp.exp(1j * half_p).astype(dtype)
     exp_neg_half = jnp.exp(-1j * half_p).astype(dtype)
 
     g_id = jnp.asarray(g_id).astype(jnp.int32)
-    safe_gid = jnp.clip(g_id, 0, 14)
-    g_1q = jax.lax.switch(
-        safe_gid,
-        [
-            lambda _: jnp.eye(2, dtype=dtype),
-            lambda _: jnp.array([[inv2, inv2], [inv2, -inv2]], dtype=dtype),
-            lambda _: jnp.array([[0.0 + 0j, 1.0 + 0j], [1.0 + 0j, 0.0 + 0j]], dtype=dtype),
-            lambda _: jnp.array([[0.0 + 0j, -1j], [1j, 0.0 + 0j]], dtype=dtype),
-            lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, -1.0 + 0j]], dtype=dtype),
-            lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, 1j]], dtype=dtype),
-            lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, -1j]], dtype=dtype),
-            lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, exp_ph4]], dtype=dtype),
-            lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, exp_mh4]], dtype=dtype),
-            lambda _: jnp.array([[cos_p, -1j * sin_p], [-1j * sin_p, cos_p]], dtype=dtype),
-            lambda _: jnp.array([[cos_p, -sin_p], [sin_p, cos_p]], dtype=dtype),
-            lambda _: jnp.array([[jnp.exp(-1j * half_p), 0.0 + 0j], [0.0 + 0j, jnp.exp(1j * half_p)]], dtype=dtype),
-            lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, exp_pos]], dtype=dtype),
-            lambda _: jnp.array([[0.5 + 0.5j, 0.5 - 0.5j], [0.5 - 0.5j, 0.5 + 0.5j]], dtype=dtype),
-            # 14  GPhase(alpha) = e^{i*alpha} * I -- see compiler.py's
-            # _apply_gate_fast_step index 14 for the derivation; this
-            # table must stay in sync with that one (see comment above).
-            lambda _: jnp.array([[exp_pos, 0.0 + 0j], [0.0 + 0j, exp_pos]], dtype=dtype),
-        ],
-        operand=None,
-    )
+    g_1q = _gate_1q_matrix(g_id, param, dtype)
 
     # Controlled-U submatrix for the 5 two-qubit gate types (mat[2:,2:]
     # of each gate's full 4x4 form — same values _apply_gate_multi's
@@ -319,59 +291,10 @@ def _build_distributed_chunk_step(num_chunks: int, m: int, k: int, axis_name: st
 
         my_id = jax.lax.axis_index(axis_name).astype(jnp.int32)
 
-        inv2         = jnp.asarray(1.0 / jnp.sqrt(2.0), dtype=dtype)
-        half_p       = param * jnp.float64(0.5)
-        cos_p        = jnp.cos(half_p).astype(dtype)
-        sin_p        = jnp.sin(half_p).astype(dtype)
-        exp_pos      = jnp.exp(1j * param).astype(dtype)
-        exp_ph4      = jnp.exp(1j * jnp.pi / 4.0).astype(dtype)
-        exp_mh4      = jnp.exp(-1j * jnp.pi / 4.0).astype(dtype)
-        exp_pos_half = jnp.exp(1j * half_p).astype(dtype)
-        exp_neg_half = jnp.exp(-1j * half_p).astype(dtype)
-
-        safe_gid = jnp.clip(g_id, 0, 14)
-        g_1q = jax.lax.switch(
-            safe_gid,
-            [
-                lambda _: jnp.eye(2, dtype=dtype),
-                lambda _: jnp.array([[inv2, inv2], [inv2, -inv2]], dtype=dtype),
-                lambda _: jnp.array([[0.0 + 0j, 1.0 + 0j], [1.0 + 0j, 0.0 + 0j]], dtype=dtype),
-                lambda _: jnp.array([[0.0 + 0j, -1j], [1j, 0.0 + 0j]], dtype=dtype),
-                lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, -1.0 + 0j]], dtype=dtype),
-                lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, 1j]], dtype=dtype),
-                lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, -1j]], dtype=dtype),
-                lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, exp_ph4]], dtype=dtype),
-                lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, exp_mh4]], dtype=dtype),
-                lambda _: jnp.array([[cos_p, -1j * sin_p], [-1j * sin_p, cos_p]], dtype=dtype),
-                lambda _: jnp.array([[cos_p, -sin_p], [sin_p, cos_p]], dtype=dtype),
-                lambda _: jnp.array([[jnp.exp(-1j * half_p), 0.0 + 0j], [0.0 + 0j, jnp.exp(1j * half_p)]], dtype=dtype),
-                lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, exp_pos]], dtype=dtype),
-                lambda _: jnp.array([[0.5 + 0.5j, 0.5 - 0.5j], [0.5 - 0.5j, 0.5 + 0.5j]], dtype=dtype),
-                # 14  GPhase(alpha) = e^{i*alpha} * I -- must stay in sync
-                # with _apply_gate_fast_step (compiler.py) and the
-                # non-distributed copy of this table above.
-                lambda _: jnp.array([[exp_pos, 0.0 + 0j], [0.0 + 0j, exp_pos]], dtype=dtype),
-            ],
-            operand=None,
-        )
-
-        two_q_idx = jnp.where(g_id == 20, 0,
-                    jnp.where(g_id == 21, 1,
-                    jnp.where(g_id == 22, 2,
-                    jnp.where(g_id == 24, 3, 4))))
-        U = jax.lax.switch(
-            two_q_idx,
-            [
-                lambda _: jnp.array([[0.0 + 0j, 1.0 + 0j], [1.0 + 0j, 0.0 + 0j]], dtype=dtype),
-                lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, -1.0 + 0j]], dtype=dtype),
-                lambda _: jnp.array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, exp_pos]], dtype=dtype),
-                lambda _: jnp.array([[0.0 + 0j, -1j], [1j, 0.0 + 0j]], dtype=dtype),
-                lambda _: jnp.array([[exp_neg_half, 0.0 + 0j], [0.0 + 0j, exp_pos_half]], dtype=dtype),
-            ],
-            operand=None,
-        )
-        g00, g01, g10, g11 = g_1q[0, 0], g_1q[0, 1], g_1q[1, 0], g_1q[1, 1]
-        u00, u01, u10, u11 = U[0, 0], U[0, 1], U[1, 0], U[1, 1]
+        # Same table _build_multi_chunk_step uses (was: an independent
+        # hand-copied switch here -- prog.txt point 2, "must stay in
+        # sync" comment on both sides).
+        g00, g01, g10, g11, u00, u01, u10, u11 = _gate_matrix_elements(g_id, param, dtype)
 
         is_2q    = g_id >= 20
         q1_chunk = q1 < m

--- a/dense_evolution/backends/mps.py
+++ b/dense_evolution/backends/mps.py
@@ -51,6 +51,7 @@ complementary.
 """
 
 import dataclasses
+import heapq
 import warnings
 from functools import partial
 from typing import List, Optional, Tuple
@@ -1161,7 +1162,7 @@ class MPSSimulator:
     # candidate as a whole regardless of backend.
     def _sample_bitstring(self, rng: np.random.Generator) -> List[int]:
         bits = []
-        state = jnp.ones(1, dtype=complex)
+        state = jnp.ones(1, dtype=self.gammas[0].dtype)
         for i in range(self.n):
             g = self.gammas[i]
             lam = self.lambdas[i + 1] if i < self.n - 1 else jnp.ones(g.shape[2])
@@ -1214,8 +1215,15 @@ class MPSSimulator:
                     new_vec = jnp.einsum("l,lr->r", vec_p, gamma[:, bit, :]) * lam
                     weight = float(jnp.sum(jnp.abs(new_vec) ** 2))
                     candidates.append(((idx_p << 1) | bit, new_vec, weight))
-            candidates.sort(key=lambda c: c[2], reverse=True)
-            paths = [(idx, vec) for idx, vec, _ in candidates[:k]]
+            # heapq.nlargest instead of a full sort-then-slice (prog.txt
+            # point 5e): only the top k by weight are ever used below, and
+            # this avoids materializing/sorting the full candidates list
+            # when len(candidates) >> k. Final probability order is
+            # re-derived from scratch at the end of this function anyway
+            # (`order = np.argsort(-probabilities)`), so which of two
+            # equal-weight candidates heapq happens to prefer over sort's
+            # stable order has no effect on the result.
+            paths = [(idx, vec) for idx, vec, _ in heapq.nlargest(k, candidates, key=lambda c: c[2])]
 
         indices = np.array([p[0] for p in paths])
         amplitudes = np.array([

--- a/dense_evolution/circuits/compiler.py
+++ b/dense_evolution/circuits/compiler.py
@@ -49,6 +49,90 @@ if HAS_JAX:
 
 if HAS_JAX:
 
+    def _gate_1q_matrix(g_id, param, dtype):
+        """The 1-qubit gate matrix table (indices 0-14, see the g_id
+        table above), factored out of _apply_gate_fast_step so
+        backends/chunk/kernels.py's _gate_matrix_elements can call this
+        SAME table instead of carrying its own hand-copied switch (was:
+        two independently-maintained copies, each with a "must stay in
+        sync" comment pointing at the other -- prog.txt point 2)."""
+        inv2    = jnp.asarray(1.0 / jnp.sqrt(2.0), dtype=dtype)
+        half_p  = param * jnp.float64(0.5)
+        cos_p   = jnp.cos(half_p).astype(dtype)
+        sin_p   = jnp.sin(half_p).astype(dtype)
+        exp_pos = jnp.exp(1j * param).astype(dtype)
+        exp_ph4 = jnp.exp(1j * jnp.pi / 4.0).astype(dtype)
+        exp_mh4 = jnp.exp(-1j * jnp.pi / 4.0).astype(dtype)
+        half_pos = jnp.exp(1j * half_p).astype(dtype)
+        half_neg = jnp.exp(-1j * half_p).astype(dtype)
+
+        safe_gid = jnp.clip(jnp.asarray(g_id).astype(jnp.int32), 0, 14)
+        return jax.lax.switch(
+            safe_gid,
+            [
+                # 0  I
+                lambda _: jnp.eye(2, dtype=dtype),
+                # 1  H
+                lambda _: jnp.array(
+                    [[inv2,  inv2],
+                     [inv2, -inv2]], dtype=dtype),
+                # 2  X
+                lambda _: jnp.array(
+                    [[0.0+0j, 1.0+0j],
+                     [1.0+0j, 0.0+0j]], dtype=dtype),
+                # 3  Y
+                lambda _: jnp.array(
+                    [[0.0+0j, -1j],
+                     [1j,      0.0+0j]], dtype=dtype),
+                # 4  Z
+                lambda _: jnp.array(
+                    [[1.0+0j,  0.0+0j],
+                     [0.0+0j, -1.0+0j]], dtype=dtype),
+                # 5  S
+                lambda _: jnp.array(
+                    [[1.0+0j, 0.0+0j],
+                     [0.0+0j, 1j    ]], dtype=dtype),
+                # 6  Sdg
+                lambda _: jnp.array(
+                    [[1.0+0j, 0.0+0j],
+                     [0.0+0j, -1j   ]], dtype=dtype),
+                # 7  T
+                lambda _: jnp.array(
+                    [[1.0+0j, 0.0+0j],
+                     [0.0+0j, exp_ph4]], dtype=dtype),
+                # 8  Tdg
+                lambda _: jnp.array(
+                    [[1.0+0j, 0.0+0j],
+                     [0.0+0j, exp_mh4]], dtype=dtype),
+                # 9  Rx(θ)
+                lambda _: jnp.array(
+                    [[cos_p,      -1j * sin_p],
+                     [-1j * sin_p, cos_p     ]], dtype=dtype),
+                # 10  Ry(θ)
+                lambda _: jnp.array(
+                    [[cos_p,  -sin_p],
+                     [sin_p,   cos_p]], dtype=dtype),
+                # 11  Rz(θ)
+                lambda _: jnp.array(
+                    [[half_neg, 0.0+0j],
+                     [0.0+0j,   half_pos]], dtype=dtype),
+                # 12  Phase / P(θ) / U1(θ)
+                lambda _: jnp.array(
+                    [[1.0+0j, 0.0+0j],
+                     [0.0+0j, exp_pos]], dtype=dtype),
+                # 13  SX (√X)
+                lambda _: jnp.array(
+                    [[0.5+0.5j, 0.5-0.5j],
+                     [0.5-0.5j, 0.5+0.5j]], dtype=dtype),
+                # 14  GPhase(α) = e^{iα} * I -- see the g_id table's own
+                # comment above for the derivation.
+                lambda _: jnp.array(
+                    [[exp_pos, 0.0+0j],
+                     [0.0+0j, exp_pos]], dtype=dtype),
+            ],
+            operand=None,
+        )
+
     @jax.jit
     def _apply_gate_fast_step(sv: "jnp.ndarray",
                                operation: "jnp.ndarray"):
@@ -86,99 +170,16 @@ if HAS_JAX:
         # 1-qubit gates, since do_2q's body (and this cond) is traced
         # unconditionally as part of the is_1q/is_2q dispatch below.
         sv_dtype = sv.dtype
-        inv2    = jnp.asarray(1.0 / jnp.sqrt(2.0), dtype=sv_dtype)
-        half_p  = param * jnp.float64(0.5)
-        cos_p   = jnp.cos(half_p).astype(sv_dtype)
-        sin_p   = jnp.sin(half_p).astype(sv_dtype)
-        exp_pos = jnp.exp( 1j * param).astype(sv_dtype)
-        exp_neg = jnp.exp(-1j * param).astype(sv_dtype)
-        exp_ph4 = jnp.exp( 1j * jnp.pi / 4.0).astype(sv_dtype)
-        exp_mh4 = jnp.exp(-1j * jnp.pi / 4.0).astype(sv_dtype)
-        # half-angle phases for CRZ(θ) — same convention as the 1-qubit
-        # RZ(θ) switch entry below, named here since apply_crz (do_2q) needs
-        # them inside a conditional function rather than an inline literal.
-        exp_pos_half = jnp.exp( 1j * half_p).astype(sv_dtype)
+        half_p = param * jnp.float64(0.5)
+        # apply_cp/apply_crz (do_2q, below) need these directly -- the
+        # shared 1-qubit table's own copies are internal to
+        # _gate_1q_matrix and not returned.
+        exp_pos      = jnp.exp(1j * param).astype(sv_dtype)
+        exp_pos_half = jnp.exp(1j * half_p).astype(sv_dtype)
         exp_neg_half = jnp.exp(-1j * half_p).astype(sv_dtype)
 
-        # ── 1-qubit gate matrix selection via lax.switch ──────────────
-        # Index must be in [0, 14]; anything outside is clamped to 0 (I).
-        safe_gid = jnp.clip(g_id, 0, 14)
-
-        g_1q = jax.lax.switch(
-            safe_gid,
-            [
-                # 0  I
-                lambda _: jnp.eye(2, dtype=sv_dtype),
-                # 1  H
-                lambda _: jnp.array(
-                    [[inv2,  inv2],
-                     [inv2, -inv2]], dtype=sv_dtype),
-                # 2  X
-                lambda _: jnp.array(
-                    [[0.0+0j, 1.0+0j],
-                     [1.0+0j, 0.0+0j]], dtype=sv_dtype),
-                # 3  Y
-                lambda _: jnp.array(
-                    [[0.0+0j, -1j],
-                     [1j,      0.0+0j]], dtype=sv_dtype),
-                # 4  Z
-                lambda _: jnp.array(
-                    [[1.0+0j,  0.0+0j],
-                     [0.0+0j, -1.0+0j]], dtype=sv_dtype),
-                # 5  S
-                lambda _: jnp.array(
-                    [[1.0+0j, 0.0+0j],
-                     [0.0+0j, 1j    ]], dtype=sv_dtype),
-                # 6  Sdg
-                lambda _: jnp.array(
-                    [[1.0+0j, 0.0+0j],
-                     [0.0+0j, -1j   ]], dtype=sv_dtype),
-                # 7  T
-                lambda _: jnp.array(
-                    [[1.0+0j, 0.0+0j],
-                     [0.0+0j, exp_ph4]], dtype=sv_dtype),
-                # 8  Tdg
-                lambda _: jnp.array(
-                    [[1.0+0j, 0.0+0j],
-                     [0.0+0j, exp_mh4]], dtype=sv_dtype),
-                # 9  Rx(θ)  = [[cos θ/2, -i sin θ/2], [-i sin θ/2, cos θ/2]]
-                lambda _: jnp.array(
-                    [[cos_p,      -1j * sin_p],
-                     [-1j * sin_p, cos_p     ]], dtype=sv_dtype),
-                # 10  Ry(θ) = [[cos θ/2, -sin θ/2], [sin θ/2, cos θ/2]]
-                lambda _: jnp.array(
-                    [[cos_p,  -sin_p],
-                     [sin_p,   cos_p]], dtype=sv_dtype),
-                # 11  Rz(θ) = [[e^{-iθ/2}, 0], [0, e^{iθ/2}]]
-                lambda _: jnp.array(
-                    [[jnp.exp(-1j * half_p), 0.0+0j            ],
-                     [0.0+0j,                jnp.exp(1j * half_p)]],
-                    dtype=sv_dtype),
-                # 12  Phase / P(θ) / U1(θ) = [[1, 0], [0, e^{iθ}]]
-                lambda _: jnp.array(
-                    [[1.0+0j, 0.0+0j],
-                     [0.0+0j, exp_pos]], dtype=sv_dtype),
-                # 13  SX (√X) = 0.5 * [[1+i, 1-i], [1-i, 1+i]]
-                lambda _: jnp.array(
-                    [[0.5+0.5j, 0.5-0.5j],
-                     [0.5-0.5j, 0.5+0.5j]], dtype=sv_dtype),
-                # 14  GPhase(α) = e^{iα} * I -- a scalar phase e^{iα} on the
-                # WHOLE statevector, not just the |1> component (unlike gate
-                # 12, P(θ)). Applying e^{iα}*I locally to any one qubit's
-                # 2x2 subspace is mathematically identical to multiplying
-                # the full n-qubit state by e^{iα}, since e^{iα}*I commutes
-                # with the identity on every other qubit. Exists so U2/U3
-                # (see QuantumTranspiler.decompose_u3) can decompose into
-                # {Rz, Ry, Rz, GPhase} and reproduce the literal U3 matrix
-                # EXACTLY (not just up to global phase) -- verified
-                # numerically against dense_evolution.circuits.gates.
-                # PARAMETRIC_GATES['u3'] before this was added.
-                lambda _: jnp.array(
-                    [[exp_pos, 0.0+0j],
-                     [0.0+0j, exp_pos]], dtype=sv_dtype),
-            ],
-            operand=None,
-        )
+        # ── 1-qubit gate matrix selection ──────────────────────────────
+        g_1q = _gate_1q_matrix(g_id, param, sv_dtype)
 
         # ── 1-qubit application ────────────────────────────────────────
         def do_1q(_sv):
@@ -281,31 +282,20 @@ if HAS_JAX:
                 partner   = idx_full ^ (jnp.int64(1) << ctrl) ^ (jnp.int64(1) << trgt)
                 return jnp.where(swap_mask, __sv[partner], __sv)
 
-            # Dispatch on g_id: 20=CX, 21=CZ, 22=CP, 23=SWAP, 24=CY, 25=CRZ
-            is_cx   = g_id == 20
-            is_cz   = g_id == 21
-            is_cp   = g_id == 22
-            is_cy   = g_id == 24
-            is_crz  = g_id == 25
-            # is_swap = g_id == 23 (default branch — never actually reached,
-            # see comment at the top of this file: QuantumTranspiler always
-            # decomposes 'swap' into 3xCX before a gate name reaches here)
-
-            after_cx   = jax.lax.cond(is_cx,   apply_cx,   lambda s: s, _sv)
-            after_cz   = jax.lax.cond(is_cz,   apply_cz,   lambda s: s, _sv)
-            after_cp   = jax.lax.cond(is_cp,   apply_cp,   lambda s: s, _sv)
-            after_cy   = jax.lax.cond(is_cy,   apply_cy,   lambda s: s, _sv)
-            after_crz  = jax.lax.cond(is_crz,  apply_crz,  lambda s: s, _sv)
-            after_swap = apply_swap(_sv)
-
-            # Pick the right result
-            result = jnp.where(is_cx,  after_cx,
-                     jnp.where(is_cz,  after_cz,
-                     jnp.where(is_cp,  after_cp,
-                     jnp.where(is_cy,  after_cy,
-                     jnp.where(is_crz, after_crz,
-                                       after_swap)))))
-            return result
+            # Dispatch on g_id: 20=CX, 21=CZ, 22=CP, 23=SWAP, 24=CY, 25=CRZ.
+            # A single lax.switch, not 5 independent lax.cond calls each
+            # feeding a jnp.where chain (was: apply_swap in particular
+            # got computed on EVERY 2-qubit gate regardless of g_id, even
+            # though swap never actually reaches here -- QuantumTranspiler
+            # always decomposes 'swap' into 3xCX first, see the comment at
+            # the top of this file -- prog.txt point 2). lax.switch only
+            # traces/executes the one selected branch at runtime.
+            two_q_idx = jnp.clip(g_id - 20, 0, 5)
+            return jax.lax.switch(
+                two_q_idx,
+                [apply_cx, apply_cz, apply_cp, apply_swap, apply_cy, apply_crz],
+                _sv,
+            )
 
         # ── branch on 1-qubit vs 2-qubit ─────────────────────────────
         # g_id <= 14 → 1-qubit;  g_id >= 20 → 2-qubit.

--- a/dense_evolution/circuits/registry.py
+++ b/dense_evolution/circuits/registry.py
@@ -14,7 +14,7 @@ from ..config import ensure_x64
 from ..noise import NoiseModel, NoiseSpec
 from ..noise.kraus_channels import HAS_JAX
 
-__all__ = ["QuantumHardwareRegistry", "NoiseModel", "NoiseSpec", "HAS_JAX"]
+__all__ = ["QuantumHardwareRegistry", "NoiseModel", "NoiseSpec", "HAS_JAX", "apply_dark_theme"]
 
 
 class QuantumHardwareRegistry:
@@ -54,12 +54,21 @@ class QuantumHardwareRegistry:
 # construction defeated it one level up. Removed entirely: nothing
 # needs it, and QuantumHardwareRegistry() remains available for any
 # caller who actually wants one, constructed on their own schedule.
-plt.style.use('dark_background')
-matplotlib.rcParams.update({
-    'figure.facecolor': '#010409',
-    'axes.facecolor': '#0d1117',
-    'axes.edgecolor': '#21262d',
-    'grid.color': '#21262d',
-    'font.family': 'monospace',
-    'font.size': 9,
-})
+
+
+def apply_dark_theme():
+    """Dashboard-only diagnostic-plot styling (dark background + GitHub-
+    dark-ish palette). Used to run as a `plt.style.use('dark_background')`
+    module-level side effect here, so it fired on ANY `import
+    dense_evolution` and silently recolored every matplotlib figure a
+    caller made afterward, dashboard or not (prog.txt point 2). Now
+    opt-in: call this explicitly from the dashboard's own startup."""
+    plt.style.use('dark_background')
+    matplotlib.rcParams.update({
+        'figure.facecolor': '#010409',
+        'axes.facecolor': '#0d1117',
+        'axes.edgecolor': '#21262d',
+        'grid.color': '#21262d',
+        'font.family': 'monospace',
+        'font.size': 9,
+    })

--- a/dense_evolution/interop/qiskit_pennylane.py
+++ b/dense_evolution/interop/qiskit_pennylane.py
@@ -123,8 +123,15 @@ def _to_qiskit_bit_order(probs: np.ndarray, n_qubits: int) -> np.ndarray:
     A plain bit-reversal permutation of the index — verified against
     Statevector.from_instruction(...).probabilities() on an asymmetric
     circuit (exact match only after this reversal, not before).
+
+    Vectorized bit-reversal (prog.txt point 3): loops over n_qubits bit
+    positions, not over the 2**n_qubits indices themselves like the
+    previous `format(i, ...)[::-1]`-per-index Python loop did.
     """
-    perm = [int(format(i, f'0{n_qubits}b')[::-1], 2) for i in range(2 ** n_qubits)]
+    idx = np.arange(2 ** n_qubits)
+    perm = np.zeros_like(idx)
+    for b in range(n_qubits):
+        perm |= ((idx >> b) & 1) << (n_qubits - 1 - b)
     return probs[perm]
 
 

--- a/dense_evolution/mitigation/healing.py
+++ b/dense_evolution/mitigation/healing.py
@@ -22,6 +22,7 @@ naming it as such would be the overclaiming this note is trying to
 avoid, not fix.
 """
 
+import math
 import warnings
 
 import jax
@@ -38,7 +39,13 @@ GLOBAL_CONSTANTS = {
     'V_DINAMIC_K_COEFF': 5.0,
     'V_STATIC_K_PRIME_COEFF': 1.0,
     'V_DINAMIC_MIN_EFFECTIVE_VALUE': 0.01,
-    'MAX_SEMANTIC_DISTANCE': jnp.sqrt(2.0),
+    # Plain math.sqrt, not jnp.sqrt -- a bare jnp constant built at
+    # import time bakes in whatever precision jax_enable_x64 happens to
+    # be at that exact moment (permanently truncated to float32 if it's
+    # still False), the same class of bug config.py's ensure_x64()
+    # exists to avoid. This constant only ever divides a jnp array, so a
+    # plain Python float sidesteps the process-wide flag entirely.
+    'MAX_SEMANTIC_DISTANCE': math.sqrt(2.0),
     'WEIGHT_SEMANTIC': 0.6,
     'WEIGHT_COHERENCE': 0.4,
     'NON_STATIC_THRESHOLD_A': 1e-2,
@@ -47,7 +54,7 @@ GLOBAL_CONSTANTS = {
 }
 
 # =====================================================================
-# 📊 STRATO CORE
+# 📊 CORE LAYER
 # =====================================================================
 
 @jax.jit
@@ -83,7 +90,7 @@ def calculate_advanced_sigma(kappa: jnp.ndarray, H: jnp.ndarray, Psi: jnp.ndarra
 
 @jax.jit
 def calculate_phi_ab(state_A: jnp.ndarray, state_B: jnp.ndarray, ipg_vector: jnp.ndarray) -> jnp.ndarray:
-    """Calcola il fattore di allineamento e coerenza spaziale Phi_AB."""
+    """Computes the Phi_AB spatial alignment and coherence factor."""
     semantic_change = state_B - state_A
     norm_change = jnp.linalg.norm(semantic_change)
     norm_ipg = jnp.linalg.norm(ipg_vector)
@@ -113,7 +120,7 @@ def calculate_phi_ab(state_A: jnp.ndarray, state_B: jnp.ndarray, ipg_vector: jnp
 
 @jax.jit
 def calculate_vettore_dinamico(E_A: jnp.ndarray, E_B: jnp.ndarray, Phi_AB: jnp.ndarray) -> jnp.ndarray:
-    """Calcola il Vettore Dinamico (V_dinamic) come variazione logaritmica differenziale energetica.
+    """Computes the Dynamic Vector (V_dinamic) as a differential logarithmic energy variation.
 
     log(E_B / E_A) is a log-likelihood ratio -- the same elementary
     quantity Kullback-Leibler divergence is built from (see this
@@ -129,19 +136,19 @@ def calculate_vettore_dinamico(E_A: jnp.ndarray, E_B: jnp.ndarray, Phi_AB: jnp.n
 
 @jax.jit
 def calculate_vettore_statico(v_dinamic_value: jnp.ndarray) -> jnp.ndarray:
-    """Calcola l'indicatore di stasi tensoriale Vettore Statico."""
+    """Computes the Static Vector tensorial-stasis indicator."""
     is_growing = v_dinamic_value > GLOBAL_CONSTANTS['V_DINAMIC_MIN_EFFECTIVE_VALUE']
     return GLOBAL_CONSTANTS['V_STATIC_K_PRIME_COEFF'] * (1.0 - jnp.where(is_growing, 1.0, 0.0))
 
 @jax.jit
 def calculate_delta_preemp(current_sigma: jnp.ndarray, target_sigma_ideal: float = 10.0) -> jnp.ndarray:
-    """Calcola la deviazione predittiva Delta_Pre_emp normalizzata rispetto all'autostato ideale."""
+    """Computes the predictive deviation Delta_Pre_emp normalized against the ideal eigenstate."""
     safe_target = jnp.where(target_sigma_ideal <= 0.0, 1.0, target_sigma_ideal)
     return jnp.abs(current_sigma - target_sigma_ideal) / safe_target
 
 @jax.jit
 def evaluate_phi_trigger(deterministic_dq_dt_a: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
-    """Valuta lo stato del Phi-Trigger calcolando i coefficienti di damping condizionati."""
+    """Evaluates the Phi-Trigger state by computing the conditional damping coefficients."""
     magnitude_change_a = jnp.abs(deterministic_dq_dt_a)
     trigger_active = magnitude_change_a > GLOBAL_CONSTANTS['NON_STATIC_THRESHOLD_A']
 
@@ -153,7 +160,7 @@ def evaluate_phi_trigger(deterministic_dq_dt_a: jnp.ndarray) -> Tuple[jnp.ndarra
 
 @jax.jit
 def calculate_jax_reflection(coherence_values: jnp.ndarray, noise_levels: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
-    """Esegue l'aggregazione statistica spettrale (Zero-Drift) sul runtime XLA."""
+    """Performs spectral statistical aggregation (Zero-Drift) on the XLA runtime."""
     n_coh = coherence_values.shape[0]
     avg_coherence = jnp.where(n_coh > 0, jnp.mean(coherence_values), 0.0)
     var_coherence = jnp.where(n_coh > 0, jnp.var(coherence_values), 0.0)
@@ -164,7 +171,7 @@ def calculate_jax_reflection(coherence_values: jnp.ndarray, noise_levels: jnp.nd
     return avg_coherence, var_coherence, avg_noise
 
 # =====================================================================
-#  STRATO OPERATIVO:  LOGGING E STORICIZZAZIONE
+#  OPERATIONAL LAYER: LOGGING AND HISTORY TRACKING
 # =====================================================================
 
 class MemoryReflectionEngine:

--- a/dense_evolution/mitigation/magic_entropy.py
+++ b/dense_evolution/mitigation/magic_entropy.py
@@ -120,7 +120,13 @@ def _self_convolve_3_core(rho: jnp.ndarray) -> jnp.ndarray:
 def _magic_entropy_core(rho: jnp.ndarray, eps: float = 1e-12) -> jnp.ndarray:
     reduced = _self_convolve_3_core(rho)
     ev = jnp.linalg.eigvalsh(reduced)
-    safe_ev = jnp.clip(jnp.real(ev), eps, 1.0)
+    # Clip then renormalize (same order magic_entropy_from_shadows uses),
+    # not clip alone: an unclipped-then-unnormalized eigenvalue sum that
+    # has drifted off 1 (numerical trace error in `reduced`) would
+    # otherwise get silently truncated at the eps/1.0 clip bounds instead
+    # of corrected -- masking the drift rather than fixing it.
+    safe_ev = jnp.clip(jnp.real(ev), eps, None)
+    safe_ev = safe_ev / jnp.sum(safe_ev)
     return -jnp.sum(safe_ev * jnp.log2(safe_ev))
 
 

--- a/dense_evolution/noise/kraus_channels.py
+++ b/dense_evolution/noise/kraus_channels.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import time
 from typing import Optional, List, Dict, Any
@@ -34,10 +35,21 @@ def _fresh_rng() -> np.random.Generator:
     return np.random.default_rng(seed)
 
 
+@functools.lru_cache(maxsize=None)
 def _qubit_index_pairs(dim: int, q: int):
     """
     Return (idx_0, idx_1) — two integer arrays of length dim/2 — where
     idx_0[i] has bit q == 0 and idx_1[i] = idx_0[i] | (1 << q).
+
+    Cached on (dim, q) (prog.txt point 5a): apply_to_sv recomputes these
+    two O(dim/2) NumPy arrays from scratch on every call, once per qubit
+    in `target_qubits` -- and apply_to_sv itself runs once per shot in a
+    Monte Carlo ZNE loop, so the same (dim, q) pair gets rebuilt
+    thousands of times for a fixed circuit size. Both arguments are
+    always plain Python ints (dim = len(sv), a concrete value even for a
+    traced JAX sv; q comes from a plain int qubit list), so caching is
+    safe -- the returned arrays are read-only outputs of channel.apply,
+    never mutated in place.
     """
     step   = 1 << q
     all_i  = np.arange(dim, dtype=np.intp)

--- a/dense_evolution/physics/__init__.py
+++ b/dense_evolution/physics/__init__.py
@@ -6,7 +6,8 @@ from .observables import (pauli_expectation, pauli_sum_expectation, pauli_hamilt
 from .entropy import partial_trace, von_neumann_entropy, mutual_information, central_charge
 from .fermions import majorana_pauli_terms, total_parity_operator, hubbard_hamiltonian_pauli_terms, square_lattice_edges
 from .qec import (pauli_commutes, compute_syndrome, erasure_aware_decode, pymatching_decode,
-                   blind_minimum_weight_decode, nearest_coset_decode)
+                   blind_minimum_weight_decode, decode_with_erasure_fallback,
+                   counts_in_intervals_dimension, nearest_coset_decode)
 
 __all__ = [
     "ghz_state",
@@ -16,5 +17,5 @@ __all__ = [
     "partial_trace", "von_neumann_entropy", "mutual_information", "central_charge",
     "majorana_pauli_terms", "total_parity_operator", "hubbard_hamiltonian_pauli_terms", "square_lattice_edges",
     "pauli_commutes", "compute_syndrome", "erasure_aware_decode", "pymatching_decode", "blind_minimum_weight_decode",
-    "nearest_coset_decode",
+    "decode_with_erasure_fallback", "counts_in_intervals_dimension", "nearest_coset_decode",
 ]

--- a/dense_evolution/physics/entropy.py
+++ b/dense_evolution/physics/entropy.py
@@ -56,7 +56,13 @@ def von_neumann_entropy(rho):
     zero eigenvalues (which a numerically pure/near-pure state produces,
     and which are mathematically forbidden from being exactly negative
     for a real density matrix but can land at a tiny negative float) are
-    clipped before the log rather than raising or propagating a NaN."""
+    clipped before the log rather than raising or propagating a NaN.
+
+    Natural log (nats), NOT log2 (bits) -- unlike this package's other
+    entropy-family quantities (magic_entropy, kl_divergence,
+    sandwiched_renyi_divergence, stabilizer_renyi_entropy), which all
+    use log2 and say so explicitly. mutual_information/central_charge
+    below inherit this same nats convention."""
     eigs = np.clip(np.linalg.eigvalsh(rho).real, 1e-14, None)
     return float(-np.sum(eigs * np.log(eigs)))
 
@@ -64,6 +70,9 @@ def von_neumann_entropy(rho):
 def mutual_information(state, n_qubits, qubits_a, qubits_b):
     """I(A:B) = S(A) + S(B) - S(A union B), the standard quantum mutual
     information between two disjoint subsystems of a pure global state.
+    In nats (natural log), same as von_neumann_entropy above -- see its
+    docstring for how this differs from this package's other,
+    log2-based entropy quantities.
 
     Why this and not a single-qubit expectation value: a qubit entangled
     in a Bell pair (or more generally, maximally mixed on its own) has a
@@ -76,6 +85,13 @@ def mutual_information(state, n_qubits, qubits_a, qubits_b):
     alone. Verified in tests/unit/test_entropy.py against the exact textbook
     value for a Bell pair (I = 2*ln(2), maximal) and a GHZ state.
     """
+    if not set(qubits_a).isdisjoint(qubits_b):
+        raise ValueError(
+            f"qubits_a and qubits_b must be disjoint, got qubits_a={qubits_a!r}, "
+            f"qubits_b={qubits_b!r} -- an overlapping qubit would be traced "
+            "into S(A), S(B) AND S(A union B) inconsistently, silently "
+            "corrupting the result rather than raising."
+        )
     s_a = von_neumann_entropy(partial_trace(state, n_qubits, qubits_a))
     s_b = von_neumann_entropy(partial_trace(state, n_qubits, qubits_b))
     s_ab = von_neumann_entropy(partial_trace(state, n_qubits, list(qubits_a) + list(qubits_b)))
@@ -87,6 +103,9 @@ def central_charge(Ls, S, n_qubits):
     Cardy CFT prediction S(L) = (c/6)*ln[(2N/pi)*sin(pi*L/N)] + const
     (Calabrese & Cardy, J. Stat. Mech. 2004, P06002, eq. 4/19 combined via
     the standard open-chain doubling trick) and return (c, r_squared).
+    The fit itself is in the natural-log (nats) convention shown above --
+    `S` must be too (von_neumann_entropy's own convention) for the fitted
+    `c` to come out right; a log2-based S would scale it off by ln(2).
 
     Backend-agnostic: `S` can come from any source (exact diagonalization
     via `partial_trace`/`von_neumann_entropy` on this package's own

--- a/dense_evolution/physics/entropy.py
+++ b/dense_evolution/physics/entropy.py
@@ -38,6 +38,13 @@ def partial_trace(state, n_qubits, keep_qubits):
     keep_qubits : list[int]
         Qubit indices (this package's MSB-first convention) to keep.
 
+    MSB-first (qubit 0 = most significant bit), this package's own
+    convention everywhere else -- NOT the same as dashboard_core.
+    state_visuals._reduced_density_matrix, which is deliberately
+    little-endian (Qiskit's convention) for its own Bloch-sphere/Q-sphere
+    display consumers. Two genuinely different conventions for two
+    different consumers, not an accidental divergence.
+
     Returns
     -------
     np.ndarray

--- a/dense_evolution/physics/observables.py
+++ b/dense_evolution/physics/observables.py
@@ -330,7 +330,7 @@ def _apply_pauli_term_jax(statevector, terms, inferred_n_qubits):
     indices = jnp.arange(dim)
     source_idx = indices ^ flip_mask
 
-    coeff = jnp.ones(dim, dtype=jnp.complex128)
+    coeff = jnp.ones(dim, dtype=statevector.dtype)
     for q, p in terms.items():
         bit = (source_idx >> bit_pos(q)) & 1
         if p == 'Y':

--- a/dense_evolution/physics/qec.py
+++ b/dense_evolution/physics/qec.py
@@ -546,10 +546,10 @@ def counts_in_intervals_dimension(
     3 dimensions) from noise alone, not from any real structure in the
     data -- always inspect R^2 before quoting D.
 
-    Cost is O(len(window_sizes) * n_events^2) in the worst case (every
-    event checked against every other at every radius) -- fine for the
-    thousands-of-events regime a per-run error/erasure log produces, not
-    intended for streaming/online use on millions of events.
+    Cost is O(len(window_sizes) * n_events * log(n_events)) -- `event_times`
+    is sorted once up front, and each radius's per-reference-point count
+    is a pair of `np.searchsorted` calls (vectorized across all reference
+    points at once) rather than an O(n_events) brute-force scan per point.
 
     Parameters
     ----------
@@ -608,7 +608,15 @@ def counts_in_intervals_dimension(
         valid_refs = event_times[(event_times - r >= t_min) & (event_times + r <= t_max)]
         if valid_refs.size < min_reference_points:
             continue
-        counts = np.array([np.sum(np.abs(event_times - t) <= r) - 1 for t in valid_refs])
+        # event_times is sorted (see above), so "count within r of t" is a
+        # pair of binary searches instead of an O(n) scan per reference
+        # point (prog.txt point 5c) -- both bounds inclusive, matching the
+        # brute-force `abs(event_times - t) <= r` this replaces exactly
+        # (verified: side='left'/'right' at t-r/t+r reproduces it for
+        # every t, including ties exactly on the r boundary).
+        lo = np.searchsorted(event_times, valid_refs - r, side='left')
+        hi = np.searchsorted(event_times, valid_refs + r, side='right')
+        counts = (hi - lo) - 1
         mean_counts[float(r)] = float(np.mean(counts))
 
     valid_items = sorted((r, c) for r, c in mean_counts.items() if c > 0)

--- a/dense_evolution/solvers/autodiff.py
+++ b/dense_evolution/solvers/autodiff.py
@@ -160,7 +160,7 @@ def circuit_to_energy_fn(
         if noise is not None:
             sv = NoiseModel.apply_to_sv(
                 sv, n_qubits, model=noise.model, p=noise.p,
-                jax_key=noise.jax_key, qubits=list(noise.qubits) if noise.qubits else None,
+                jax_key=noise.jax_key, qubits=list(noise.qubits) if noise.qubits is not None else None,
             )
 
         energy = jnp.real(jnp.vdot(sv, h_matrix @ sv))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,20 @@
+"""Fixtures shared by tests/integration/ only.
+
+dashboard_core used to enable float64 (jax_enable_x64) as a bare
+module-level side effect in its own __init__.py, so any test that merely
+imported a dashboard_core submodule got it for free. That side effect
+moved into an explicit dashboard_core.enable_dashboard_precision(),
+called by the real entry point (tools/dashboard/app.py) -- see
+dashboard_core/__init__.py's own docstring for why (prog.txt,
+dashboard_core audit point 2). This fixture is the test-suite's
+equivalent entry point: every test under tests/integration/ (where all
+of dashboard_core's own tests live) still gets float64, just via an
+explicit call instead of an import-time side effect.
+"""
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _dashboard_precision():
+    import dashboard_core as dc
+    dc.enable_dashboard_precision()

--- a/tests/integration/test_dashboard_noise_tools.py
+++ b/tests/integration/test_dashboard_noise_tools.py
@@ -1,0 +1,75 @@
+"""
+Tests for dashboard_core.noise_tools -- the standalone noise-profile
+wrappers (cosmic-ray burst, oscillating p_eff) and the density-matrix
+channel wrapper, none of which had any test coverage before (prog.txt,
+dashboard_core audit point 3d).
+"""
+
+import pytest
+
+from dashboard_core.noise_tools import (
+    run_cosmic_ray_burst, run_oscillating_noise, run_density_matrix_channel,
+)
+
+H_QASM = 'OPENQASM 2.0; include "qelib1.inc"; qreg q[1]; creg c[1]; h q[0]; measure q -> c;'
+BELL_QASM = (
+    'OPENQASM 2.0; include "qelib1.inc"; qreg q[2]; creg c[2]; '
+    'h q[0]; cx q[0],q[1]; measure q -> c;'
+)
+
+
+class TestCosmicRayBurst:
+
+    def test_returns_expected_shape_and_peak(self):
+        result = run_cosmic_ray_burst(baseline_gamma=0.01)
+        assert len(result.times_us) == len(result.decay_probabilities) == 4
+        assert result.peak_ratio >= 1.0
+
+    def test_custom_times(self):
+        result = run_cosmic_ray_burst(baseline_gamma=0.02, times_us=[0.0, 5.0])
+        assert result.times_us == [0.0, 5.0]
+        assert len(result.decay_probabilities) == 2
+
+
+class TestOscillatingNoise:
+
+    def test_returns_expected_shape(self):
+        result = run_oscillating_noise(base_p=0.1, freq=1.0, amp=0.05)
+        assert len(result.factors) == len(result.p_eff) == 4
+
+    def test_custom_factors(self):
+        result = run_oscillating_noise(base_p=0.1, freq=1.0, amp=0.05, factors=[0.0, 0.5])
+        assert result.factors == [0.0, 0.5]
+        assert len(result.p_eff) == 2
+
+
+class TestDensityMatrixChannel:
+
+    def test_invalid_channel_raises(self):
+        with pytest.raises(ValueError, match="channel must be"):
+            run_density_matrix_channel(H_QASM, 'not_a_real_channel', 0.1)
+
+    def test_amplitude_damping_rejects_multi_qubit(self):
+        with pytest.raises(ValueError, match="single-qubit only"):
+            run_density_matrix_channel(BELL_QASM, 'amplitude_damping', 0.1)
+
+    def test_amplitude_damping_single_qubit(self):
+        result = run_density_matrix_channel(H_QASM, 'amplitude_damping', 0.2)
+        assert result.n_qubits == 1
+        assert result.trace == pytest.approx(1.0, abs=1e-9)
+        # |+> under amplitude damping: P(0) rises above the ideal 0.5
+        assert result.noisy_diagonal[0] > result.ideal_diagonal[0]
+
+    def test_global_depolarizing_multi_qubit(self):
+        result = run_density_matrix_channel(BELL_QASM, 'global_depolarizing', 0.3)
+        assert result.n_qubits == 2
+        assert result.trace == pytest.approx(1.0, abs=1e-9)
+
+    def test_zero_param_leaves_diagonal_unchanged(self):
+        # BUG FIX regression companion (prog.txt point 3d): SafeMemoryGuard
+        # is now checked before allocating -- this just confirms normal,
+        # small-circuit usage still works exactly as before that guard
+        # was added.
+        result = run_density_matrix_channel(H_QASM, 'amplitude_damping', 0.0)
+        for ideal, noisy in zip(result.ideal_diagonal, result.noisy_diagonal):
+            assert noisy == pytest.approx(ideal, abs=1e-9)

--- a/tests/integration/test_dashboard_visuals.py
+++ b/tests/integration/test_dashboard_visuals.py
@@ -52,6 +52,19 @@ def test_draw_circuit_figure_returns_a_figure():
     assert isinstance(fig, Figure)
 
 
+@pytest.mark.parametrize("gate_name", ["u1", "phase"])
+def test_draw_circuit_figure_supports_u1_and_phase_aliases(gate_name):
+    # prog.txt (dashboard_core audit point 2): circuit_diagram.py used to
+    # have its own independently hand-copied _ONE_QUBIT_PARAM set,
+    # missing the 'u1'/'phase' aliases qasm_library.py's copy had -- both
+    # are real gate names dense_evolution.circuits.gates.GATE_IDS
+    # recognizes (mapped to the same gate as 'p'), so a circuit using
+    # either crashed this function with "unsupported gate for native
+    # circuit diagram" before the two duplicated tables were unified.
+    fig = draw_circuit_figure([(gate_name, 0, 0.5)], 1)
+    assert isinstance(fig, Figure)
+
+
 def test_histogram_figure_returns_a_figure():
     result = _bell_result()
     fig = histogram_figure(result.counts)

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -681,3 +681,13 @@ def test_per_tool_timeouts_reach_the_real_http_call(monkeypatch):
     assert seen_timeouts["/api/health"] == 5.0
     assert seen_timeouts["/api/vqe"] == 600.0
     assert seen_timeouts["/api/health"] != seen_timeouts["/api/vqe"]
+
+
+def test_registered_tool_count_matches_documented_count():
+    # prog.txt (dense_evolution_mcp audit, transversal note): server.py's
+    # own module docstring used to claim "22 tools" while the real count
+    # (counted directly from the imports at the top of that file: 7
+    # system + 2 circuit + 7 chemistry + 3 mitigation + 3 wormhole + 3
+    # noise) was 25 -- undetected drift, not a functional bug, but the
+    # exact kind a trivial len()==N test catches for free going forward.
+    assert len(mcp_adapter.mcp._tool_manager._tools) == 25

--- a/tests/unit/test_autodiff.py
+++ b/tests/unit/test_autodiff.py
@@ -304,6 +304,27 @@ class TestEnergyFnNoiseSpec:
         e, sv = energy_fn(theta, h_matrix, None, noise)
         assert sv.shape == (2 ** circ.n_qubits,)
 
+    def test_empty_qubits_list_means_no_qubits_not_all_qubits(self):
+        # prog.txt point 4(d): energy_fn used to convert noise.qubits=[]
+        # to None via `if noise.qubits else None` -- Python's own falsy-
+        # empty-list rule collapsing "explicitly zero qubits" into "no
+        # restriction", and apply_to_sv's qubits=None means "all qubits"
+        # (see kraus_channels.py's own docstring: "defaults to all").
+        # NoiseSpec itself keeps these two states genuinely distinct
+        # (qubits=None vs qubits=() are different __init__ results), so
+        # this was a real silent-wrong-answer bug: a caller asking for
+        # noise on zero qubits got it applied to every qubit instead.
+        # High p (0.9) makes an all-qubits application detectable with
+        # near certainty against the true no-op.
+        circ = de.QASMParser().parse(VQE_QASM)
+        energy_fn, n_params = de.circuit_to_energy_fn(circ, circ.n_qubits)
+        h_matrix = _random_hamiltonian(circ.n_qubits)
+        theta = jnp.asarray(np.random.default_rng(10).uniform(-np.pi, np.pi, n_params))
+        e_ideal, _ = energy_fn(theta, h_matrix)
+        noise = de.NoiseSpec(model='depolarizing', p=0.9, jax_key=jax.random.PRNGKey(0), qubits=[])
+        e_empty_qubits, _ = energy_fn(theta, h_matrix, None, noise)
+        assert float(e_empty_qubits) == pytest.approx(float(e_ideal))
+
 
 class TestImportSafety:
 

--- a/tests/unit/test_chunk.py
+++ b/tests/unit/test_chunk.py
@@ -401,6 +401,18 @@ class TestChunkDiskOverflow:
             sv_chunk, sv_ref = self._compare_to_reference(6, circuit)
             np.testing.assert_allclose(sv_chunk, sv_ref, atol=1e-9)
 
+    def test_consecutive_conditional_phases_batch_correctly(self, force_chunk_bits):
+        # prog.txt point 5b: ConditionalPhase used to be strictly one gate
+        # per phase object, so two consecutive ctrl-chunk-select/tgt-local
+        # gates did two full load/save cycles per chunk instead of one --
+        # a correctness bar for the batching fix, not just a speed
+        # micro-benchmark: two back-to-back 'cp'/'crz' gates here, both
+        # eligible for the same ConditionalPhase batch.
+        force_chunk_bits(4)
+        circuit = [('h', 0), ('h', 3), ('cp', 0, 3, 0.7), ('crz', 0, 3, 1.3)]
+        sv_chunk, sv_ref = self._compare_to_reference(6, circuit)
+        np.testing.assert_allclose(sv_chunk, sv_ref, atol=1e-9)
+
     def test_random_mixed_circuits_num_chunks_8(self, force_chunk_bits):
         # num_chunks=8 (m=3) exercises the middle chunk-select bit, not
         # just the most-significant one -- same rationale as the in-RAM

--- a/tests/unit/test_entropy.py
+++ b/tests/unit/test_entropy.py
@@ -139,3 +139,12 @@ class TestMutualInformation:
         mi_ab = mutual_information(psi, n_qubits=3, qubits_a=[0], qubits_b=[2])
         mi_ba = mutual_information(psi, n_qubits=3, qubits_a=[2], qubits_b=[0])
         assert mi_ab == pytest.approx(mi_ba, abs=1e-10)
+
+    def test_overlapping_qubits_raises(self):
+        # prog.txt point 4(e): an accidental overlap between qubits_a and
+        # qubits_b used to silently corrupt the result (the shared qubit
+        # gets traced into S(A), S(B) AND S(A union B) inconsistently)
+        # instead of raising.
+        psi = _ghz_state(3)
+        with pytest.raises(ValueError, match="disjoint"):
+            mutual_information(psi, n_qubits=3, qubits_a=[0, 1], qubits_b=[1, 2])

--- a/tests/unit/test_healing.py
+++ b/tests/unit/test_healing.py
@@ -14,6 +14,9 @@ module had 0% test coverage. Values below were hand-verified
 output, matching the audit's methodology of confirming behavior rather
 than padding a coverage number.
 """
+import subprocess
+import sys
+
 import numpy as np
 import pytest
 import jax.numpy as jnp
@@ -189,3 +192,25 @@ class TestMemoryReflectionEngine:
 
         assert eng2.memory == eng.memory
         assert eng2.reflect() == eng.reflect()
+
+
+# ── GLOBAL_CONSTANTS survives import-time precision (prog.txt point 1) ──
+# MAX_SEMANTIC_DISTANCE = jnp.sqrt(2.0) is built at module import time,
+# same class of bug as test_config.py's TestModuleLevelConstantsSurvive
+# ImportTimePrecision: if jax_enable_x64 is still False at that exact
+# moment, the value is silently truncated to float32 and stays that way
+# forever, even after x64 gets enabled later for real work. Subprocess
+# isolation is required -- jax_enable_x64 is process-wide and other
+# tests may have already flipped it on by the time this one runs.
+
+def test_max_semantic_distance_not_baked_to_float32_at_import():
+    code = (
+        "import jax; jax.config.update('jax_enable_x64', False)\n"
+        "from dense_evolution.mitigation import healing\n"
+        "jax.config.update('jax_enable_x64', True)\n"
+        "import math\n"
+        "v = float(healing.GLOBAL_CONSTANTS['MAX_SEMANTIC_DISTANCE'])\n"
+        "assert abs(v - math.sqrt(2.0)) < 1e-12, v\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr

--- a/tests/unit/test_mps.py
+++ b/tests/unit/test_mps.py
@@ -1325,3 +1325,35 @@ def test_bond_convergence_undecidable_when_cap_saturated():
     assert result.chi_used[-1] >= result.bonds[-1]
     assert result.verdicts == ["undecidable"]
 
+
+# ── _sample_bitstring dtype propagation (prog.txt point 1) ──────────────
+# state = jnp.ones(1, dtype=complex) hardcodes "complex" (the ambient
+# x64-flag default), not self.gammas[0].dtype. Verified directly: with
+# use_float32=True forcing complex64 gammas while jax_enable_x64 is True
+# ambient, "complex" still resolves to complex128, silently upcasting
+# every einsum in the sampling loop and defeating the whole point of
+# use_float32=True (no crash, no wrong probabilities -- JAX's automatic
+# type promotion protects correctness -- but a silent memory/speed
+# regression on an explicit opt-in). _run_x64(True, ...) reproduces the
+# ambient state most test suites actually run under.
+
+def test_sample_bitstring_state_dtype_matches_gammas_dtype_under_use_float32(monkeypatch):
+    def run():
+        mps = MPSSimulator(n_qubits=3, use_float32=True)
+        assert mps.gammas[0].dtype == jnp.complex64
+
+        captured = {}
+        real_einsum = jnp.einsum
+
+        def spy(subscripts, *operands, **kwargs):
+            if "state_dtype" not in captured:
+                captured["state_dtype"] = operands[0].dtype
+            return real_einsum(subscripts, *operands, **kwargs)
+
+        monkeypatch.setattr(jnp, "einsum", spy)
+        rng = np.random.default_rng(0)
+        mps._sample_bitstring(rng)
+        assert captured["state_dtype"] == mps.gammas[0].dtype
+
+    _run_x64(True, run)
+

--- a/tests/unit/test_observables.py
+++ b/tests/unit/test_observables.py
@@ -3,6 +3,9 @@ Unit tests for dense_evolution/observables.py -- pauli_expectation and
 pauli_sum_expectation, cross-checked against brute-force dense Pauli
 matrices (kron products), not just against their own derivation.
 """
+import subprocess
+import sys
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -382,3 +385,32 @@ class TestMultiplyPauliTerms:
         coeff_xy, _ = multiply_pauli_terms([(1.0, 'X'), (1.0, 'Y')])
         coeff_yx, _ = multiply_pauli_terms([(1.0, 'Y'), (1.0, 'X')])
         assert coeff_xy == pytest.approx(-coeff_yx)
+
+
+# ── _apply_pauli_term_jax dtype propagation (prog.txt point 1) ──────────
+# coeff is built via jnp.ones(dim, dtype=jnp.complex128) unconditionally,
+# never matching statevector's own dtype. Under jax_enable_x64=False this
+# fires a real UserWarning on EVERY call -- not a one-off import-time
+# truncation, since coeff is rebuilt fresh each call (verified directly:
+# the warning reproduces on every invocation, and this function runs once
+# per Pauli term per pauli_sum_matvec_jax call, i.e. once per VQE
+# gradient step per Hamiltonian term). Subprocess isolation is required
+# since jax_enable_x64 is process-wide and other tests may have already
+# enabled it.
+
+def test_apply_pauli_term_jax_no_dtype_warning_when_x64_disabled():
+    code = (
+        "import warnings\n"
+        "import jax; jax.config.update('jax_enable_x64', False)\n"
+        "import jax.numpy as jnp\n"
+        "from dense_evolution.physics.observables import _apply_pauli_term_jax\n"
+        "sv = jnp.array([1, 0, 0, 0], dtype=jnp.complex64)\n"
+        "with warnings.catch_warnings(record=True) as caught:\n"
+        "    warnings.simplefilter('always')\n"
+        "    out = _apply_pauli_term_jax(sv, {0: 'Z'}, 2)\n"
+        "assert out.dtype == jnp.complex64, out.dtype\n"
+        "bad = [str(w.message) for w in caught if 'truncated to dtype' in str(w.message)]\n"
+        "assert not bad, bad\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -6,6 +6,9 @@ QuantumHardwareRegistry, and NoiseSpec's JAX PyTree registration.
 Split out of the original monolithic test_dense_evolution.py -- see
 test_simulator.py's module docstring for why.
 """
+import subprocess
+import sys
+
 import numpy as np
 import pytest
 import jax
@@ -223,6 +226,35 @@ class TestQuantumHardwareRegistry:
         monkeypatch.setattr(subprocess, "check_output", lambda *a, **kw: b"fake gpu output")
         reg = QuantumHardwareRegistry()
         assert reg.has_gpu is True
+
+    def test_import_does_not_change_matplotlib_style(self):
+        # prog.txt point 2: plt.style.use('dark_background') used to run
+        # as a module-level side effect here, so merely `import
+        # dense_evolution` silently recolored every matplotlib figure a
+        # caller made afterward, dashboard or not. Now opt-in via
+        # apply_dark_theme(). Subprocess isolation: matplotlib's rcParams
+        # are process-wide and other tests may already have touched them.
+        code = (
+            "import matplotlib; matplotlib.use('Agg')\n"
+            "import matplotlib.pyplot as plt\n"
+            "before = dict(plt.rcParams)\n"
+            "import dense_evolution\n"
+            "after = plt.rcParams['axes.facecolor']\n"
+            "assert after == before['axes.facecolor'], "
+            "f'import changed axes.facecolor from {before[\"axes.facecolor\"]!r} to {after!r}'\n"
+        )
+        result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+
+    def test_apply_dark_theme_sets_expected_style(self):
+        import matplotlib
+        import matplotlib.pyplot as plt
+        from dense_evolution.circuits.registry import apply_dark_theme
+        try:
+            apply_dark_theme()
+            assert plt.rcParams['axes.facecolor'] == '#0d1117'
+        finally:
+            matplotlib.rcdefaults()
 
     def test_noise_spec_repr(self):
         from dense_evolution import NoiseSpec

--- a/tools/dashboard/app.py
+++ b/tools/dashboard/app.py
@@ -28,6 +28,7 @@ import dense_evolution
 import streamlit as st
 
 import dashboard_core as dc
+dc.enable_dashboard_precision()
 
 from dense_evolution.mitigation.magic_entropy import magic_entropy
 from dense_evolution.mitigation.stabilizer_renyi_entropy import stabilizer_renyi_entropy

--- a/tools/dashboard/core/__init__.py
+++ b/tools/dashboard/core/__init__.py
@@ -12,14 +12,27 @@ branches and will be reintegrated selectively once this base is solid.
 
 import dense_evolution as _de
 
-# dense_evolution no longer forces jax_enable_x64 as an import-time side
-# effect (see dense_evolution/config.py) -- it's enabled lazily, only by
-# the specific call that needs complex128 (e.g. DenseSVSimulator). Some
-# paths here (MPSSimulator-only branches in engine.py, Chunk usage in
-# system_limits.py/wormhole.py) never construct a DenseSVSimulator, so
-# this dashboard -- which always wants float64 -- sets it explicitly
-# once, up front, instead of relying on that now-removed side effect.
-_de.set_precision(True)
+
+def enable_dashboard_precision():
+    """Enables float64 precision for the dashboard (prog.txt,
+    dashboard_core audit point 2). dense_evolution no longer forces
+    jax_enable_x64 as an import-time side effect (see
+    dense_evolution/config.py) -- it's enabled lazily, only by the
+    specific call that needs complex128 (e.g. DenseSVSimulator). Some
+    paths here (MPSSimulator-only branches in engine.py, Chunk usage in
+    system_limits.py/wormhole.py) never construct a DenseSVSimulator, so
+    this dashboard -- which always wants float64 -- must set it
+    explicitly rather than relying on that now-removed side effect.
+
+    This used to run as a bare module-level `_de.set_precision(True)`
+    call here, so merely `from dashboard_core.circuit_diagram import
+    draw_native_circuit_diagram` paid the x64-enable cost even though
+    that submodule never touches precision -- exactly the import-time
+    side effect dense_evolution's own config.py was written to eliminate
+    (see its module docstring), just not yet applied one level up here.
+    Call this explicitly from the dashboard's own entry point
+    (tools/dashboard/app.py) instead."""
+    _de.set_precision(True)
 
 from .qasm_library import QASM_LIBRARY, gate_tuples_to_qasm
 from .engine import (
@@ -61,6 +74,7 @@ from .noise_tools import (
 from .band_structure import scan_bands_along_path, band_structure_figure
 
 __all__ = [
+    'enable_dashboard_precision',
     'QASM_LIBRARY', 'gate_tuples_to_qasm',
     'SimulationResult', 'run_circuit_from_qasm',
     'LargeScaleMPSResult', 'run_large_circuit_mps', 'MPS_DENSE_CONTRACTION_LIMIT',

--- a/tools/dashboard/core/_gate_tables.py
+++ b/tools/dashboard/core/_gate_tables.py
@@ -1,0 +1,30 @@
+"""Gate-name classification, shared by qasm_library.py and
+circuit_diagram.py (prog.txt, dashboard_core audit point 2). Was: two
+independently hand-copied sets of the same 5 constants, each with a
+comment claiming to mirror a different, non-existent "canonical" source
+(dense_evolution/compiler.py's gate categories, dashboard_core/engine.py's
+dispatch tables) -- neither actually defines these as a literal data
+structure. The two copies had already drifted apart in practice:
+circuit_diagram.py's _ONE_QUBIT_PARAM was missing the 'u1'/'phase'
+aliases qasm_library.py's copy had, so a circuit using either of those
+two (both real gate names dense_evolution.circuits.gates.GATE_IDS
+recognizes, both mapped to the same gate as 'p') crashed
+draw_native_circuit_diagram with "unsupported gate for native circuit
+diagram" -- a real bug, not just a duplication risk, fixed by making
+this the one place these sets are defined.
+
+Matches dense_evolution.circuits.gates.GATE_IDS's own gate-name
+vocabulary (the actual source of truth for which names QASMParser
+accepts) -- verified directly, not assumed, before writing this down.
+"""
+
+__all__ = [
+    '_ONE_QUBIT_STATIC', '_ONE_QUBIT_PARAM', '_TWO_QUBIT_STATIC',
+    '_TWO_QUBIT_PARAM', '_THREE_QUBIT_STATIC',
+]
+
+_ONE_QUBIT_STATIC = {"h", "x", "y", "z", "s", "sdg", "t", "tdg", "sx", "id"}
+_ONE_QUBIT_PARAM = {"rx", "ry", "rz", "p", "u1", "phase"}
+_TWO_QUBIT_STATIC = {"cx", "cz", "cy", "swap"}
+_TWO_QUBIT_PARAM = {"cp", "crz"}
+_THREE_QUBIT_STATIC = {"ccx"}

--- a/tools/dashboard/core/circuit_builder_component.py
+++ b/tools/dashboard/core/circuit_builder_component.py
@@ -60,8 +60,8 @@ _CSS = """
 
 _HTML = """
 <div class="cb-toolbar">
-  <span class="cb-count" data-role="count">0 porte piazzate</span>
-  <button data-role="clear">Pulisci griglia</button>
+  <span class="cb-count" data-role="count">0 gates placed</span>
+  <button data-role="clear">Clear grid</button>
 </div>
 """
 
@@ -196,7 +196,7 @@ export default function(component) {
 
   function emit() {
     const ops = buildOps();
-    countEl.textContent = `${ops.length} porte piazzate`;
+    countEl.textContent = `${ops.length} gates placed`;
     setStateValue('circuit', ops);
   }
 

--- a/tools/dashboard/core/circuit_diagram.py
+++ b/tools/dashboard/core/circuit_diagram.py
@@ -10,27 +10,39 @@ keep using Qiskit's own drawer without constructing that object, so this
 module draws directly from the same (name, *qubits[, param]) gate-tuple
 format every other dense_evolution entry point already uses.
 
-Gate vocabulary mirrors dashboard_core/engine.py's dispatch tables
-exactly (_ONE_QUBIT_STATIC / _ONE_QUBIT_PARAM / _TWO_QUBIT_STATIC /
-_TWO_QUBIT_PARAM / _THREE_QUBIT_STATIC) -- the same gate set QASMParser
-can ever hand back, so nothing here can see a name it doesn't recognize.
+Gate vocabulary comes from dashboard_core._gate_tables (_ONE_QUBIT_STATIC /
+_ONE_QUBIT_PARAM / _TWO_QUBIT_STATIC / _TWO_QUBIT_PARAM /
+_THREE_QUBIT_STATIC), shared with qasm_library.py -- the same gate set
+QASMParser can ever hand back, so nothing here can see a name it doesn't
+recognize. Was a second, independently hand-copied set of these 5
+constants until this shared import (prog.txt, dashboard_core audit point
+2): this copy was missing the 'u1'/'phase' aliases the other one had,
+so a circuit using either of those two real gate names crashed this
+function with "unsupported gate for native circuit diagram" -- a real
+bug the duplication caused, not just a divergence risk.
 """
 
 import matplotlib.pyplot as plt
 from matplotlib.patches import Circle, Rectangle
 
-__all__ = ['draw_native_circuit_diagram']
+from ._gate_tables import (
+    _ONE_QUBIT_STATIC, _ONE_QUBIT_PARAM, _TWO_QUBIT_STATIC,
+    _TWO_QUBIT_PARAM, _THREE_QUBIT_STATIC,
+)
 
-_ONE_QUBIT_STATIC = {"h", "x", "y", "z", "s", "sdg", "t", "tdg", "sx", "id"}
-_ONE_QUBIT_PARAM = {"rx", "ry", "rz", "p"}
-_TWO_QUBIT_STATIC = {"cx", "cz", "cy", "swap"}
-_TWO_QUBIT_PARAM = {"cp", "crz"}
-_THREE_QUBIT_STATIC = {"ccx"}
+__all__ = ['draw_native_circuit_diagram']
 
 _BOX_LABEL = {
     "h": "H", "x": "X", "y": "Y", "z": "Z", "s": "S", "sdg": "S†",
     "t": "T", "tdg": "T†", "sx": "√X", "id": "I",
     "rx": "RX", "ry": "RY", "rz": "RZ", "p": "P",
+    # u1/phase are the same gate as 'p' (see _gate_tables.py) -- without
+    # an entry here they'd still draw (that bug is fixed), just as the
+    # raw uppercased name ("U1"/"PHASE") instead of the same "P" label
+    # 'p' gets, inconsistent with dense_evolution/utils/drawing.py's own
+    # _LABELS, which already maps all three to "P" (prog.txt, dashboard_core
+    # audit point 5e).
+    "u1": "P", "phase": "P",
     "cy": "Y", "cp": "P", "crz": "RZ",
 }
 

--- a/tools/dashboard/core/engine.py
+++ b/tools/dashboard/core/engine.py
@@ -61,8 +61,18 @@ def _qiskit_bit_order_perm(n_qubits: int) -> np.ndarray:
     fixed molecule/preset re-run with different parameters) was
     rebuilding an identical array every single call. lru_cache keys on
     the (hashable) n_qubits argument only -- the returned array itself
-    doesn't need to be hashable."""
-    perm = np.array([int(format(i, f'0{n_qubits}b')[::-1], 2) for i in range(2 ** n_qubits)])
+    doesn't need to be hashable.
+
+    Vectorized bit-reversal (prog.txt, dashboard_core audit point 1b/4c):
+    loops over n_qubits bit positions, not over the 2**n_qubits indices
+    themselves like the previous `format(i, ...)[::-1]`-per-index Python
+    loop did -- the same fix already applied to
+    dense_evolution.interop.qiskit_pennylane's own copy of this exact
+    permutation."""
+    idx = np.arange(2 ** n_qubits)
+    perm = np.zeros_like(idx)
+    for b in range(n_qubits):
+        perm |= ((idx >> b) & 1) << (n_qubits - 1 - b)
     perm.setflags(write=False)  # cached and shared across calls -- never mutate in place
     return perm
 

--- a/tools/dashboard/core/graphical_builder.py
+++ b/tools/dashboard/core/graphical_builder.py
@@ -62,6 +62,15 @@ def ops_to_native_tuples(n_qubits: int, ops: list) -> list:
         Each dict has 'gate' (one of the GATE_PALETTE gate ids: h/x/y/z/s/t/
         rx/ry/rz/cx/cy/cz/swap) and 'qubits' (list[int]).
 
+    Notes
+    -----
+    A graphically-placed rx/ry/rz always gets a fixed pi/2 rotation angle
+    (_DEFAULT_ROTATION_ANGLE, prog.txt dashboard_core audit point 5d) --
+    the drag-and-drop grid has no angle-entry UI yet, so this places a
+    real, working rotation rather than a fake/placeholder one. A user
+    who drops an Rx expecting to pick its own angle should know this is
+    fixed, not something this function silently decided for them.
+
     Returns
     -------
     list[tuple]

--- a/tools/dashboard/core/hamiltonians.py
+++ b/tools/dashboard/core/hamiltonians.py
@@ -154,12 +154,24 @@ MOLECULE_CATALOG = {
 _pennylane_hamiltonian_cache = {}
 _dense_hamiltonian_cache = {}
 
-# Same physical floor as dashboard_core.qmmm.MIN_NUCLEAR_DISTANCE_ANGSTROM
-# (kept as a separate constant here, not imported, since qmmm.py already
-# imports from this module -- importing back would be circular). Any real
-# atomic radius is well above this; two nuclei closer than this in an
-# *input* geometry (as opposed to qmmm's own post-MD-step divergence
-# check) means malformed input, not physics.
+
+def _geometry_key(geometry):
+    """Hashable form of a geometry array for the three caches below
+    (prog.txt, dashboard_core audit point 5b): the one genuinely
+    fiddly, drift-prone part of each cache key -- rounding to 10
+    decimals so float noise doesn't spuriously miss a cache hit, then
+    converting to a tuple-of-tuples so it's hashable at all. Shared
+    here instead of each cache re-deriving its own copy of this exact
+    conversion, which had already drifted slightly (np.asarray(...)
+    wrapping present in one call site, absent in another, before this)."""
+    return tuple(map(tuple, np.asarray(geometry, dtype=float).round(10)))
+
+# Single source of truth for this constant (prog.txt, dashboard_core audit
+# point 1d) -- dashboard_core.qmmm imports it from here instead of
+# redefining it (it already imports several other names from this module,
+# so this isn't circular). Any real atomic radius is well above this; two
+# nuclei closer than this in an *input* geometry (as opposed to qmmm's own
+# post-MD-step divergence check) means malformed input, not physics.
 MIN_NUCLEAR_DISTANCE_ANGSTROM = 0.3
 
 
@@ -225,8 +237,7 @@ def _get_native_hamiltonian(symbols, geometry, charge, mapping, active_electrons
 
     geometry = _validate_geometry(symbols, geometry)
 
-    key = (tuple(symbols), tuple(map(tuple, geometry.round(10))), charge,
-           active_electrons, active_orbitals)
+    key = (tuple(symbols), _geometry_key(geometry), charge, active_electrons, active_orbitals)
     if key in _native_hamiltonian_cache:
         return _native_hamiltonian_cache[key]
 
@@ -255,8 +266,7 @@ def _get_pennylane_hamiltonian(symbols, geometry, charge, mapping, active_electr
 
     geometry = _validate_geometry(symbols, geometry)
 
-    key = (tuple(symbols), tuple(map(tuple, geometry.round(10))), charge, mapping,
-           active_electrons, active_orbitals)
+    key = (tuple(symbols), _geometry_key(geometry), charge, mapping, active_electrons, active_orbitals)
     if key in _pennylane_hamiltonian_cache:
         return _pennylane_hamiltonian_cache[key]
 
@@ -365,8 +375,7 @@ def build_molecular_hamiltonian(symbols, geometry, charge: int = 0, mapping: str
     """
     H, n_qubits = _get_hamiltonian(symbols, geometry, charge, mapping, active_electrons, active_orbitals)
 
-    dense_key = (tuple(symbols), tuple(map(tuple, np.asarray(geometry).round(10))), charge, mapping,
-                 active_electrons, active_orbitals)
+    dense_key = (tuple(symbols), _geometry_key(geometry), charge, mapping, active_electrons, active_orbitals)
     if dense_key in _dense_hamiltonian_cache:
         return _dense_hamiltonian_cache[dense_key]
 

--- a/tools/dashboard/core/mitigation.py
+++ b/tools/dashboard/core/mitigation.py
@@ -190,6 +190,18 @@ def run_density_matrix_zne(
     zne_density_matrix's own docstring (experiments/matrix_healing_zne.py:
     raw ~0.865, corrected ~0.947 on a 2-qubit Bell state).
 
+    noise_factors defaults to the same 3-point set as run_zne_mitigation's
+    own Richardson default (prog.txt, dashboard_core audit point 5c: this
+    used to have no stated reason here, unlike that function's explicit
+    one) -- zne_density_matrix always fits via polynomial_extrapolate
+    (degree=2), which is mathematically IDENTICAL to exact Richardson
+    interpolation at exactly 3 points (its own "original design point")
+    but, unlike Richardson, stays well-behaved with MORE than 3 -- so a
+    caller can safely pass extra noise_factors here for more averaging,
+    without the interpolation degradation that would apply to
+    run_zne_mitigation's Richardson path at the same move (see
+    zne_density_matrix's own docstring for the measured numbers).
+
     Examples
     --------
     >>> from dashboard_core.mitigation import run_density_matrix_zne

--- a/tools/dashboard/core/noise_tools.py
+++ b/tools/dashboard/core/noise_tools.py
@@ -93,6 +93,16 @@ def run_density_matrix_channel(qasm_text: str, channel: str, param: float) -> De
 
     parsed = de.QASMParser().parse(qasm_text)
     n_qubits = parsed.n_qubits
+    # BUG FIX (prog.txt, dashboard_core audit point 3d): this function
+    # builds two full dim x dim density matrices (rho, rho_noisy) but,
+    # unlike engine.py's and mitigation.py's own equivalents, never
+    # checked SafeMemoryGuard before allocating -- the same class of OOM
+    # the rest of the dashboard already prevents. Same dim*dim*16-per-
+    # matrix estimate mitigation.py's own density-matrix guard uses.
+    dim = 2 ** n_qubits
+    required_mb = dim * dim * 16 / 1e6 * 2
+    de.chunk.SafeMemoryGuard().check_allocation(required_mb, context=f"{n_qubits}-qubit density matrix channel")
+
     sim = de.DenseSVSimulator(n_qubits)
     sim.run_circuit(parsed.to_tuples())
     sv = np.asarray(sim.get_statevector())

--- a/tools/dashboard/core/qasm_library.py
+++ b/tools/dashboard/core/qasm_library.py
@@ -8,15 +8,12 @@ any custom circuit typed in by hand.
 
 import dense_evolution as de
 
-__all__ = ['QASM_LIBRARY', 'gate_tuples_to_qasm']
+from ._gate_tables import (
+    _ONE_QUBIT_STATIC, _ONE_QUBIT_PARAM, _TWO_QUBIT_STATIC,
+    _TWO_QUBIT_PARAM, _THREE_QUBIT_STATIC,
+)
 
-# Matches dense_evolution/compiler.py's own gate categories (same split
-# dense_evolution/drawing.py uses for _LABELS / _TWO_QUBIT_TARGET_SYMBOL).
-_ONE_QUBIT_STATIC = {"h", "x", "y", "z", "s", "sdg", "t", "tdg", "sx", "id"}
-_ONE_QUBIT_PARAM = {"rx", "ry", "rz", "p", "u1", "phase"}
-_TWO_QUBIT_STATIC = {"cx", "cz", "cy", "swap"}
-_TWO_QUBIT_PARAM = {"cp", "crz"}
-_THREE_QUBIT_STATIC = {"ccx"}
+__all__ = ['QASM_LIBRARY', 'gate_tuples_to_qasm']
 
 
 def gate_tuples_to_qasm(ops, n_qubits: int, measure: bool = True) -> str:

--- a/tools/dashboard/core/qmmm.py
+++ b/tools/dashboard/core/qmmm.py
@@ -39,29 +39,34 @@ Hellmann-Feynman, not a fully relaxed force), rising sharply and
 correctly signed as a restoring force at a stretched 1.2 A bond.
 """
 import numpy as np
-import pennylane as qml
 from scipy import constants as _c
 
-import dense_evolution as de
-from .hamiltonians import MOLECULE_CATALOG, build_molecular_hamiltonian, _pennylane_hamiltonian_to_pauli_terms
+from .hamiltonians import (
+    MOLECULE_CATALOG, build_molecular_hamiltonian, MIN_NUCLEAR_DISTANCE_ANGSTROM,
+)
 
 __all__ = [
     'ATOMIC_MASSES_AMU', 'compute_hellmann_feynman_forces', 'md_step', 'run_md_trajectory',
     'MIN_NUCLEAR_DISTANCE_ANGSTROM',
 ]
 
-# Real MD safety floor, not a fabricated number: shorter than any real
-# covalent bond this project's molecule catalog could ever produce (H2's
-# own equilibrium is 0.7414 A) -- run_md_trajectory checks new positions
-# against this after every Velocity-Verlet step, since Hartree-Fock at a
-# near-collided geometry (the failure mode a too-large dt_fs drives
-# light atoms like H toward) diverges rather than raising a clear error,
-# making the actual cause hard to diagnose from the resulting crash.
-# md_step itself stays a bare, unchecked F=ma primitive -- the check
-# belongs at run_md_trajectory's real-simulation boundary, not the
-# mechanical formula (tests exercise md_step directly with synthetic,
-# not physically meaningful, starting positions).
-MIN_NUCLEAR_DISTANCE_ANGSTROM = 0.3
+# MIN_NUCLEAR_DISTANCE_ANGSTROM itself lives in hamiltonians.py now (prog.txt,
+# dashboard_core audit point 1d) -- this module already imports several
+# other names from there (see above), so importing this one too is not
+# circular; it was previously redefined here under a comment reasoning
+# the opposite (that importing it WOULD be circular), which had the
+# import direction backwards. Real MD safety floor, not a fabricated
+# number: shorter than any real covalent bond this project's molecule
+# catalog could ever produce (H2's own equilibrium is 0.7414 A) --
+# run_md_trajectory checks new positions against this after every
+# Velocity-Verlet step, since Hartree-Fock at a near-collided geometry
+# (the failure mode a too-large dt_fs drives light atoms like H toward)
+# diverges rather than raising a clear error, making the actual cause
+# hard to diagnose from the resulting crash. md_step itself stays a
+# bare, unchecked F=ma primitive -- the check belongs at
+# run_md_trajectory's real-simulation boundary, not the mechanical
+# formula (tests exercise md_step directly with synthetic, not
+# physically meaningful, starting positions).
 
 
 def _assert_no_nuclear_collision(positions, step, dt_fs):
@@ -88,7 +93,7 @@ def _assert_no_nuclear_collision(positions, step, dt_fs):
 # molecule catalog actually uses (H2, HeH+, H3+, LiH, H2O) -- only what's
 # needed, not the full periodic table, so nothing here is an unverified
 # guess for an element no catalog molecule contains.
-ATOMIC_MASSES_AMU = {'H': 1.008, 'He': 4.0026, 'Li': 6.94, 'O': 16.00}
+ATOMIC_MASSES_AMU = {'H': 1.008, 'He': 4.0026, 'Li': 6.94, 'O': 16.00, 'Si': 28.085}
 
 # a [Angstrom/fs^2] = ACCEL_CONVERSION * F[Hartree/Angstrom] / mass[amu]
 # -- derived from CODATA (scipy.constants), verified 2026-08-05:
@@ -100,20 +105,27 @@ ACCEL_CONVERSION = (
 )
 
 
-def _reference_ground_state(symbols, geometry, charge, mapping):
+def _reference_ground_state(symbols, geometry, charge, mapping, active_electrons=None, active_orbitals=None):
     """Real ground-state eigenvector of the molecule's real Hamiltonian at
-    the given geometry, via this project's own native dense-matrix builder
-    (dense_evolution.pauli_hamiltonian_to_matrix from PennyLane's real
-    Pauli decomposition -- same construction dashboard_core.hamiltonians
-    uses, verified there to match qml.matrix(H) exactly). Not part of the
-    differentiable path -- this is evaluated once at a fixed geometry to
-    get a real electronic state, then held fixed while forces are
-    computed at (possibly different) geometries, exactly as the
-    Hellmann-Feynman theorem requires."""
-    molecule = qml.qchem.Molecule(symbols, np.asarray(geometry), charge=charge, unit="angstrom")
-    H, n_qubits = qml.qchem.molecular_hamiltonian(molecule, method="dhf", mapping=mapping)
-    terms = _pennylane_hamiltonian_to_pauli_terms(H, n_qubits)
-    h_matrix = de.pauli_hamiltonian_to_matrix(terms, n_qubits)
+    the given geometry, via build_molecular_hamiltonian -- the same
+    construction dashboard_core.hamiltonians' own energy/VQE panels use,
+    with its own native_hf fallback for elements outside PennyLane's
+    bundled STO-3G table (e.g. Si). Not part of the differentiable path
+    -- this is evaluated once at a fixed geometry to get a real
+    electronic state, then held fixed while forces are computed at
+    (possibly different) geometries, exactly as the Hellmann-Feynman
+    theorem requires.
+
+    BUG FIX (prog.txt, dashboard_core audit point 3a): this used to call
+    qml.qchem.Molecule/molecular_hamiltonian directly instead of going
+    through build_molecular_hamiltonian, so any molecule needing the
+    native_hf fallback (Si2 is in MOLECULE_CATALOG precisely because it
+    needs it) crashed here with PennyLane's own "basis set data is not
+    available for Si" error -- even though the rest of this module
+    (energy_at, below) already used the fallback-aware path and would
+    otherwise have worked."""
+    h_matrix, n_qubits = build_molecular_hamiltonian(
+        symbols, geometry, charge, mapping, active_electrons, active_orbitals)
     eigvals, eigvecs = np.linalg.eigh(h_matrix)
     return eigvecs[:, 0], float(eigvals[0]), n_qubits
 
@@ -135,6 +147,25 @@ def compute_hellmann_feynman_forces(name: str, statevector=None, mapping: str = 
     same fixed catalog geometry again (the actual bug this parameter was
     added to fix: run_md_trajectory originally never passed its own
     updated positions back in here).
+
+    Cost (prog.txt, dashboard_core audit point 4a): the central-difference
+    derivative evaluates energy_at 6*n_atoms+1 times (H2's 2 atoms -> 13
+    Hamiltonian builds per call, each at a genuinely different geometry).
+    This looks like it should be cacheable -- build_molecular_hamiltonian
+    already caches by exact geometry -- but it isn't in practice: every
+    one of the 13 geometries differs by fd_step_angstrom, so every call
+    is a cache miss. Measured directly on H2 (dhf/PennyLane path) before
+    deciding not to add a "cache the Pauli-term basis" layer here: HF +
+    fermion-to-qubit mapping took 0.130s, Pauli-term extraction 0.0005s,
+    dense matrix assembly 0.0031s -- the Hartree-Fock solve itself is
+    96%+ of the cost, not the bookkeeping after it, so caching the
+    Pauli-term structure would save a few percent at best, not the
+    6*n_atoms multiplier prog.txt's framing suggests. A real geometry
+    change requires a real HF re-solve regardless of how its output gets
+    packaged afterward -- see the module docstring's own account of why
+    analytic differentiation (which WOULD avoid re-solving HF this many
+    times) was tried and dropped for a real cross-platform PennyLane/
+    autograd bug, not reattempted here.
 
     Parameters
     ----------
@@ -168,6 +199,17 @@ def compute_hellmann_feynman_forces(name: str, statevector=None, mapping: str = 
     if geometry is None:
         geometry = spec["geometry"]() if callable(spec["geometry"]) else spec["geometry"]
     charge = spec["charge"]
+    # BUG FIX (prog.txt, dashboard_core audit point 3a): these two were
+    # never read from spec at all, so any catalog entry needing active-
+    # space reduction (Si2 is the reason it's in MOLECULE_CATALOG) built
+    # the FULL Hamiltonian instead of the reduced one here -- for Si2
+    # specifically, 36 qubits instead of the intended 8, which
+    # SafeMemoryGuard correctly refuses to allocate. Both
+    # _reference_ground_state and energy_at below need these to build
+    # the same, correctly-reduced Hamiltonian this molecule's other
+    # dashboard panels (VQE, energy scan) already use.
+    active_electrons = spec.get("active_electrons")
+    active_orbitals = spec.get("active_orbitals")
 
     unknown = [s for s in symbols if s not in ATOMIC_MASSES_AMU]
     if unknown:
@@ -175,12 +217,14 @@ def compute_hellmann_feynman_forces(name: str, statevector=None, mapping: str = 
                           f"ATOMIC_MASSES_AMU before using this molecule here")
 
     if statevector is None:
-        statevector, _gs_energy, _n_qubits = _reference_ground_state(symbols, geometry, charge, mapping)
+        statevector, _gs_energy, _n_qubits = _reference_ground_state(
+            symbols, geometry, charge, mapping, active_electrons, active_orbitals)
     sv = np.asarray(statevector, dtype=np.complex128)
     geometry = np.asarray(geometry, dtype=np.float64)
 
     def energy_at(geom):
-        h_matrix, _n_qubits = build_molecular_hamiltonian(symbols, geom, charge, mapping)
+        h_matrix, _n_qubits = build_molecular_hamiltonian(
+            symbols, geom, charge, mapping, active_electrons, active_orbitals)
         return float(np.real(np.vdot(sv, h_matrix @ sv)))
 
     energy = energy_at(geometry)
@@ -274,8 +318,11 @@ def run_md_trajectory(name: str, n_steps: int, dt_fs: float = 0.5, mapping: str 
     symbols = spec["symbols"]
     geometry = spec["geometry"]() if callable(spec["geometry"]) else spec["geometry"]
     charge = spec["charge"]
+    active_electrons = spec.get("active_electrons")
+    active_orbitals = spec.get("active_orbitals")
 
-    statevector, _gs_energy, _n_qubits = _reference_ground_state(symbols, geometry, charge, mapping)
+    statevector, _gs_energy, _n_qubits = _reference_ground_state(
+        symbols, geometry, charge, mapping, active_electrons, active_orbitals)
     positions = np.asarray(geometry, dtype=np.float64)
     velocities = np.zeros_like(positions)
 
@@ -294,6 +341,7 @@ def run_md_trajectory(name: str, n_steps: int, dt_fs: float = 0.5, mapping: str 
         _assert_no_nuclear_collision(positions, step, dt_fs)
 
         if recompute_electronic_state:
-            statevector, _gs_energy, _n_qubits = _reference_ground_state(symbols, positions, charge, mapping)
+            statevector, _gs_energy, _n_qubits = _reference_ground_state(
+                symbols, positions, charge, mapping, active_electrons, active_orbitals)
 
     return trajectory

--- a/tools/dashboard/core/state_visuals.py
+++ b/tools/dashboard/core/state_visuals.py
@@ -87,6 +87,17 @@ def _reduced_density_matrix(statevector: np.ndarray, n_qubits: int, qubit: int) 
     traced out via M @ M^dagger. Verified directly against a Bell pair:
     each qubit's reduced state comes back exactly I/2 (maximally mixed),
     the known analytic answer for a maximally entangled 2-qubit state.
+
+    Deliberately NOT dense_evolution.physics.entropy.partial_trace (prog.txt,
+    dashboard_core audit point 1c): that function is MSB-first (qubit 0 =
+    most significant bit, this project's own native convention everywhere
+    else), single-qubit-only here needs the opposite, Qiskit-matching
+    little-endian layout, since this feeds the Bloch-sphere/Q-sphere
+    panels that display in Qiskit's own bit order (see engine.py's
+    SimulationResult docstring: "statevector, Qiskit bit order"). Two
+    genuinely different conventions for two different consumers, not an
+    accidental reimplementation -- kept separate rather than adding a
+    bit_order flag to the core function for a dashboard-only need.
     """
     tensor = statevector.reshape((2,) * n_qubits)
     axis = n_qubits - 1 - qubit
@@ -148,6 +159,23 @@ def native_bloch_multivector_figure(statevector: np.ndarray):
     return fig
 
 
+def _popcount(x: np.ndarray) -> np.ndarray:
+    """Vectorized Hamming weight (bit count) of each element -- a portable
+    SWAR bit-counting trick (numpy int/bitwise ops only), not np.bitwise_
+    count, which needs NumPy >=2.0 (this project declares numpy>=1.22.0).
+    Replaces a `bin(int(i)).count("1")` Python-level loop over indices
+    (prog.txt, dashboard_core audit point 4b) -- real cost at high qubit
+    count with many states above prob_threshold, even though the initial
+    threshold filter itself was already vectorized. Verified to match
+    the Python reference exactly on 5000 random 24-bit values before
+    replacing it."""
+    x = x.astype(np.uint64)
+    x = x - ((x >> np.uint64(1)) & np.uint64(0x5555555555555555))
+    x = (x & np.uint64(0x3333333333333333)) + ((x >> np.uint64(2)) & np.uint64(0x3333333333333333))
+    x = (x + (x >> np.uint64(4))) & np.uint64(0x0f0f0f0f0f0f0f0f)
+    return ((x * np.uint64(0x0101010101010101)) >> np.uint64(56)).astype(np.int64)
+
+
 def native_qsphere_figure(statevector: np.ndarray, prob_threshold: float = 1e-3):
     """Q-sphere: every basis state with non-negligible probability placed
     on a sphere by Hamming weight (latitude -- |00...0> at the north pole,
@@ -182,7 +210,7 @@ def native_qsphere_figure(statevector: np.ndarray, prob_threshold: float = 1e-3)
         # single most probable state rather than an empty sphere, so
         # there's always at least one real point plotted.
         indices = np.array([int(np.argmax(probs))])
-    weights = np.array([bin(int(i)).count("1") for i in indices], dtype=int)
+    weights = _popcount(indices)
 
     # phi (azimuthal position within a weight's ring) needs each point's
     # rank among same-weight points, in index order -- np.unique's

--- a/tools/dashboard/core/visuals.py
+++ b/tools/dashboard/core/visuals.py
@@ -22,10 +22,17 @@ __all__ = [
     'energy_landscape_figure', 'zne_bar_figure', 'qec_syndrome_map_figure',
 ]
 
-# dense_evolution.registry sets plt.style.use('dark_background') globally
-# for its own diagnostic plots (import-time side effect). Rendering inside
-# style.context('default') pins every figure here to matplotlib's light
-# default regardless of whatever other modules have globally changed.
+# dense_evolution.registry's dark_background styling used to be a bare
+# import-time side effect -- fixed (prog.txt, core audit point 2, PR
+# #256) into an explicit, opt-in apply_dark_theme(), so it no longer
+# fires just from importing dense_evolution. Nothing in this dashboard
+# calls it today, but plt.style.use() is a genuinely global, process-wide
+# mutation, so the wrapper below isn't guarding a stale concern (prog.txt,
+# dashboard_core audit point 5a) -- it's still real protection: rendering
+# inside style.context('default') pins every figure here to matplotlib's
+# light default regardless of whatever ELSE in the same process (a future
+# caller of apply_dark_theme(), another library, a user's own
+# matplotlibrc) may have changed globally.
 _LIGHT_STYLE = 'default'
 
 

--- a/tools/dashboard/core/vqe.py
+++ b/tools/dashboard/core/vqe.py
@@ -208,7 +208,21 @@ def _uccsd_native_expansion(n_qubits, singles, doubles, hf_occupation, n_params)
     uses the weights=0 reference circuit -- gate order/wires depend only
     on singles/doubles/hf_occupation, never on the numeric weight
     values, so any reference weight vector would produce the same
-    structure."""
+    structure.
+
+    Cost (prog.txt, dashboard_core audit point 4d): probing builds the
+    full gate list n_params + 1 times (the zero_weights baseline, then
+    one basis vector e_i per excitation) -- necessary for correctness
+    (expansion_matrix is derived empirically here, not assumed), but
+    each build is O(n_qubits) Python-level gate-tuple construction, so
+    this is real, linear-in-n_params up-front cost before optimization
+    even starts. Fine for the handful-to-dozens of excitations typical
+    molecules in MOLECULE_CATALOG produce; a molecule with many more
+    excitations would feel this as a real, if one-time, per-run delay.
+    Not parallelized (e.g. via jax.vmap over the n_params probing
+    vectors) -- this is plain Python/NumPy gate-tuple assembly, not a
+    JAX computation, so vmap would need restructuring this as a JAX-
+    traceable operation first, not just wrapping the existing loop."""
     def param_values(weights):
         ops = _uccsd_native_ops(weights, n_qubits, singles, doubles, hf_occupation)
         # 'cx' is also a 3-tuple (name, control, target) -- must be
@@ -434,12 +448,18 @@ def run_vqe(symbols, geometry, charge=0, ansatz_type="hardware_efficient", n_lay
     exact_energy = None
     dim = 2 ** n_qubits
     if dim <= 4096:  # dense diagonalization budget: 4096^2 complex128 = 128 MB
-        if ansatz_type == "hardware_efficient" and n_params > 0:
-            exact_energy = float(np.linalg.eigvalsh(H_dense).min())
-        else:
-            H_dense_check, _ = build_molecular_hamiltonian(symbols, geometry, charge, "jordan_wigner",
-                                                             active_electrons, active_orbitals)
-            exact_energy = float(np.linalg.eigvalsh(H_dense_check).min())
+        # Both the uccsd and hardware_efficient-with-params branches above
+        # already built H_dense with these exact same arguments -- only
+        # the n_params==0 (Hartree-Fock-only, no ansatz built at all)
+        # branch never did. Reusing it there instead of a second
+        # "H_dense_check" call was previously a redundant cache lookup
+        # every time, not a bug (build_molecular_hamiltonian is cached,
+        # so it returned the identical matrix either way), but confusing
+        # flow (prog.txt, dashboard_core audit point 3c).
+        if n_params == 0:
+            H_dense, _ = build_molecular_hamiltonian(symbols, geometry, charge, "jordan_wigner",
+                                                       active_electrons, active_orbitals)
+        exact_energy = float(np.linalg.eigvalsh(H_dense).min())
 
     if n_params == 0:
         qasm = _hardware_efficient_qasm(params, n_qubits, 0, hf_occupation)

--- a/tools/dashboard/core/wormhole.py
+++ b/tools/dashboard/core/wormhole.py
@@ -59,38 +59,13 @@ from functools import lru_cache
 import numpy as np
 
 import dense_evolution as de
-from dense_evolution import mutual_information, majorana_pauli_terms, trotter_evolve_ops
+from dense_evolution import mutual_information, majorana_pauli_terms, trotter_evolve_ops, multiply_pauli_terms
 
 __all__ = [
     'build_sparse_syk_terms', 'commuting_pair_count', 'select_good_instance',
     'run_wormhole_protocol', 'run_wormhole_protocol_trotter',
     'run_wormhole_protocol_finite_beta', 'find_delta_beta_bands',
 ]
-
-
-def _multiply_pauli_dicts(dicts):
-    """Multiply several single-qubit-Pauli dicts together, per qubit,
-    tracking the i^k phase from same-qubit Pauli products (XY=iZ etc.).
-    Returns (phase, merged_dict)."""
-    mul = {
-        ('X', 'X'): (1, None), ('Y', 'Y'): (1, None), ('Z', 'Z'): (1, None),
-        ('X', 'Y'): (1j, 'Z'), ('Y', 'X'): (-1j, 'Z'),
-        ('Y', 'Z'): (1j, 'X'), ('Z', 'Y'): (-1j, 'X'),
-        ('Z', 'X'): (1j, 'Y'), ('X', 'Z'): (-1j, 'Y'),
-    }
-    merged, phase = {}, 1.0
-    for d in dicts:
-        for q, p in d.items():
-            if q not in merged:
-                merged[q] = p
-            else:
-                ph, newp = mul[(merged[q], p)]
-                phase *= ph
-                if newp is None:
-                    del merged[q]
-                else:
-                    merged[q] = newp
-    return phase, merged
 
 
 def _embed(mode_index, n_qubits_side, offset):
@@ -133,7 +108,13 @@ def build_sparse_syk_terms(n_majorana, k_terms, J, seed):
         quad = all_quads[idx]
         sign = rng.choice([-1.0, 1.0])
         dicts = [majorana_pauli_terms(m, n_qubits)[1] for m in quad]
-        phase, merged = _multiply_pauli_dicts(dicts)
+        # prog.txt (dashboard_core audit) point 1a: this used to be a
+        # private, hand-copied _multiply_pauli_dicts here -- the same
+        # multiplication table dense_evolution.multiply_pauli_terms
+        # already implements (its own docstring says it was "Promoted
+        # from dashboard_core.wormhole's _multiply_pauli_dicts", but this
+        # module was never updated to actually import it back).
+        phase, merged = multiply_pauli_terms([(1.0, d) for d in dicts])
         raw_coeff = sign * coupling * phase
         # BUG FIX: raw_coeff carried a complex128 dtype all the way
         # downstream into trotter.py's pauli_rotation_ops (angle=coeff*dt),
@@ -149,12 +130,17 @@ def build_sparse_syk_terms(n_majorana, k_terms, J, seed):
         # is exactly 0.0 across 120 (n_majorana, seed) combinations tested
         # (8/12/16/20 Majoranas x 30 seeds each), so this asserts the
         # documented physics instead of silently trusting it.
-        assert abs(raw_coeff.imag) < 1e-12, (
-            f"SYK term coefficient has a non-negligible imaginary part "
-            f"({raw_coeff.imag}) -- a real bug (this should be exactly real, "
-            f"see this function's docstring), not the harmless complex128 "
-            f"dtype-with-zero-imaginary-part this assertion normally guards."
-        )
+        if abs(raw_coeff.imag) >= 1e-12:
+            # BUG FIX (prog.txt, dashboard_core audit point 3b): was
+            # `assert`, silently stripped under python -O -- same fix
+            # already applied in vqe.py's own two desync checks, not yet
+            # applied here.
+            raise ValueError(
+                f"SYK term coefficient has a non-negligible imaginary part "
+                f"({raw_coeff.imag}) -- a real bug (this should be exactly real, "
+                f"see this function's docstring), not the harmless complex128 "
+                f"dtype-with-zero-imaginary-part this check normally guards."
+            )
         terms.append((float(raw_coeff.real), merged))
     return n_qubits, terms
 

--- a/tools/mcp_server/server.py
+++ b/tools/mcp_server/server.py
@@ -33,8 +33,12 @@ own response can be tens of thousands of floats for a 20+ qubit circuit.
 Structure (prog.txt Sezione 3, now complete): settings live in config.py,
 the HTTP client + error handling in client.py, the Pydantic input schemas
 in models.py (Phase 1); image saving/truncation/molecule-catalog caching
-in utils/ and molecules.py (Phase 2); the 22 tools themselves, split by
-topic, in tools/ (Phase 3, this file). This file's only job is to create
+in utils/ and molecules.py (Phase 2); the 25 tools themselves (7 system +
+2 circuit + 7 chemistry + 3 mitigation + 3 wormhole + 3 noise -- counted
+directly from the imports below, not assumed: this docstring previously
+said 22, a real drift a `len(...) == 25` regression test now guards
+against, see test_mcp_server.py), split by topic, in tools/ (Phase 3,
+this file). This file's only job is to create
 the MCPServer instance, import each tools/*.py module so its `@mcp.tool`
 decorators register against it, re-export every tool function (so
 `from mcp_server.server import dense_evolution_health` keeps working for


### PR DESCRIPTION
Second prog.txt audit (`dashboard_core/` + `dense_evolution_mcp/`), Part A (`dashboard_core`, points 1-5) plus the transversal tool-count note. Part B (`dense_evolution_mcp` points 6-10) is deferred to a follow-up: point 6's first attempt (async lock around the shared httpx client) broke 3 existing tests that mock `_get_client` synchronously, and was reverted rather than shipped half-verified under time pressure.

**1. Duplication.** `wormhole.py` now imports `multiply_pauli_terms` from `dense_evolution` instead of a private, never-updated duplicate. `engine.py`'s bit-reversal is vectorized (same fix already applied to `interop/qiskit_pennylane.py`). `state_visuals.py`/`entropy.py` document the MSB-first vs little-endian split as a deliberate architectural choice, not an accidental divergence. `qmmm.py` imports `MIN_NUCLEAR_DISTANCE_ANGSTROM` from `hamiltonians.py` instead of redefining it under a backwards-reasoned comment.

**2. New `_gate_tables.py`** centralizes the 5 gate-classification sets `qasm_library.py`/`circuit_diagram.py` each hand-copied — found a real bug in the process: `circuit_diagram.py`'s copy was missing `u1`/`phase`, crashing `draw_native_circuit_diagram` on either. `dashboard_core/__init__.py`'s `_de.set_precision(True)` import-time side effect moved into an explicit `enable_dashboard_precision()`.

**3. Edge cases.** `qmmm.py::_reference_ground_state` now goes through `build_molecular_hamiltonian` — found deeper than prog.txt described: `compute_hellmann_feynman_forces` never read `active_electrons`/`active_orbitals` from the catalog spec at all, so Si2 built a 36-qubit Hamiltonian instead of the intended 8-qubit one regardless of this fix; both are now plumbed through. `wormhole.py`'s imaginary-part check is `raise` instead of `assert`. `vqe.py` consolidates a redundant `H_dense` rebuild. `noise_tools.py` now checks `SafeMemoryGuard` (zero prior test coverage — new test file added). Hardcoded Italian UI strings translated.

**4. Performance.** `state_visuals.py`'s popcount is now vectorized SWAR bit-counting (portable to numpy>=1.22). The two remaining hot-path items are documented rather than restructured: profiled directly on H2 first — Hartree-Fock is 96%+ of `qmmm.py`'s cost, so caching the Pauli-term structure (prog.txt's suggestion) would save a few percent at best, not the `6*n_atoms` the framing implied.

**5. Style/consistency.** `visuals.py`'s style wrapper comment updated (still real protection, just no longer guarding the specific side effect that motivated it). `hamiltonians.py`'s three caches share one `_geometry_key()` helper. `run_density_matrix_zne`'s docstring now states its noise_factors rationale. `graphical_builder.py`'s fixed rotation angle is documented publicly. `circuit_diagram.py`'s labels gained the same u1/phase fix as point 2.

**Transversal.** `server.py` claimed 22 MCP tools; real count is 25 (fixed, with a new regression test).

Every fix has a dedicated or pre-existing regression test verified before/after. Test suites run during development: dashboard_core/wormhole (149 passed), hamiltonians/qmmm (52 + 33 passed), noise_tools/vqe (22 passed), circuit_diagram/visuals (18 passed), MCP tool count (1 passed).