### PR TITLE
Bump version to 8.1.80

### DIFF
--- a/dense_evolution/__init__.py
+++ b/dense_evolution/__init__.py
@@ -57,7 +57,7 @@ from .physics.qec import (pauli_commutes, compute_syndrome, erasure_aware_decode
                            blind_minimum_weight_decode, decode_with_erasure_fallback,
                            counts_in_intervals_dimension, nearest_coset_decode)
 
-__version__ = "8.1.79"
+__version__ = "8.1.80"
 
 __all__ = [
     "__version__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dense-evolution"
-version = "8.1.79"
+version = "8.1.80"
 description = "High-performance quantum simulation toolkit -- Statevector/MPS engines with JIT compilation, noise modeling, VQE, QEC, quantum chemistry, and agent-native tooling"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Since 8.1.79:

- **Fix**: core `dense_evolution` audit findings (dtype/precision fixes, `kernels.py`/`compiler.py` gate-table duplication removed via a single shared `_gate_1q_matrix` + `do_2q` converted to one `lax.switch`, `registry.py`'s dark-theme side effect made opt-in, a real bug in `autodiff.py` where `NoiseSpec(qubits=[])` silently applied noise to *every* qubit instead of none, `entropy.py::mutual_information` now rejects overlapping qubit sets, `magic_entropy.py` renormalization, `kraus_channels.py`/`qec.py`/`mps.py`/`disk_overflow.py` performance fixes) (#256)
- **Fix**: `dashboard_core`/`dense_evolution_mcp` audit findings, Part A (a real bug where `circuit_diagram.py` crashed on `u1`/`phase` gates, a real bug where Si2's Hellmann-Feynman forces silently built a 36-qubit Hamiltonian instead of the intended 8-qubit active-space-reduced one, `wormhole.py` deduplicated against `dense_evolution.multiply_pauli_terms`, `SafeMemoryGuard` added to `noise_tools.py`, several performance/consistency fixes, MCP tool-count docstring drift fixed with a regression test) (#257)
- CI-only, not user-facing: pytest-xdist parallelization (#255), docs-build dependency fix (#254)

Every fix has a dedicated regression test. Full `tests/unit` + relevant `tests/integration` suites green on both PRs before merge.

Not part of this bump: `dense_evolution_mcp` audit points 6-10 (tracked in #258) -- point 6's first attempt was reverted after breaking existing tests, so it's deferred to a follow-up rather than shipped half-verified.